### PR TITLE
Initialize wxImageList with the correct scale (fixes #2069)

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -219,7 +219,7 @@ void Tab::create_preset_tab()
     m_treectrl = new wxTreeCtrl(panel, wxID_ANY, wxDefaultPosition, wxSize(20 * m_em_unit, -1),
 		wxTR_NO_BUTTONS | wxTR_HIDE_ROOT | wxTR_SINGLE | wxTR_NO_LINES | wxBORDER_SUNKEN | wxWANTS_CHARS);
 	m_left_sizer->Add(m_treectrl, 1, wxEXPAND);
-    m_icons = new wxImageList(int(16 * scale_factor), int(16 * scale_factor), true, 1);
+    m_icons = new wxImageList(int(16 * scale_factor + 0.5f), int(16 * scale_factor + 0.5f), true, 1);
 	// Index of the last icon inserted into $self->{icons}.
 	m_icon_count = -1;
 	m_treectrl->AssignImageList(m_icons);


### PR DESCRIPTION
When initializing wxImageList match the same scaling formula in
wxExtensions.cpp::create_scaled_bitmap.

The different rounding can create assertion failures depending on the
screen resolution.