### PR TITLE
Add debug preprocessor directive in Technologies.hpp to render picking pass to window. 

### DIFF
--- a/src/libslic3r/Technologies.hpp
+++ b/src/libslic3r/Technologies.hpp
@@ -15,6 +15,8 @@
 #define ENABLE_RENDER_STATISTICS 0
 // Shows an imgui dialog with camera related data
 #define ENABLE_CAMERA_STATISTICS 0
+//  Render the picking pass instead of the main scene 
+#define ENABLE_RENDER_PICKING_PASS 0
 
 
 //====================

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1625,6 +1625,7 @@ void GLCanvas3D::render()
             _picking_pass();
     }
 
+#if !ENABLE_RENDER_PICKING_PASS
     // draw scene
     glsafe(::glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
     _render_background();
@@ -1654,6 +1655,7 @@ void GLCanvas3D::render()
 
     _render_current_gizmo();
     _render_selection_sidebar_hints();
+#endif // !ENABLE_RENDER_PICKING_PASS
 
 #if ENABLE_SHOW_CAMERA_TARGET
     _render_camera_target();

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -259,6 +259,10 @@ void GLGizmoSlaSupports::render_clipping_plane(const Selection& selection) const
 
 void GLGizmoSlaSupports::on_render_for_picking(const Selection& selection) const
 {
+#if ENABLE_RENDER_PICKING_PASS
+	m_z_shift = selection.get_volume(*selection.get_volume_idxs().begin())->get_sla_shift_z();
+#endif
+
     glsafe(::glEnable(GL_DEPTH_TEST));
     render_points(selection, true);
 }


### PR DESCRIPTION
This adds a debug preprocessor directive which you can use to force PrusaSlicer to render the OpenGL picking pass rather than the normal display. This was very helpful when troubleshooting a bug.

Here is an example of what this looks like:

![image](https://user-images.githubusercontent.com/5125421/59557840-3a2c5000-8fa1-11e9-806b-e871cfc5bc27.png)