### PR TITLE
Fix two errors with -Werror=format-security

### DIFF
--- a/xs/xsp/Print.xsp
+++ b/xs/xsp/Print.xsp
@@ -165,7 +165,7 @@ _constant()
             try {
                 THIS->process();
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};
 
@@ -173,7 +173,7 @@ _constant()
             try {
                 THIS->export_gcode(path_template, nullptr);
             } catch (std::exception& e) {
-                croak(e.what());
+                croak("%s\n", e.what());
             }
         %};
 


### PR DESCRIPTION
Fedora (and, I supposed, most recent Linux distros) build everything
with -Werror=format-security.  If you attempt to build with
-DSLIC3R_PERL_XS (which we need in order to run the test suite), the
build fails because of two strings in the Perl XS code:

/usr/bin/perl -MExtUtils::XSpp::Cmd -e xspp -- -t "/builddir/build/BUILD/PrusaSlicer-version_2.0.0-rc2/xs/xsp/typemap.xspt" "/builddir/build/BUILD/PrusaSlicer-version_2.0.0-rc2/xs/xsp/Print.xsp":585:31: error: format not a string literal and no format arguments [-Werror=format-security]

Ths fixes up two instances of that.