### PR TITLE
Fix gyroid/3d honeycomb perimeter connection (fixes #1690)

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -286,9 +286,15 @@ inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines
     dst.reserve(dst.size() + polylines.size());
     for (Polyline &polyline : polylines)
         if (polyline.is_valid()) {
-            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
-            dst.push_back(extrusion_path);
-            extrusion_path->polyline = polyline;
+            if (polyline.points.back() == polyline.points.front()) {
+                ExtrusionPath path(role, mm3_per_mm, width, height);
+                path.polyline.points = polyline.points;
+                dst.emplace_back(new ExtrusionLoop(std::move(path)));
+            } else {
+                ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
+                dst.push_back(extrusion_path);
+                extrusion_path->polyline = polyline;
+            }
         }
 }
 
@@ -297,9 +303,15 @@ inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines
     dst.reserve(dst.size() + polylines.size());
     for (Polyline &polyline : polylines)
         if (polyline.is_valid()) {
-            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
-            dst.push_back(extrusion_path);
-            extrusion_path->polyline = std::move(polyline);
+            if (polyline.points.back() == polyline.points.front()) {
+                ExtrusionPath path(role, mm3_per_mm, width, height);
+                path.polyline.points = polyline.points;
+                dst.emplace_back(new ExtrusionLoop(std::move(path)));
+            } else {
+                ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
+                dst.push_back(extrusion_path);
+                extrusion_path->polyline = std::move(polyline);
+            }
         }
     polylines.clear();
 }

--- a/src/libslic3r/Fill/Fill3DHoneycomb.cpp
+++ b/src/libslic3r/Fill/Fill3DHoneycomb.cpp
@@ -190,7 +190,7 @@ void Fill3DHoneycomb::_fill_surface_single(
         if (params.dont_connect) {
             polylines_out.insert(polylines_out.end(), polylines_chained.begin(), polylines_chained.end());
         } else {
-            this->connect_infill(polylines_chained, expolygon, polylines_out);
+            this->connect_infill(polylines_chained, expolygon, polylines_out, params);
         }
 
     }

--- a/src/libslic3r/Fill/Fill3DHoneycomb.cpp
+++ b/src/libslic3r/Fill/Fill3DHoneycomb.cpp
@@ -161,43 +161,38 @@ void Fill3DHoneycomb::_fill_surface_single(
     for (Polylines::iterator it = polylines.begin(); it != polylines.end(); ++ it)
         it->translate(bb.min(0), bb.min(1));
 
-    // clip pattern to boundaries
-    polylines = intersection_pl(polylines, (Polygons)expolygon);
-
-    // connect lines
-    if (! params.dont_connect && ! polylines.empty()) { // prevent calling leftmost_point() on empty collections
-        ExPolygon expolygon_off;
-        {
-            ExPolygons expolygons_off = offset_ex(expolygon, SCALED_EPSILON);
-            if (! expolygons_off.empty()) {
-                // When expanding a polygon, the number of islands could only shrink. Therefore the offset_ex shall generate exactly one expanded island for one input island.
-                assert(expolygons_off.size() == 1);
-                std::swap(expolygon_off, expolygons_off.front());
+    // clip pattern to boundaries, keeping the polyline order & ordering the fragment to be able to join them easily
+    Polylines polylines_chained;
+    for (size_t idx_polyline = 0; idx_polyline < polylines.size(); ++idx_polyline) {
+        Polyline &poly_to_cut = polylines[idx_polyline];
+        Polylines polylines_to_sort = intersection_pl(Polylines() = { poly_to_cut }, (Polygons)expolygon);
+        for (Polyline &polyline : polylines_to_sort) {
+            //TODO: replace by closest_index_point()
+            if (poly_to_cut.points.front().distance_to_square(polyline.points.front()) > poly_to_cut.points.front().distance_to_square(polyline.points.back())) {
+                polyline.reverse();
             }
         }
-        Polylines chained = PolylineCollection::chained_path_from(
-            std::move(polylines), 
-            PolylineCollection::leftmost_point(polylines), false); // reverse allowed
-        bool first = true;
-        for (Polylines::iterator it_polyline = chained.begin(); it_polyline != chained.end(); ++ it_polyline) {
-            if (! first) {
-                // Try to connect the lines.
-                Points &pts_end = polylines_out.back().points;
-                const Point &first_point = it_polyline->points.front();
-                const Point &last_point = pts_end.back();
-                // TODO: we should also check that both points are on a fill_boundary to avoid 
-                // connecting paths on the boundaries of internal regions
-                if ((last_point - first_point).cast<double>().norm() <= 1.5 * distance && 
-                    expolygon_off.contains(Line(last_point, first_point))) {
-                    // Append the polyline.
-                    pts_end.insert(pts_end.end(), it_polyline->points.begin(), it_polyline->points.end());
-                    continue;
+        if (polylines_to_sort.size() > 1) {
+            Point nearest = poly_to_cut.points.front();
+            //Bubble sort
+            for (size_t idx_sort = polylines_to_sort.size() - 1; idx_sort > 0; idx_sort--) {
+                for (size_t idx_bubble = 0; idx_bubble < idx_sort; idx_bubble++) {
+                    if (polylines_to_sort[idx_bubble + 1].points.front().distance_to_square(nearest) < polylines_to_sort[idx_bubble].points.front().distance_to_square(nearest)) {
+                        iter_swap(polylines_to_sort.begin() + idx_bubble, polylines_to_sort.begin() + idx_bubble + 1);
+                    }
                 }
             }
-            // The lines cannot be connected.
-            polylines_out.emplace_back(std::move(*it_polyline));
-            first = false;
         }
+        polylines_chained.insert(polylines_chained.end(), polylines_to_sort.begin(), polylines_to_sort.end());
+    }
+    // connect lines if needed
+    if (!polylines_chained.empty()) {
+        if (params.dont_connect) {
+            polylines_out.insert(polylines_out.end(), polylines_chained.begin(), polylines_chained.end());
+        } else {
+            this->connect_infill(polylines_chained, expolygon, polylines_out);
+        }
+
     }
 }
 

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -290,7 +290,9 @@ Points getFrontier(Polylines &polylines, const Point& p1, const Point& p2, const
                 //remove points
                 if (idx_12 <= idx_21) {
                     poly.points.erase(poly.points.begin() + idx_12, poly.points.begin() + idx_21 + 1);
-                    cut_polygon(poly, idx_11, p1, p2);
+                    if (idx_12 != 0) {
+                        cut_polygon(poly, idx_11, p1, p2);
+                    } //else : already cut at the good place
                 } else {
                     poly.points.erase(poly.points.begin() + idx_12, poly.points.end());
                     poly.points.erase(poly.points.begin(), poly.points.begin() + idx_21);
@@ -304,7 +306,9 @@ Points getFrontier(Polylines &polylines, const Point& p1, const Point& p2, const
                 //remove points
                 if (idx_22 <= idx_11) {
                     poly.points.erase(poly.points.begin() + idx_22, poly.points.begin() + idx_11 + 1);
-                    cut_polygon(poly, idx_21, p1, p2);
+                    if (idx_22 != 0) {
+                        cut_polygon(poly, idx_21, p1, p2);
+                    } //else : already cut at the good place
                 } else {
                     poly.points.erase(poly.points.begin() + idx_22, poly.points.end());
                     poly.points.erase(poly.points.begin(), poly.points.begin() + idx_11);

--- a/src/libslic3r/Fill/FillBase.hpp
+++ b/src/libslic3r/Fill/FillBase.hpp
@@ -109,7 +109,7 @@ protected:
 
     virtual std::pair<float, Point> _infill_direction(const Surface *surface) const;
 
-    void connect_infill(const Polylines &infill_ordered, const ExPolygon &boundary, Polylines &polylines_out);
+    void connect_infill(const Polylines &infill_ordered, const ExPolygon &boundary, Polylines &polylines_out, const FillParams &params);
 
 public:
     static coord_t  _adjust_solid_spacing(const coord_t width, const coord_t distance);

--- a/src/libslic3r/Fill/FillBase.hpp
+++ b/src/libslic3r/Fill/FillBase.hpp
@@ -109,6 +109,8 @@ protected:
 
     virtual std::pair<float, Point> _infill_direction(const Surface *surface) const;
 
+    void connect_infill(const Polylines &infill_ordered, const ExPolygon &boundary, Polylines &polylines_out);
+
 public:
     static coord_t  _adjust_solid_spacing(const coord_t width, const coord_t distance);
 

--- a/src/libslic3r/Fill/FillGyroid.cpp
+++ b/src/libslic3r/Fill/FillGyroid.cpp
@@ -191,13 +191,21 @@ void FillGyroid::_fill_surface_single(
         polylines_chained.insert(polylines_chained.end(), polylines_to_sort.begin(), polylines_to_sort.end());
     }
 
+    size_t polylines_out_first_idx = polylines_out.size();
     if (!polylines_chained.empty()) {
-
         // connect lines
         if (params.dont_connect) {
             polylines_out.insert(polylines_out.end(), polylines_chained.begin(), polylines_chained.end());
         } else {
-            this->connect_infill(polylines_chained, expolygon, polylines_out);
+            this->connect_infill(polylines_chained, expolygon, polylines_out, params);
+        }
+    }
+
+    //remove too small bits (larger than longer);
+    for (size_t idx = polylines_out_first_idx; idx < polylines_out.size(); idx++) {
+        if (polylines_out[idx].length() < scale_(this->spacing * 3)) {
+            polylines_out.erase(polylines_out.begin() + idx);
+            idx--;
         }
     }
 }

--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -119,6 +119,13 @@ public:
     double ccw_angle(const Point &p1, const Point &p2) const;
     Point  projection_onto(const MultiPoint &poly) const;
     Point  projection_onto(const Line &line) const;
+
+    double distance_to(const Point &point) const { return (point - *this).cast<double>().norm(); }
+    double distance_to_square(const Point &point) const {
+        double dx = (point.x() - this->x());
+        double dy = (point.y() - this->y());
+        return dx*dx + dy*dy;
+    }
 };
 
 namespace int128 {


### PR DESCRIPTION
Merge the relevant commits from @supermerill's fork that fix infill/perimeter connection when using gyroid or 3d honeycomb.

See issue #1690 for more details. This PR is here for convenience, since supermerill changes required some massaging to work on the current master. These changes also include some conflicting changes for PR#1692 so, if @bubnikv is reading ;), I'd actually suggest merging this change first as it fixes a real bug.

I already have a pre-recorded resolution of #1692 that applies cleanly on top of this if needed.