### PR TITLE
Update to config wizard to make it generic again.

### DIFF
--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2,7 +2,10 @@
 
 [vendor]
 # Vendor name will be shown by the Config Wizard.
-name = Prusa Research
+name = Prusa {technology}
+technologies = FFF; SLA
+full_name = Prusa {technology} Technology Printers
+
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the Slic3r configuration to be downgraded.
 config_version = 0.8.0-alpha7

--- a/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -108,16 +108,10 @@ struct PageWelcome: ConfigWizardPage
 
 struct PagePrinters: ConfigWizardPage
 {
-    enum Technology {
-        // Bitflag equivalent of PrinterTechnology
-        T_FFF = 0x1,
-        T_SLA = 0x2,
-        T_Any = ~0,
-    };
 
     std::vector<PrinterPicker *> printer_pickers;
 
-    PagePrinters(ConfigWizard *parent, wxString title, wxString shortname, const VendorProfile &vendor, unsigned indent, Technology technology);
+    PagePrinters(ConfigWizard *parent, wxString title, wxString shortname, const VendorProfile &vendor, unsigned indent, PrinterTechnology technology);
 
     void select_all(bool select, bool alternates = false);
     int get_width() const;
@@ -262,11 +256,9 @@ struct ConfigWizard::priv
     wxButton *btn_cancel = nullptr;
 
     PageWelcome      *page_welcome = nullptr;
-    PagePrinters     *page_fff = nullptr;
-    PagePrinters     *page_msla = nullptr;
+    std::vector<PagePrinters*> page_vendors;
     PageCustom       *page_custom = nullptr;
     PageUpdate       *page_update = nullptr;
-    PageVendors      *page_vendors = nullptr;   // XXX: ?
 
     // Custom setup pages
     PageFirmware     *page_firmware = nullptr;

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -117,6 +117,27 @@ VendorProfile VendorProfile::from_ini(const ptree &tree, const boost::filesystem
 
     const auto &vendor_section = get_or_throw(tree, "vendor")->second;
     res.name = get_or_throw(vendor_section, "name")->second.data();
+    auto full_name_node = vendor_section.find("full_name");
+    res.full_name = (full_name_node == vendor_section.not_found()) ? res.name : full_name_node->second.data();
+    const auto technologies_field = vendor_section.get<std::string>("technologies", "");
+    std::vector<std::string> technologies;
+    if (Slic3r::unescape_strings_cstyle(technologies_field, technologies) && !technologies.empty()) {
+        for (const std::string &technology : technologies) {
+            if (technology == "FFF")
+                res.technologies.push_back(PrinterTechnology::ptFFF);
+            else if (technology == "SLA")
+                res.technologies.push_back(PrinterTechnology::ptSLA);
+            else if (technology == "Any")
+                res.technologies.push_back(PrinterTechnology::ptAny);
+            else if (technology == "Unknown")
+                res.technologies.push_back(PrinterTechnology::ptUnknown);
+            else
+                BOOST_LOG_TRIVIAL(error) << boost::format("Vendor bundle: `%1%`: Malformed technologies field: `%2%`") % id % technologies_field;
+        }
+    } else {
+        //default to FFF if not present
+        res.technologies.push_back(PrinterTechnology::ptFFF);
+    }
 
     auto config_version_str = get_or_throw(vendor_section, "config_version")->second.data();
     auto config_version = Semver::parse(config_version_str);
@@ -160,7 +181,6 @@ VendorProfile VendorProfile::from_ini(const ptree &tree, const boost::filesystem
 			if (model.technology == ptSLA)
 				continue;
 #endif
-			section.second.get<std::string>("variants", "");
             const auto variants_field = section.second.get<std::string>("variants", "");
             std::vector<std::string> variants;
             if (Slic3r::unescape_strings_cstyle(variants_field, variants)) {

--- a/src/slic3r/GUI/Preset.hpp
+++ b/src/slic3r/GUI/Preset.hpp
@@ -39,6 +39,8 @@ class VendorProfile
 {
 public:
     std::string                     name;
+    std::string                     full_name;
+    std::vector<PrinterTechnology>  technologies;
     std::string                     id;
     Semver                          config_version;
     std::string                     config_update_url;


### PR DESCRIPTION
the new wizard doesn't allow user-defined config bundle.
This is a pr to re-enable it: it use two new fields in the header (with default if not populated):
 * full_name
 * technologies
Should be equivalent to the current (alpha7) behaviour.

I also removed a bit of dead code (the legacy thing)
