### PR TITLE
Add support to upload to Flashair WLAN SD card

### DIFF
--- a/resources/localization/list.txt
+++ b/resources/localization/list.txt
@@ -39,6 +39,7 @@ src/slic3r/GUI/WipeTowerDialog.cpp
 src/slic3r/GUI/wxExtensions.cpp
 src/slic3r/Utils/Duet.cpp
 src/slic3r/Utils/OctoPrint.cpp
+src/slic3r/Utils/FlashAir.cpp
 src/slic3r/Utils/PresetUpdater.cpp
 src/slic3r/Utils/FixModelByWin10.cpp
 src/libslic3r/Zipper.cpp

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1269,8 +1269,10 @@ void PrintConfigDef::init_fff_params()
     def->enum_keys_map = &ConfigOptionEnum<PrintHostType>::get_enum_values();
     def->enum_values.push_back("octoprint");
     def->enum_values.push_back("duet");
+    def->enum_values.push_back("flashair");
     def->enum_labels.push_back("OctoPrint");
     def->enum_labels.push_back("Duet");
+    def->enum_labels.push_back("FlashAir");
     def->mode = comAdvanced;
     def->default_value = new ConfigOptionEnum<PrintHostType>(htOctoPrint);
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -30,7 +30,7 @@ enum GCodeFlavor {
 };
 
 enum PrintHostType {
-    htOctoPrint, htDuet
+    htOctoPrint, htDuet, htFlashAir
 };
 
 enum InfillPattern {
@@ -92,6 +92,7 @@ template<> inline const t_config_enum_values& ConfigOptionEnum<PrintHostType>::g
     if (keys_map.empty()) {
         keys_map["octoprint"]       = htOctoPrint;
         keys_map["duet"]            = htDuet;
+        keys_map["flashair"]        = htFlashAir;
     }
     return keys_map;
 }

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -138,6 +138,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/OctoPrint.hpp
     Utils/Duet.cpp
     Utils/Duet.hpp
+    Utils/FlashAir.cpp
+    Utils/FlashAir.hpp
     Utils/PrintHost.cpp
     Utils/PrintHost.hpp
     Utils/Bonjour.cpp

--- a/src/slic3r/Utils/FlashAir.cpp
+++ b/src/slic3r/Utils/FlashAir.cpp
@@ -5,8 +5,6 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 
 #include <wx/frame.h>
 #include <wx/event.h>
@@ -73,7 +71,7 @@ wxString FlashAir::get_test_ok_msg () const
 
 wxString FlashAir::get_test_failed_msg (wxString &msg) const
 {
-	return wxString::Format("%s: %s", _(L("Could not connect to FlashAir")), msg, _(L("Note: FlashAir with firmware 2.00.02 or newer and activated upload function is required."));
+	return wxString::Format("%s: %s", _(L("Could not connect to FlashAir")), msg, _(L("Note: FlashAir with firmware 2.00.02 or newer and activated upload function is required.")));
 }
 
 bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const

--- a/src/slic3r/Utils/FlashAir.cpp
+++ b/src/slic3r/Utils/FlashAir.cpp
@@ -1,0 +1,220 @@
+#include "FlashAir.hpp"
+
+#include <algorithm>
+#include <ctime>
+#include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include <wx/frame.h>
+#include <wx/event.h>
+#include <wx/progdlg.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/checkbox.h>
+
+#include "libslic3r/PrintConfig.hpp"
+#include "slic3r/GUI/GUI.hpp"
+#include "slic3r/GUI/I18N.hpp"
+#include "slic3r/GUI/MsgDialog.hpp"
+#include "Http.hpp"
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace Slic3r {
+
+FlashAir::FlashAir(DynamicPrintConfig *config) :
+	host(config->opt_string("print_host"))
+{}
+
+FlashAir::~FlashAir() {}
+
+const char* FlashAir::get_name() const { return "FlashAir"; }
+
+bool FlashAir::test(wxString &msg) const
+{
+	// Since the request is performed synchronously here,
+	// it is ok to refer to `msg` from within the closure
+
+	const char *name = get_name();
+
+	bool res = false;
+	auto url = make_url("command.cgi", "op", "118");
+
+	BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Get upload enabled at: %2%") % name % url;
+
+	auto http = Http::get(std::move(url));
+	http.on_error([&](std::string body, std::string error, unsigned status) {
+			BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error getting upload enabled: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
+			res = false;
+			msg = format_error(body, error, status);
+		})
+		.on_complete([&, this](std::string body, unsigned) {
+			BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got upload enabled: %2%") % name % body;
+
+			res = boost::starts_with(body, "1");
+			if (! res) {
+				msg = _(L("Upload not enabled on FlashAir card."));
+			}
+		})
+		.perform_sync();
+
+	return res;
+}
+
+wxString FlashAir::get_test_ok_msg () const
+{
+	return _(L("Connection to FlashAir works correctly and upload is enabled."));
+}
+
+wxString FlashAir::get_test_failed_msg (wxString &msg) const
+{
+	return wxString::Format("%s: %s", _(L("Could not connect to FlashAir")), msg, _(L("Note: FlashAir with firmware 2.00.02 or newer and activated upload function is required."));
+}
+
+bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const
+{
+	const char *name = get_name();
+
+	const auto upload_filename = upload_data.upload_path.filename();
+	const auto upload_parent_path = upload_data.upload_path.parent_path();
+
+	wxString test_msg;
+	if (! test(test_msg)) {
+		error_fn(std::move(test_msg));
+		return false;
+	}
+
+	bool res = false;
+
+	auto urlPrepare = make_url("upload.cgi", "WRITEPROTECT=ON&FTIME", timestamp_str());
+	auto urlUpload = make_url("upload.cgi");
+
+	BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Uploading file %2% at %3% / %4%, filename: %5%")
+		% name
+		% upload_data.source_path
+		% urlPrepare
+		% urlUpload
+		% upload_filename.string();
+
+	// set filetime for upload and make card writeprotect to prevent filesystem damage
+	auto httpPrepare = Http::get(std::move(urlPrepare));
+	httpPrepare.on_error([&](std::string body, std::string error, unsigned status) {
+			BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error prepareing upload: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
+			error_fn(format_error(body, error, status));
+			res = false;
+		})
+		.on_complete([&, this](std::string body, unsigned) {
+			BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got prepare result: %2%") % name % body;
+			res = boost::icontains(body, "SUCCESS");
+			if (! res) {
+				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
+				error_fn(format_error(body, L("Unknown error occured"), 0));
+			}
+		})
+		.perform_sync();
+	
+	if(! res ) {
+		return res;
+	}
+	
+	// start file upload
+	auto http = Http::post(std::move(urlUpload));
+	http.form_add_file("file", upload_data.source_path.string(), upload_filename.string())
+		.on_complete([&](std::string body, unsigned status) {
+			BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: File uploaded: HTTP %2%: %3%") % name % status % body;
+			res = boost::icontains(body, "SUCCESS");
+			if (! res) {
+				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
+				error_fn(format_error(body, L("Unknown error occured"), 0));
+			}
+		})
+		.on_error([&](std::string body, std::string error, unsigned status) {
+			BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error uploading file: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
+			error_fn(format_error(body, error, status));
+			res = false;
+		})
+		.on_progress([&](Http::Progress progress, bool &cancel) {
+			prorgess_fn(std::move(progress), cancel);
+			if (cancel) {
+				// Upload was canceled
+				BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Upload canceled") % name;
+				res = false;
+			}
+		})
+		.perform_sync();
+
+	return res;
+}
+
+bool FlashAir::has_auto_discovery() const
+{
+	return false;
+}
+
+bool FlashAir::can_test() const
+{
+	return true;
+}
+
+bool FlashAir::can_start_print() const
+{
+	return false;
+}
+
+std::string FlashAir::timestamp_str() const
+{
+	auto t = std::time(nullptr);
+	auto tm = *std::localtime(&t);
+
+	const char *name = get_name();
+
+	unsigned long fattime = ((tm.tm_year - 80) << 25) | 
+							((tm.tm_mon + 1) << 21) |
+							(tm.tm_mday << 16) |
+							(tm.tm_hour << 11) |
+							(tm.tm_min << 5) |
+							(tm.tm_sec >> 1);
+
+	return (boost::format("%1$#x") % fattime).str();
+}
+
+std::string FlashAir::make_url(const std::string &path) const
+{
+	if (host.find("http://") == 0 || host.find("https://") == 0) {
+		if (host.back() == '/') {
+			return (boost::format("%1%%2%") % host % path).str();
+		} else {
+			return (boost::format("%1%/%2%") % host % path).str();
+		}
+	} else {
+		if (host.back() == '/') {
+			return (boost::format("http://%1%%2%") % host % path).str();
+		} else {
+			return (boost::format("http://%1%/%2%") % host % path).str();
+		}
+	}
+}
+
+std::string FlashAir::make_url(const std::string &path, const std::string &arg, const std::string &val) const
+{
+	if (host.find("http://") == 0 || host.find("https://") == 0) {
+		if (host.back() == '/') {
+			return (boost::format("%1%%2%?%3%=%4%") % host % path % arg % val).str();
+		} else {
+			return (boost::format("%1%/%2%?%3%=%4%") % host % path % arg % val).str();
+		}
+	} else {
+		if (host.back() == '/') {
+			return (boost::format("http://%1%%2%?%3%=%4%") % host % path % arg % val).str();
+		} else {
+			return (boost::format("http://%1%/%2%?%3%=%4%") % host % path % arg % val).str();
+		}
+	}
+}
+
+}

--- a/src/slic3r/Utils/FlashAir.hpp
+++ b/src/slic3r/Utils/FlashAir.hpp
@@ -1,0 +1,44 @@
+#ifndef slic3r_FlashAir_hpp_
+#define slic3r_FlashAir_hpp_
+
+#include <string>
+#include <wx/string.h>
+
+#include "PrintHost.hpp"
+
+
+namespace Slic3r {
+
+
+class DynamicPrintConfig;
+class Http;
+
+class FlashAir : public PrintHost
+{
+public:
+	FlashAir(DynamicPrintConfig *config);
+	virtual ~FlashAir();
+
+	virtual const char* get_name() const;
+
+	virtual bool test(wxString &curl_msg) const;
+	virtual wxString get_test_ok_msg () const;
+	virtual wxString get_test_failed_msg (wxString &msg) const;
+	virtual bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const;
+	virtual bool has_auto_discovery() const;
+	virtual bool can_test() const;
+	virtual bool can_start_print() const;
+	virtual std::string get_host() const { return host; }
+
+private:
+	std::string host;
+
+	std::string timestamp_str() const;
+	std::string make_url(const std::string &path) const;
+	std::string make_url(const std::string &path, const std::string &arg, const std::string &val) const;
+};
+
+
+}
+
+#endif

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -14,6 +14,7 @@
 #include "libslic3r/Channel.hpp"
 #include "OctoPrint.hpp"
 #include "Duet.hpp"
+#include "FlashAir.hpp"
 #include "../GUI/PrintHostDialogs.hpp"
 
 namespace fs = boost::filesystem;
@@ -43,6 +44,7 @@ PrintHost* PrintHost::get_print_host(DynamicPrintConfig *config)
         switch (host_type) {
             case htOctoPrint: return new OctoPrint(config);
             case htDuet:      return new Duet(config);
+            case htFlashAir:  return new FlashAir(config);
             default:          return nullptr;
         }
     } else {


### PR DESCRIPTION
This pull requests adds support to upload gcode to FlashAir WLAN sdcards like it is possible with octoprint.

The upload process implements the toshiba suggested procedure [1] by first setting the card to read-only for the host before the actual upload takes place.
The correct time stamp for the file is also transferred when the read-only is set.

The change mainly consists of the newly added flashair.cpp/hpp files following the OctoPrint.cpp/hpp or Duet.cpp/hpp files.

If I missed some guidelines regarding contriubtion, code style or translation, please give me a hint so that I can fix that. 

[1] https://www.flashair-developers.com/en/documents/tutorials/advanced/2/