### PR TITLE
Centering model on bed, using bed shape from config (if available).

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -378,7 +378,15 @@ int CLI::run(int argc, char **argv)
                 if (! m_config.opt_bool("dont_arrange")) {
                     //FIXME make the min_object_distance configurable.
                     model.arrange_objects(fff_print.config().min_object_distance());
-					model.center_instances_around_point(m_config.option<ConfigOptionPoint>("center")->value);
+                    if (m_print_config.has("bed_shape")) {
+                        const auto bed_shape = Slic3r::Polygon::new_scale(
+                                m_print_config.opt<ConfigOptionPoints>("bed_shape")->values);
+                        auto centroid = bed_shape.centroid().cast<double>();
+                        auto unscaleCentroid = Point(unscale<double>(centroid.x()), unscale<double>(centroid.y()));
+                        model.center_instances_around_point(unscaleCentroid.cast<double>());
+                    } else {
+                        model.center_instances_around_point(m_config.option<ConfigOptionPoint>("center")->value);
+                    }
                 }
                 if (printer_technology == ptFFF) {
                     for (auto* mo : model.objects)


### PR DESCRIPTION
Good evening everyone,

Thanks for all of the great work with PrusaSlic3r! We're using the slic3r in command line/ non-gui mode, and we need to automatically center the model for arbitrary bed sizes. We noticed that the default bed centering is at `(100,100)`, and thought this could be generalized (and this is actually not the center of the bed for prusa printers).

The code does this: if the `dont-arrange` option is *not* specified, and there is a `bed_shape` in the config, it centers the model around the centroid of the bed shape polygon. If no `bed_shape` is specified, it reverts to the old behavior.

Thanks in advance!

Best,
Luke