### PR TITLE
Make 'nearest' seam position truly near

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2640,6 +2640,7 @@ std::string GCode::extrude_loop(ExtrusionLoop loop, std::string description, dou
 
         std::vector<float> distances(polygon.points.size(), 0.f);
         if (seam_position == spNearest) {
+            Point last_pos_proj = polygon.points[last_pos_proj_idx];
             for (size_t i = 0; i < polygon.points.size(); ++ i)
                 distances[i] = last_pos_proj.distance_to_squared(polygon.points[i]);
             dist_max = *std::max_element(distances.begin(), distances.end());

--- a/src/libslic3r/Point.cpp
+++ b/src/libslic3r/Point.cpp
@@ -66,6 +66,11 @@ void Point::rotate(double angle, const Point &center)
     (*this)(1) = (coord_t)round( (double)center(1) + c * dy + s * dx );
 }
 
+double Point::distance_to_squared(const Point &point) const
+{
+    return sqr<double>((*this)(0) - point.x()) + sqr<double>((*this)(1) - point.y());
+}
+
 int Point::nearest_point_index(const Points &points) const
 {
     PointConstPtrs p;

--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -117,6 +117,7 @@ public:
     void   rotate(double angle, const Point &center);
     Point  rotated(double angle) const { Point res(*this); res.rotate(angle); return res; }
     Point  rotated(double angle, const Point &center) const { Point res(*this); res.rotate(angle, center); return res; }
+    double distance_to_squared(const Point &point) const;
     int    nearest_point_index(const Points &points) const;
     int    nearest_point_index(const PointConstPtrs &points) const;
     int    nearest_point_index(const PointPtrs &points) const;


### PR DESCRIPTION
This implements suggestions by @supermerill in issue #1409 to make the ‘nearest’ seam position behave much more as one would expect from it, and how I remember it from older versions. The current implementation, which I believe to have been introduced with the transition from Perl to C++, is way too similar to 'aligned'. Not only does it often blatantly ignore the ‘nearest’ idea by stubbornly jumping back to the same seam point as in the previous layer, sometimes it also does things that make no sense at all, like jumping to a faraway different point when moving from the inner to the outer contour.

I have tested this on several models. In most cases the total travel distance and print time is reduced. In one particular case, total travel distance is reduced by as much as 40%. Most importantly though, the seam positions it selects now look much more sensible to me for a setting called “nearest.”
G-code and total travel distance counts for some examples are attached: [NearestSeamTests.zip](https://github.com/prusa3d/Slic3r/files/3169497/NearestSeamTests.zip). Stepping through these with a viewer like http://gcode.ws/ is a good way to see how the modified seam algorithm behaves w.r.t. the old one.

@supermerill has suggested adding a variant that only differs by a weaker `last_pos_weight` factor of 1.0 instead of 5.0. This is worth considering, but is not included in this pull request. Such seam position option could be called “best” or “preferred” because it would make less of a trade-off between quality and reduced distance.

Preview of [this project](https://github.com/prusa3d/Slic3r/files/3158594/NotNearest.3mf.zip) sliced with ‘nearest’ seam in 1.42.0-beta2:
![example-master](https://user-images.githubusercontent.com/16401844/57575364-53455c80-7449-11e9-80f8-28f4600f94a9.jpg)

The exact same project sliced in my build:
![example-new](https://user-images.githubusercontent.com/16401844/57575367-5c362e00-7449-11e9-93a2-df9b0b918838.jpg)
