### PR TITLE
Enable wipe tower for all multi-extruder configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ xs/MANIFEST.bak
 xs/assertlib*
 .init_bundle.ini
 local-lib
+.DS_Store
+resources

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -167,7 +167,7 @@ static inline Point wipe_tower_point_to_object_point(GCode &gcodegen, const Wipe
     return Point(scale_(wipe_tower_pt.x - gcodegen.origin()(0)), scale_(wipe_tower_pt.y - gcodegen.origin()(1)));
 }
 
-std::string WipeTowerIntegration::append_tcr(GCode &gcodegen, const WipeTower::ToolChangeResult &tcr, int new_extruder_id) const
+std::string WipeTowerIntegration::append_tcr(GCode &gcodegen, const WipeTower::ToolChangeResult &tcr, int new_extruder_id, float print_z) const
 {
     std::string gcode;
 
@@ -195,24 +195,57 @@ std::string WipeTowerIntegration::append_tcr(GCode &gcodegen, const WipeTower::T
         "Travel to a Wipe Tower");
     gcode += gcodegen.unretract();
 
-    // Let the tool change be executed by the wipe tower class.
-    // Inform the G-code writer about the changes done behind its back.
-    gcode += tcr_rotated_gcode;
-    // Let the m_writer know the current extruder_id, but ignore the generated G-code.
-	if (new_extruder_id >= 0 && gcodegen.writer().need_toolchange(new_extruder_id))
-        gcodegen.writer().toolchange(new_extruder_id);
-    gcodegen.placeholder_parser().set("current_extruder", new_extruder_id);
-
-    // Always append the filament start G-code even if the extruder did not switch,
-    // because the wipe tower resets the linear advance and we want it to be re-enabled.
+    // Process the end filament gcode.
+    std::string end_filament_gcode_str;
+    if (gcodegen.writer().extruder() != nullptr) {
+        // Process the custom end_filament_gcode in case of single_extruder_multi_material.
+        unsigned int        old_extruder_id     = gcodegen.writer().extruder()->id();
+        const std::string  &end_filament_gcode  = gcodegen.config().end_filament_gcode.get_at(old_extruder_id);
+        if (gcodegen.writer().extruder() != nullptr && ! end_filament_gcode.empty()) {
+            end_filament_gcode_str = gcodegen.placeholder_parser_process("end_filament_gcode", end_filament_gcode, old_extruder_id);
+            check_add_eol(end_filament_gcode_str);
+        }
+    }
+    
+    // Process the tool chagne gcode.
+    std::string toolchange_gcode_str;
+    const std::string  &toolchange_gcode  = gcodegen.config().toolchange_gcode.value;
+    if (gcodegen.writer().extruder() != nullptr && ! toolchange_gcode.empty()) {
+        // Process the custom toolchange_gcode.
+        DynamicConfig config;
+        config.set_key_value("previous_extruder", new ConfigOptionInt((int)gcodegen.writer().extruder()->id()));
+        config.set_key_value("next_extruder",     new ConfigOptionInt((int)new_extruder_id));
+        config.set_key_value("layer_num",         new ConfigOptionInt(gcodegen.m_layer_index));
+        config.set_key_value("layer_z",           new ConfigOptionFloat(print_z));
+        toolchange_gcode_str = gcodegen.placeholder_parser_process("toolchange_gcode", toolchange_gcode, new_extruder_id, &config);
+        check_add_eol(toolchange_gcode_str);
+    }
+    
+    // Process the start filament gcode.
+    std::string start_filament_gcode_str;
     const std::string &start_filament_gcode = gcodegen.config().start_filament_gcode.get_at(new_extruder_id);
     if (! start_filament_gcode.empty()) {
         // Process the start_filament_gcode for the active filament only.
         DynamicConfig config;
         config.set_key_value("filament_extruder_id", new ConfigOptionInt(new_extruder_id));
-        gcode += gcodegen.placeholder_parser_process("start_filament_gcode", start_filament_gcode, new_extruder_id, &config);
-        check_add_eol(gcode);
+        start_filament_gcode_str = gcodegen.placeholder_parser_process("start_filament_gcode", start_filament_gcode, new_extruder_id, &config);
+        check_add_eol(start_filament_gcode_str);
     }
+    
+    // Insert the end filament, toolchange, and start filament gcode.
+    DynamicConfig config;
+    config.set_key_value("end_filament_gcode",   new ConfigOptionString(end_filament_gcode_str));
+    config.set_key_value("toolchange_gcode",     new ConfigOptionString(toolchange_gcode_str));
+    config.set_key_value("start_filament_gcode", new ConfigOptionString(start_filament_gcode_str));
+    std::string tcr_gcode, tcr_escaped_gcode = gcodegen.placeholder_parser_process("tcr_rotated_gcode", tcr_rotated_gcode, new_extruder_id, &config);
+    unescape_string_cstyle(tcr_escaped_gcode, tcr_gcode);
+    gcode += tcr_gcode;
+    check_add_eol(toolchange_gcode_str);
+
+    // Let the m_writer know the current extruder_id, but ignore the generated G-code.
+	if (new_extruder_id >= 0 && gcodegen.writer().need_toolchange(new_extruder_id))
+        gcodegen.writer().toolchange(new_extruder_id);
+
     // A phony move to the end position at the wipe tower.
     gcodegen.writer().travel_to_xy(Vec2d(end_pos.x, end_pos.y));
     gcodegen.set_last_pos(wipe_tower_point_to_object_point(gcodegen, end_pos));
@@ -313,14 +346,14 @@ std::string WipeTowerIntegration::prime(GCode &gcodegen)
     return gcode;
 }
 
-std::string WipeTowerIntegration::tool_change(GCode &gcodegen, int extruder_id, bool finish_layer)
+std::string WipeTowerIntegration::tool_change(GCode &gcodegen, int extruder_id, bool finish_layer, float print_z)
 {
     std::string gcode;
 	assert(m_layer_idx >= 0 && m_layer_idx <= m_tool_changes.size());
     if (! m_brim_done || gcodegen.writer().need_toolchange(extruder_id) || finish_layer) {
 		if (m_layer_idx < m_tool_changes.size()) {
 			assert(m_tool_change_idx < m_tool_changes[m_layer_idx].size());
-			gcode += append_tcr(gcodegen, m_tool_changes[m_layer_idx][m_tool_change_idx++], extruder_id);
+			gcode += append_tcr(gcodegen, m_tool_changes[m_layer_idx][m_tool_change_idx++], extruder_id, print_z);
 		}
         m_brim_done = true;
     }
@@ -333,7 +366,7 @@ std::string WipeTowerIntegration::finalize(GCode &gcodegen)
     std::string gcode;
     if (std::abs(gcodegen.writer().get_position()(2) - m_final_purge.print_z) > EPSILON)
         gcode += gcodegen.change_layer(m_final_purge.print_z);
-    gcode += append_tcr(gcodegen, m_final_purge, -1);
+    gcode += append_tcr(gcodegen, m_final_purge, -1, m_final_purge.print_z);
     return gcode;
 }
 
@@ -803,15 +836,13 @@ void GCode::_do_export(Print &print, FILE *file)
     // Write the custom start G-code
     _writeln(file, start_gcode);
     // Process filament-specific gcode in extruder order.
-    if (print.config().single_extruder_multi_material) {
-        if (has_wipe_tower) {
-            // Wipe tower will control the extruder switching, it will call the start_filament_gcode.
-        } else {
-            // Only initialize the initial extruder.
-            DynamicConfig config;
-            config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(initial_extruder_id)));
-			_writeln(file, this->placeholder_parser_process("start_filament_gcode", print.config().start_filament_gcode.values[initial_extruder_id], initial_extruder_id, &config));
-        }
+    if (has_wipe_tower) {
+        // Wipe tower will control the extruder switching, it will call the start_filament_gcode.
+    } else if (print.config().single_extruder_multi_material) {
+        // Only initialize the initial extruder.
+        DynamicConfig config;
+        config.set_key_value("filament_extruder_id", new ConfigOptionInt(int(initial_extruder_id)));
+        _writeln(file, this->placeholder_parser_process("start_filament_gcode", print.config().start_filament_gcode.values[initial_extruder_id], initial_extruder_id, &config));
     } else {
         DynamicConfig config;
         for (const std::string &start_gcode : print.config().start_filament_gcode.values) {
@@ -1596,7 +1627,7 @@ void GCode::process_layer(
     for (unsigned int extruder_id : layer_tools.extruders)
     {
         gcode += (layer_tools.has_wipe_tower && m_wipe_tower) ?
-            m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back()) :
+            m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back(), print_z) :
             this->set_extruder(extruder_id, print_z);
 
         // let analyzer tag generator aware of a role type change

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -99,13 +99,13 @@ public:
 
     std::string prime(GCode &gcodegen);
     void next_layer() { ++ m_layer_idx; m_tool_change_idx = 0; }
-    std::string tool_change(GCode &gcodegen, int extruder_id, bool finish_layer);
+    std::string tool_change(GCode &gcodegen, int extruder_id, bool finish_layer, float print_z);
     std::string finalize(GCode &gcodegen);
     std::vector<float> used_filament_length() const;
 
 private:
     WipeTowerIntegration& operator=(const WipeTowerIntegration&);
-    std::string append_tcr(GCode &gcodegen, const WipeTower::ToolChangeResult &tcr, int new_extruder_id) const;
+    std::string append_tcr(GCode &gcodegen, const WipeTower::ToolChangeResult &tcr, int new_extruder_id, float print_z) const;
 
     // Postprocesses gcode: rotates and moves all G1 extrusions and returns result
     std::string rotate_wipe_tower_moves(const std::string& gcode_original, const WipeTower::xy& start_pos, const WipeTower::xy& translation, float angle) const;

--- a/src/libslic3r/GCode/PrintExtents.cpp
+++ b/src/libslic3r/GCode/PrintExtents.cpp
@@ -138,7 +138,7 @@ BoundingBoxf get_wipe_tower_extrusions_extents(const Print &print, const coordf_
     // We need to get position and angle of the wipe tower to transform them to actual position.
     Transform2d trafo =
         Eigen::Translation2d(print.config().wipe_tower_x.value, print.config().wipe_tower_y.value) *
-        Eigen::Rotation2Dd(print.config().wipe_tower_rotation_angle.value);
+        Eigen::Rotation2Dd(Geometry::deg2rad(print.config().wipe_tower_rotation_angle.value));
 
     BoundingBoxf bbox;
     for (const std::vector<WipeTower::ToolChangeResult> &tool_changes : print.wipe_tower_data().tool_changes) {
@@ -158,6 +158,43 @@ BoundingBoxf get_wipe_tower_extrusions_extents(const Print &print, const coordf_
         }
     }
     return bbox;
+}
+
+// Returns a vector of points of a projection of the wipe tower for the layers <= max_print_z.
+// The projection does not contain the priming regions.
+std::vector<Vec2d> get_wipe_tower_extrusions_points(const Print &print, const coordf_t max_print_z)
+{
+    // Wipe tower extrusions are saved as if the tower was at the origin with no rotation
+    // We need to get position and angle of the wipe tower to transform them to actual position.
+    Transform2d trafo =
+        Eigen::Translation2d(print.config().wipe_tower_x.value, print.config().wipe_tower_y.value) *
+        Eigen::Rotation2Dd(Geometry::deg2rad(print.config().wipe_tower_rotation_angle.value));
+
+    BoundingBoxf bbox;
+    for (const std::vector<WipeTower::ToolChangeResult> &tool_changes : print.wipe_tower_data().tool_changes) {
+        if (!tool_changes.empty() && tool_changes.front().print_z > max_print_z)
+            break;
+        for (const WipeTower::ToolChangeResult &tcr : tool_changes) {
+            for (size_t i = 1; i < tcr.extrusions.size(); ++i) {
+                const WipeTower::Extrusion &e = tcr.extrusions[i];
+                if (e.width > 0) {
+                    Vec2d delta = 0.5 * Vec2d(e.width, e.width);
+                    Vec2d p1 = Vec2d((&e - 1)->pos.x, (&e - 1)->pos.y);
+                    Vec2d p2 = Vec2d(e.pos.x, e.pos.y);
+                    bbox.merge(p1.cwiseMin(p2) - delta);
+                    bbox.merge(p1.cwiseMax(p2) + delta);
+                }
+            }
+        }
+    }
+
+    std::vector<Vec2d> points;
+    points.push_back(trafo * Vec2d(bbox.min.x(), bbox.max.y()));
+    points.push_back(trafo * Vec2d(bbox.max.x(), bbox.max.y()));
+    points.push_back(trafo * Vec2d(bbox.max.x(), bbox.min.y()));
+    points.push_back(trafo * Vec2d(bbox.min.x(), bbox.min.y()));
+
+    return points;
 }
 
 // Returns a bounding box of the wipe tower priming extrusions.

--- a/src/libslic3r/GCode/PrintExtents.hpp
+++ b/src/libslic3r/GCode/PrintExtents.hpp
@@ -22,6 +22,10 @@ BoundingBoxf get_print_object_extrusions_extents(const PrintObject &print_object
 // The projection does not contain the priming regions.
 BoundingBoxf get_wipe_tower_extrusions_extents(const Print &print, const coordf_t max_print_z);
 
+// Returns a vector of points of a projection of the wipe tower for the layers <= max_print_z.
+// The projection does not contain the priming regions.
+std::vector<Vec2d> get_wipe_tower_extrusions_points(const Print &print, const coordf_t max_print_z);
+
 // Returns a bounding box of the wipe tower priming extrusions.
 BoundingBoxf get_wipe_tower_priming_extrusions_extents(const Print &print);
 

--- a/src/libslic3r/GCode/WipeTowerPrusaMM.cpp
+++ b/src/libslic3r/GCode/WipeTowerPrusaMM.cpp
@@ -844,19 +844,21 @@ void WipeTowerPrusaMM::toolchange_Unload(
     // Retraction:
     float old_x = writer.x();
     float turning_point = (!m_left_to_right ? xl : xr );
-    float total_retraction_distance = m_cooling_tube_retraction + m_cooling_tube_length/2.f - 15.f; // the 15mm is reserved for the first part after ramming
-    writer.suppress_preview()
-          .retract(15.f, m_filpar[m_current_tool].unloading_speed_start * 60.f) // feedrate 5000mm/min = 83mm/s
-          .retract(0.70f * total_retraction_distance, 1.0f * m_filpar[m_current_tool].unloading_speed * 60.f)
-          .retract(0.20f * total_retraction_distance, 0.5f * m_filpar[m_current_tool].unloading_speed * 60.f)
-          .retract(0.10f * total_retraction_distance, 0.3f * m_filpar[m_current_tool].unloading_speed * 60.f)
-          
-          /*.load_move_x_advanced(turning_point, -15.f, 83.f, 50.f) // this is done at fixed speed
-          .load_move_x_advanced(old_x,         -0.70f * total_retraction_distance, 1.0f * m_filpar[m_current_tool].unloading_speed)
-          .load_move_x_advanced(turning_point, -0.20f * total_retraction_distance, 0.5f * m_filpar[m_current_tool].unloading_speed)
-          .load_move_x_advanced(old_x,         -0.10f * total_retraction_distance, 0.3f * m_filpar[m_current_tool].unloading_speed)
-          .travel(old_x, writer.y()) // in case previous move was shortened to limit feedrate*/
-          .resume_preview();
+    if ((m_cooling_tube_retraction != 0 || m_cooling_tube_length != 0) && m_filpar[m_current_tool].unloading_speed_start != 0 && m_filpar[m_current_tool].unloading_speed != 0) {
+        float total_retraction_distance = m_cooling_tube_retraction + m_cooling_tube_length/2.f - 15.f; // the 15mm is reserved for the first part after ramming
+        writer.suppress_preview()
+              .retract(15.f, m_filpar[m_current_tool].unloading_speed_start * 60.f) // feedrate 5000mm/min = 83mm/s
+              .retract(0.70f * total_retraction_distance, 1.0f * m_filpar[m_current_tool].unloading_speed * 60.f)
+              .retract(0.20f * total_retraction_distance, 0.5f * m_filpar[m_current_tool].unloading_speed * 60.f)
+              .retract(0.10f * total_retraction_distance, 0.3f * m_filpar[m_current_tool].unloading_speed * 60.f)
+              
+              /*.load_move_x_advanced(turning_point, -15.f, 83.f, 50.f) // this is done at fixed speed
+              .load_move_x_advanced(old_x,         -0.70f * total_retraction_distance, 1.0f * m_filpar[m_current_tool].unloading_speed)
+              .load_move_x_advanced(turning_point, -0.20f * total_retraction_distance, 0.5f * m_filpar[m_current_tool].unloading_speed)
+              .load_move_x_advanced(old_x,         -0.10f * total_retraction_distance, 0.3f * m_filpar[m_current_tool].unloading_speed)
+              .travel(old_x, writer.y()) // in case previous move was shortened to limit feedrate*/
+              .resume_preview();
+    }
     if (new_temperature != 0 && (new_temperature != m_old_temperature || m_is_first_layer) ) { 	// Set the extruder temperature, but don't wait.
         // If the required temperature is the same as last time, don't emit the M104 again (if user adjusted the value, it would be reset)
         // However, always change temperatures on the first layer (this is to avoid issues with priming lines turned off).
@@ -906,6 +908,9 @@ void WipeTowerPrusaMM::toolchange_Change(
     // Ask the writer about how much of the old filament we consumed:
     if (m_current_tool < m_used_filament_length.size())
     	m_used_filament_length[m_current_tool] += writer.get_and_reset_used_filament_length();
+    
+    writer.append("[end_filament_gcode]\n");
+    writer.append("[toolchange_gcode]\n");
 
 	// Speed override for the material. Go slow for flex and soluble materials.
 	int speed_override;
@@ -920,6 +925,9 @@ void WipeTowerPrusaMM::toolchange_Change(
 		assert(speed_override == 100);
 	else
 		writer.speed_override(speed_override);
+    
+    writer.append("[start_filament_gcode]\n");
+    
 	writer.flush_planner_queue();
 	m_current_tool = new_tool;
 }
@@ -927,32 +935,34 @@ void WipeTowerPrusaMM::toolchange_Change(
 void WipeTowerPrusaMM::toolchange_Load(
 	PrusaMultiMaterial::Writer &writer,
 	const box_coordinates  &cleaning_box)
-{	
-	float xl = cleaning_box.ld.x + m_perimeter_width * 0.75f;
-	float xr = cleaning_box.rd.x - m_perimeter_width * 0.75f;
-	float oldx = writer.x();	// the nozzle is in place to do the first wiping moves, we will remember the position
+{
+    if ((m_parking_pos_retraction != 0 || m_extra_loading_move != 0) && m_filpar[m_current_tool].loading_speed_start != 0 && m_filpar[m_current_tool].loading_speed != 0) {
+        float xl = cleaning_box.ld.x + m_perimeter_width * 0.75f;
+        float xr = cleaning_box.rd.x - m_perimeter_width * 0.75f;
+        float oldx = writer.x();	// the nozzle is in place to do the first wiping moves, we will remember the position
 
-    // Load the filament while moving left / right, so the excess material will not create a blob at a single position.
-    float turning_point = ( oldx-xl < xr-oldx ? xr : xl );
-    float edist = m_parking_pos_retraction+m_extra_loading_move;
+        // Load the filament while moving left / right, so the excess material will not create a blob at a single position.
+        float turning_point = ( oldx-xl < xr-oldx ? xr : xl );
+        float edist = m_parking_pos_retraction+m_extra_loading_move;
 
-    writer.append("; CP TOOLCHANGE LOAD\n")
-		  .suppress_preview()
-		  /*.load_move_x_advanced(turning_point, 0.2f * edist, 0.3f * m_filpar[m_current_tool].loading_speed)  // Acceleration
-		  .load_move_x_advanced(oldx,          0.5f * edist,        m_filpar[m_current_tool].loading_speed)  // Fast phase
-		  .load_move_x_advanced(turning_point, 0.2f * edist, 0.3f * m_filpar[m_current_tool].loading_speed)  // Slowing down
-		  .load_move_x_advanced(oldx,          0.1f * edist, 0.1f * m_filpar[m_current_tool].loading_speed)  // Super slow*/
+        writer.append("; CP TOOLCHANGE LOAD\n")
+              .suppress_preview()
+              /*.load_move_x_advanced(turning_point, 0.2f * edist, 0.3f * m_filpar[m_current_tool].loading_speed)  // Acceleration
+              .load_move_x_advanced(oldx,          0.5f * edist,        m_filpar[m_current_tool].loading_speed)  // Fast phase
+              .load_move_x_advanced(turning_point, 0.2f * edist, 0.3f * m_filpar[m_current_tool].loading_speed)  // Slowing down
+              .load_move_x_advanced(oldx,          0.1f * edist, 0.1f * m_filpar[m_current_tool].loading_speed)  // Super slow*/
 
-          .load(0.2f * edist, 60.f * m_filpar[m_current_tool].loading_speed_start)
-          .load_move_x_advanced(turning_point, 0.7f * edist,        m_filpar[m_current_tool].loading_speed)  // Fast phase
-		  .load_move_x_advanced(oldx,          0.1f * edist, 0.1f * m_filpar[m_current_tool].loading_speed)  // Super slow*/
+              .load(0.2f * edist, 60.f * m_filpar[m_current_tool].loading_speed_start)
+              .load_move_x_advanced(turning_point, 0.7f * edist,        m_filpar[m_current_tool].loading_speed)  // Fast phase
+              .load_move_x_advanced(oldx,          0.1f * edist, 0.1f * m_filpar[m_current_tool].loading_speed)  // Super slow*/
 
-          .travel(oldx, writer.y()) // in case last move was shortened to limit x feedrate
-		  .resume_preview();
+              .travel(oldx, writer.y()) // in case last move was shortened to limit x feedrate
+              .resume_preview();
 
-	// Reset the extruder current to the normal value.
-	if (m_set_extruder_trimpot)
-		writer.set_extruder_trimpot(550);
+        // Reset the extruder current to the normal value.
+        if (m_set_extruder_trimpot)
+            writer.set_extruder_trimpot(550);
+    }
 }
 
 // Wipe the newly loaded filament until the end of the assigned wipe area.

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1189,17 +1189,15 @@ std::string Print::validate() const
             return L("The Spiral Vase option can only be used when printing single material objects.");
     }
 
-    if (m_config.single_extruder_multi_material) {
-        for (size_t i=1; i<m_config.nozzle_diameter.values.size(); ++i)
-            if (m_config.nozzle_diameter.values[i] != m_config.nozzle_diameter.values[i-1])
-                return L("All extruders must have the same diameter for single extruder multimaterial printer.");
-    }
-
     if (this->has_wipe_tower() && ! m_objects.empty()) {
         if (m_config.gcode_flavor != gcfRepRap && m_config.gcode_flavor != gcfRepetier && m_config.gcode_flavor != gcfMarlin)
             return L("The Wipe Tower is currently only supported for the Marlin, RepRap/Sprinter and Repetier G-code flavors.");
         if (! m_config.use_relative_e_distances)
             return L("The Wipe Tower is currently only supported with the relative extruder addressing (use_relative_e_distances=1).");
+        
+        for (size_t i=1; i<m_config.nozzle_diameter.values.size(); ++i)
+            if (m_config.nozzle_diameter.values[i] != m_config.nozzle_diameter.values[i-1])
+                return L("All extruders must have the same diameter for the Wipe Tower.");
 
         if (m_objects.size() > 1) {
             bool                                has_custom_layering = false;
@@ -1708,7 +1706,6 @@ void Print::_make_brim()
 bool Print::has_wipe_tower() const
 {
     return 
-        m_config.single_extruder_multi_material.value && 
         ! m_config.spiral_vase.value &&
         m_config.wipe_tower.value && 
         m_config.nozzle_diameter.values.size() > 1;
@@ -1770,37 +1767,75 @@ void Print::_make_wipe_tower()
         }
     }
     this->throw_if_canceled();
+    
+    bool semm = m_config.single_extruder_multi_material.value;
+    float cooling_tube_retraction = 0.0;
+    float cooling_tube_length = 0.0;
+    float parking_pos_retraction = 0.0;
+    bool extra_loading_move = 0.0;
+    bool high_current_on_filament_swap = false;
+    
+    if (semm) {
+        cooling_tube_retraction = float(m_config.cooling_tube_retraction.value);
+        cooling_tube_length = float(m_config.cooling_tube_length.value);
+        parking_pos_retraction = float(m_config.parking_pos_retraction.value);
+        extra_loading_move = float(m_config.extra_loading_move.value);
+        high_current_on_filament_swap = m_config.high_current_on_filament_swap.value;
+    }
 
     // Initialize the wipe tower.
     WipeTowerPrusaMM wipe_tower(
         float(m_config.wipe_tower_x.value),     float(m_config.wipe_tower_y.value), 
         float(m_config.wipe_tower_width.value),
-        float(m_config.wipe_tower_rotation_angle.value), float(m_config.cooling_tube_retraction.value),
-        float(m_config.cooling_tube_length.value), float(m_config.parking_pos_retraction.value),
-        float(m_config.extra_loading_move.value), float(m_config.wipe_tower_bridging), 
-        m_config.high_current_on_filament_swap.value, m_config.gcode_flavor, wipe_volumes,
+        float(m_config.wipe_tower_rotation_angle.value), cooling_tube_retraction,
+        cooling_tube_length, parking_pos_retraction,
+        extra_loading_move, float(m_config.wipe_tower_bridging),
+        high_current_on_filament_swap, m_config.gcode_flavor, wipe_volumes,
         m_wipe_tower_data.tool_ordering.first_extruder());
 
     //wipe_tower.set_retract();
     //wipe_tower.set_zhop();
 
     // Set the extruder & material properties at the wipe tower object.
-    for (size_t i = 0; i < number_of_extruders; ++ i)
+    for (size_t i = 0; i < number_of_extruders; ++ i) {
+        float loading_speed = 0.0;
+        float loading_speed_start = 0.0;
+        float unloading_speed = 0.0;
+        float unloading_speed_start = 0.0;
+        float toolchange_delay = 0.0;
+        int cooling_moves = 0;
+        float cooling_initial_speed = 0.0;
+        float cooling_final_speed = 0.0;
+        std::string ramming_parameters;
+        
+        if (semm) {
+            loading_speed = m_config.filament_loading_speed.get_at(i);
+            loading_speed_start = m_config.filament_loading_speed_start.get_at(i);
+            unloading_speed = m_config.filament_unloading_speed.get_at(i);
+            unloading_speed_start = m_config.filament_unloading_speed_start.get_at(i);
+            toolchange_delay = m_config.filament_toolchange_delay.get_at(i);
+            cooling_moves = m_config.filament_cooling_moves.get_at(i);
+            cooling_initial_speed = m_config.filament_cooling_initial_speed.get_at(i);
+            cooling_final_speed = m_config.filament_cooling_final_speed.get_at(i);
+            ramming_parameters = m_config.filament_ramming_parameters.get_at(i);
+        }
+    
         wipe_tower.set_extruder(
             i, 
             WipeTowerPrusaMM::parse_material(m_config.filament_type.get_at(i).c_str()),
             m_config.temperature.get_at(i),
             m_config.first_layer_temperature.get_at(i),
-            m_config.filament_loading_speed.get_at(i),
-            m_config.filament_loading_speed_start.get_at(i),
-            m_config.filament_unloading_speed.get_at(i),
-            m_config.filament_unloading_speed_start.get_at(i),
-            m_config.filament_toolchange_delay.get_at(i),
-            m_config.filament_cooling_moves.get_at(i),
-            m_config.filament_cooling_initial_speed.get_at(i),
-            m_config.filament_cooling_final_speed.get_at(i),
-            m_config.filament_ramming_parameters.get_at(i),
+            loading_speed,
+            loading_speed_start,
+            unloading_speed,
+            unloading_speed_start,
+            toolchange_delay,
+            cooling_moves,
+            cooling_initial_speed,
+            cooling_final_speed,
+            ramming_parameters,
             m_config.nozzle_diameter.get_at(i));
+    }
 
     m_wipe_tower_data.priming = Slic3r::make_unique<WipeTower::ToolChangeResult>(
         wipe_tower.prime(this->skirt_first_layer_height(), m_wipe_tower_data.tool_ordering.all_extruders(), false));

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2043,11 +2043,10 @@ void GLCanvas3D::reload_scene(bool refresh_immediately, bool force_full_scene_re
             // Should the wipe tower be visualized ?
             unsigned int extruders_count = (unsigned int)dynamic_cast<const ConfigOptionFloats*>(m_config->option("nozzle_diameter"))->values.size();
 
-            bool semm = dynamic_cast<const ConfigOptionBool*>(m_config->option("single_extruder_multi_material"))->value;
             bool wt = dynamic_cast<const ConfigOptionBool*>(m_config->option("wipe_tower"))->value;
             bool co = dynamic_cast<const ConfigOptionBool*>(m_config->option("complete_objects"))->value;
 
-            if ((extruders_count > 1) && semm && wt && !co)
+            if ((extruders_count > 1) && wt && !co)
             {
                 // Height of a print (Show at least a slab)
                 double height = std::max(m_model->bounding_box().max(2), 10.0);
@@ -5451,7 +5450,7 @@ void GLCanvas3D::_load_fff_shells()
         double max_z = print->objects()[0]->model_object()->get_model()->bounding_box().max(2);
         const PrintConfig& config = print->config();
         unsigned int extruders_count = config.nozzle_diameter.size();
-        if ((extruders_count > 1) && config.single_extruder_multi_material && config.wipe_tower && !config.complete_objects) {
+        if ((extruders_count > 1) && config.wipe_tower && !config.complete_objects) {
             float depth = print->get_wipe_tower_depth();
 
             // Calculate wipe tower brim spacing.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -874,11 +874,10 @@ void Tab::update_wiping_button_visibility() {
         return; // ys_FIXME
     bool wipe_tower_enabled = dynamic_cast<ConfigOptionBool*>(  (m_preset_bundle->prints.get_edited_preset().config  ).option("wipe_tower"))->value;
     bool multiple_extruders = dynamic_cast<ConfigOptionFloats*>((m_preset_bundle->printers.get_edited_preset().config).option("nozzle_diameter"))->values.size() > 1;
-    bool single_extruder_mm = dynamic_cast<ConfigOptionBool*>(  (m_preset_bundle->printers.get_edited_preset().config).option("single_extruder_multi_material"))->value;
 
     auto wiping_dialog_button = wxGetApp().sidebar().get_wiping_dialog_button();
     if (wiping_dialog_button) {
-        wiping_dialog_button->Show(wipe_tower_enabled && multiple_extruders && single_extruder_mm);
+        wiping_dialog_button->Show(wipe_tower_enabled && multiple_extruders);
         wiping_dialog_button->GetParent()->Layout();
     }
 }
@@ -1557,6 +1556,9 @@ void TabFilament::build()
 		};
 		optgroup->append_line(line);
 
+        optgroup = page->new_optgroup(_(L("Wipe tower parameters")));
+        optgroup->append_single_option_line("filament_minimal_purge_on_wipe_tower");
+
         optgroup = page->new_optgroup(_(L("Toolchange parameters with single extruder MM printers")));
 		optgroup->append_single_option_line("filament_loading_speed_start");
         optgroup->append_single_option_line("filament_loading_speed");
@@ -1568,7 +1570,6 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_cooling_moves");
         optgroup->append_single_option_line("filament_cooling_initial_speed");
         optgroup->append_single_option_line("filament_cooling_final_speed");
-        optgroup->append_single_option_line("filament_minimal_purge_on_wipe_tower");
 
         line = optgroup->create_single_option_line("filament_ramming_parameters");// { _(L("Ramming")), "" };
         line.widget = [this](wxWindow* parent) {


### PR DESCRIPTION
This PR enables the wipe tower to be used by all multi-extruder configurations as discussed in #1944. For Single Nozzle Multi Material configurations, the behavior is the same as it was prior to this change. For non-SNMM configurations, the purging and ramming processes are bypassed, but the Tool Change GCode can still be used to perform custom actions.