### PR TITLE
Disconnected infill

### DIFF
--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -164,6 +164,7 @@ infill_every_layers = 1
 infill_extruder = 1
 infill_extrusion_width = 0.45
 infill_first = 0
+infill_no_connect = 0
 infill_only_where_needed = 0
 infill_overlap = 25%
 interface_shells = 0

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -120,6 +120,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        params.extruder 	 = layerm.region()->extruder(extrusion_role);
 		        params.pattern 		 = layerm.region()->config().fill_pattern.value;
 		        params.density       = float(layerm.region()->config().fill_density);
+		        params.dont_connect  = layerm.region()->config().infill_no_connect;
 
 		        if (surface.is_solid()) {
 		            params.density = 100.f;
@@ -370,6 +371,7 @@ void Layer::make_fills(FillAdaptive_Internal::Octree* adaptive_fill_octree, Fill
         FillParams params;
         params.density 		= float(0.01 * surface_fill.params.density);
         params.dont_adjust 	= surface_fill.params.dont_adjust; // false
+        params.dont_connect	= surface_fill.params.dont_connect;
 
         for (ExPolygon &expoly : surface_fill.expolygons) {
 			// Spacing is modified by the filler to indicate adjustments. Reset it for each expolygon.

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -81,7 +81,7 @@ void FillRectilinear::_fill_surface_single(
     size_t n_polylines_out_old = polylines_out.size();
 
     // connect lines
-    if (! params.dont_connect && ! polylines.empty()) { // prevent calling leftmost_point() on empty collections
+    if (! polylines.empty()) { // prevent calling leftmost_point() on empty collections
         // offset the expolygon by max(min_spacing/2, extra)
         ExPolygon expolygon_off;
         {
@@ -94,7 +94,7 @@ void FillRectilinear::_fill_surface_single(
         }
         bool first = true;
         for (Polyline &polyline : chain_polylines(std::move(polylines))) {
-            if (! first) {
+            if (! params.dont_connect && ! first) {
                 // Try to connect the lines.
                 Points &pts_end = polylines_out.back().points;
                 const Point &first_point = polyline.points.front();

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -409,7 +409,7 @@ const std::vector<std::string>& Preset::print_options()
         "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
         "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", 
     	"ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
-        "max_print_speed", "max_volumetric_speed",
+        "max_print_speed", "max_volumetric_speed", "infill_no_connect",
 #ifdef HAS_PRESSURE_EQUALIZER
         "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative",
 #endif /* HAS_PRESSURE_EQUALIZER */

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1072,6 +1072,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("infill_no_connect", coBool);
+    def->label = L("Don't connect infill to perimeters");
+    def->category = L("Infill");
+    def->tooltip = L("Disable extra lines connecting infill to perimeters. These extra lines create a stronger bond, "
+		     "but can result in an uneven pattern in translucent materials.");
+    def->cli = "infill-no-connect!";
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("infill_only_where_needed", coBool);
     def->label = L("Only infill where needed");
     def->category = L("Infill");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -523,6 +523,7 @@ public:
     ConfigOptionInt                 infill_extruder;
     ConfigOptionFloatOrPercent      infill_extrusion_width;
     ConfigOptionInt                 infill_every_layers;
+    ConfigOptionBool                infill_no_connect;
     ConfigOptionFloatOrPercent      infill_overlap;
     ConfigOptionFloat               infill_speed;
     // Ironing options
@@ -574,6 +575,7 @@ protected:
         OPT_PTR(infill_extruder);
         OPT_PTR(infill_extrusion_width);
         OPT_PTR(infill_every_layers);
+        OPT_PTR(infill_no_connect);
         OPT_PTR(infill_overlap);
         OPT_PTR(infill_speed);
         OPT_PTR(ironing);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -618,6 +618,7 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "fill_angle"
             || opt_key == "fill_pattern"
             || opt_key == "fill_link_max_length"
+            || opt_key == "infill_no_connect"
             || opt_key == "top_infill_extrusion_width"
             || opt_key == "first_layer_extrusion_width") {
             steps.emplace_back(posInfill);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -237,7 +237,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_infill = config->option<ConfigOptionPercent>("fill_density")->value > 0;
     // infill_extruder uses the same logic as in Print::extruders()
-    for (auto el : { "fill_pattern", "infill_every_layers", "infill_only_where_needed",
+    for (auto el : { "fill_pattern", "infill_every_layers", "infill_only_where_needed", "infill_no_connect",
                     "solid_infill_every_layers", "solid_infill_below_area", "infill_extruder" })
         toggle_field(el, have_infill);
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1368,6 +1368,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("bridge_angle");
         optgroup->append_single_option_line("only_retract_when_crossing_perimeters");
         optgroup->append_single_option_line("infill_first");
+        optgroup->append_single_option_line("infill_no_connect");
 
     page = add_options_page(L("Skirt and brim"), "skirt+brim");
         optgroup = page->new_optgroup(L("Skirt"));


### PR DESCRIPTION
Based on existing work of @supermerill, forward-ported to current master.

- New internal option: infill_no_connect, which disables infill-to-perimeters connection.
- Internally maps to existing FillParams.dont_connect
- Two GUI switches:
  1) Print Settings -> Infill -> Advanced -> Don't connect infill to perimeters
  2) Object -> Add settings -> Infill -> [same]
- CLI switch: --infill-no-connect!
- Fix usage of dont_connect in `3d_honeycomb`, `gyroid` and `lines`