### PR TITLE
Prusa3d master adaptive

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -520,6 +520,7 @@ sub build {
     
     $self->init_config_options(qw(
         layer_height first_layer_height
+        adaptive_slicing adaptive_slicing_quality
         perimeters spiral_vase
         top_solid_layers bottom_solid_layers
         extra_perimeters ensure_vertical_shell_thickness avoid_crossing_perimeters thin_walls overhangs
@@ -567,6 +568,9 @@ sub build {
             my $optgroup = $page->new_optgroup('Layer height');
             $optgroup->append_single_option_line('layer_height');
             $optgroup->append_single_option_line('first_layer_height');
+            $optgroup->append_single_option_line('adaptive_slicing');
+            $optgroup->append_single_option_line('adaptive_slicing_quality');
+            $optgroup->get_field('adaptive_slicing_quality')->set_scale(1);
         }
         {
             my $optgroup = $page->new_optgroup('Vertical shells');
@@ -815,6 +819,12 @@ sub _update {
 
     my $config = $self->{config};
     
+    my $have_adaptive_slicing = $config->adaptive_slicing;
+    $self->get_field($_)->toggle($have_adaptive_slicing)
+        for qw(adaptive_slicing_quality);
+    $self->get_field($_)->toggle(!$have_adaptive_slicing)
+        for qw(layer_height);
+
     if ($config->spiral_vase && !($config->perimeters == 1 && $config->top_solid_layers == 0 && $config->fill_density == 0)) {
         my $dialog = Wx::MessageDialog->new($self,
             "The Spiral Vase mode requires:\n"

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -9,6 +9,23 @@ PrintConfigDef::PrintConfigDef()
     
     ConfigOptionDef* def;
     
+    def = this->add("adaptive_slicing", coBool);
+    def->label = "Adaptive layer heights";
+    def->tooltip = "Automatically determine layer heights by the objects topology instead of using a static value.";
+    def->cli = "adaptive-slicing!";
+    def->default_value = new ConfigOptionBool(false);
+
+    def = this->add("adaptive_slicing_quality", coPercent);
+    def->label = "Adaptive quality";
+    def->tooltip = "Controls the quality / printing time tradeoff for adaptive layer generation. 0 -> fastest printing with max layer height, 100 -> highest quality, min layer height";
+    def->sidetext = "%";
+    def->cli = "adaptive_slicing_quality=f";
+    def->min = 0;
+    def->max = 100;
+    def->gui_type = "slider";
+    def->width = 200;
+    def->default_value = new ConfigOptionPercent(75);
+
     def = this->add("avoid_crossing_perimeters", coBool);
     def->label = "Avoid crossing perimeters";
     def->tooltip = "Optimize travel moves in order to minimize the crossing of perimeters. This is mostly useful with Bowden extruders which suffer from oozing. This feature slows down both the print and the G-code generation.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -138,6 +138,8 @@ class StaticPrintConfig : public PrintConfigBase, public StaticConfig
 class PrintObjectConfig : public virtual StaticPrintConfig
 {
     public:
+    ConfigOptionBool                adaptive_slicing;
+    ConfigOptionPercent             adaptive_slicing_quality;
     ConfigOptionBool                clip_multipart_objects;
     ConfigOptionBool                dont_support_bridges;
     ConfigOptionFloatOrPercent      extrusion_width;
@@ -176,6 +178,8 @@ class PrintObjectConfig : public virtual StaticPrintConfig
     }
 
     virtual ConfigOption* optptr(const t_config_option_key &opt_key, bool create = false) {
+        OPT_PTR(adaptive_slicing);
+        OPT_PTR(adaptive_slicing_quality);
         OPT_PTR(clip_multipart_objects);
         OPT_PTR(dont_support_bridges);
         OPT_PTR(extrusion_width);

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -217,7 +217,9 @@ PrintObject::invalidate_state_by_config_options(const std::vector<t_config_optio
             steps.insert(posPerimeters);
         } else if (*opt_key == "layer_height"
             || *opt_key == "first_layer_height"
-            || *opt_key == "raft_layers") {
+            || *opt_key == "raft_layers"
+            || *opt_key == "adaptive_slicing"
+            || *opt_key == "adaptive_slicing_quality") {
             steps.insert(posSlice);
 			this->reset_layer_height_profile();
 		}
@@ -976,8 +978,7 @@ bool PrintObject::update_layer_height_profile(std::vector<coordf_t> &layer_heigh
         layer_height_profile.clear();
 
     if (layer_height_profile.empty()) {
-        if (0)
-//        if (this->layer_height_profile.empty())
+        if (this->config.adaptive_slicing.value)
             layer_height_profile = layer_height_profile_adaptive(slicing_params, this->layer_height_ranges,
                 this->model_object()->volumes);
         else

--- a/xs/src/libslic3r/Slicing.hpp
+++ b/xs/src/libslic3r/Slicing.hpp
@@ -52,6 +52,11 @@ struct SlicingParameters
 	// The regular layer height, applied for all but the first layer, if not overridden by layer ranges
 	// or by the variable layer thickness table.
     coordf_t    layer_height;
+
+    // Quality control value for adaptive layer generation
+    unsigned int adaptive_slicing_quality;
+
+
     // Minimum / maximum layer height, to be used for the automatic adaptive layer height algorithm,
     // or by an interactive layer height editor.
     coordf_t    min_layer_height;

--- a/xs/src/libslic3r/SlicingAdaptive.hpp
+++ b/xs/src/libslic3r/SlicingAdaptive.hpp
@@ -18,8 +18,11 @@ public:
 	void set_slicing_parameters(SlicingParameters params) { m_slicing_params = params; }
 	void add_mesh(const TriangleMesh *mesh) { m_meshes.push_back(mesh); }
 	void prepare();
-	float cusp_height(float z, float cusp_value, int &current_facet);
+	float layer_height(float z, int &current_facet);
 	float horizontal_facet_distance(float z);
+
+private:
+	float _layer_height_from_facet(int ordered_id, float scaled_quality_factor);
 
 protected:
 	SlicingParameters 					m_slicing_params;

--- a/xs/xsp/Print.xsp
+++ b/xs/xsp/Print.xsp
@@ -147,6 +147,7 @@ _constant()
             if (force) {
                 SlicingParameters slicing_params = THIS->slicing_parameters(); 
                 bool level_of_detail_2nd_level = true;
+                THIS->model_object()->layer_height_profile_valid = true;
                 RETVAL = generate_layer_height_texture(
                     slicing_params, 
                     generate_object_layers(slicing_params, THIS->model_object()->layer_height_profile), 


### PR DESCRIPTION
Integration of adaptive slicing into the interactive layer height tool.
I mostly used the existing SlicingAdaptive class, but replaced the cusp measure.
The quality is now controlled by a slider in %, where 0 means thickest possible layers and 100% is maximum resolution.
Layer gradation and horizontal feature detection are currently not implemented, I'm unsure how useful it is, but could easily be re-activated.

Two annotations:

- The slider field now synchronizes it's value with the textctrl, this also applies to the cut dialog.
- Syncing interactive updates and re-slicing between GUI and backend is a pain. I currently just invalidate the `layer_height_profile` at the model_object to have the gui draw the height profile right after slicing. I really don't like the current concept of having two copies of the the height_profile with identical names...

I'm very willing to keep up the work after feedback :-)