### PR TITLE
Use system Eigen3 on linux when found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,10 +306,10 @@ endif()
 
 # Find eigen3 or use bundled version
 if (NOT SLIC3R_STATIC)
-    find_package(Eigen3 3)
+    find_package(Eigen3 3.3)
 endif ()
-if (NOT Eigen3_FOUND)
-    set(Eigen3_FOUND 1)
+if (NOT EIGEN3_FOUND)
+    set(EIGEN3_FOUND 1)
     set(EIGEN3_INCLUDE_DIR ${LIBDIR}/eigen/)
 endif ()
 include_directories(BEFORE SYSTEM ${EIGEN3_INCLUDE_DIR})


### PR DESCRIPTION
find_package(Eigen3) sets EIGEN3_FOUND (all uppercase).
See https://github.com/prusa3d/PrusaSlicer/blob/44f0e387dcb42b279fb561238aa49fac00dc5bd3/cmake/modules/FindEigen3.cmake#L60

Also bump the minimum required version to 3.3, which is what is bundled.

There are two more instances of "Eigen3_FOUND" in https://github.com/prusa3d/PrusaSlicer/blob/44f0e387dcb42b279fb561238aa49fac00dc5bd3/deps/igl-fixes.patch#L34 (and following lines)

Since igl is bundled, the patch step is never executed on my system. I leave this up to you.