### PR TITLE
Delay refresh until initialized

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -2292,6 +2292,9 @@ void GLCanvas3D::on_size(wxSizeEvent& evt)
 
 void GLCanvas3D::on_idle(wxIdleEvent& evt)
 {
+    if (!m_initialized)
+        return;
+
     m_dirty |= m_toolbar.update_items_state();
     m_dirty |= m_view_toolbar.update_items_state();
 


### PR DESCRIPTION
on_idle can be called too early on wxGtk3/X11.
Check for m_initialized before refreshing.

Ping @vojtechkral: this avoids calling glOrtho with bogus width/height as mentione here https://github.com/prusa3d/PrusaSlicer/issues/1963#issuecomment-493524364