### PR TITLE
Fix italian translation

### DIFF
--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -6902,7 +6902,7 @@ msgstr "supporti e pad"
 
 #: src/libslic3r/PrintConfig.cpp:1043
 msgid "Supports remaining times"
-msgstr "Tempo rimanente Supporti"
+msgstr "Supporto tempo residuo"
 
 #: src/libslic3r/PrintConfig.cpp:1052
 msgid "Supports silent mode"


### PR DESCRIPTION
"Tempo rimanente Supporti" has a totally different meaning than the original "Supports remaining times" and it's wrong.

--

"Tempo rimanente Supporti" in italiano fa riferimento al tempo rimanente *dei supporti* che non ha niente a che vedere con l'M73. La traduzione corretta è qualcosa tipo "Supporto tempo residuo", per indicare che il firmware supporta la funzionalità del tempo residuo (o una cosa simile) dato che tale opzione fa uso di M73 ovvero comunicare al firmware della stampa (con progress bar, ETA ecc, ecc)