### PR TITLE
Fix format-security-related build failure

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -354,7 +354,7 @@ bool ImGuiWrapper::undo_redo_list(const ImVec2& size, const bool is_undo, bool (
         ImGui::Selectable(item_text, i < hovered);
 
         if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(item_text);
+            ImGui::SetTooltip("%s", item_text);
             hovered = i;
             is_hovered = true;
         }


### PR DESCRIPTION
Calling a printf-like function without a format string will cause gcc to
emit a warhing and causes a build failure on distros which build
everything with -Werror=format-security.

Signed-off-by: Jason Tibbitts <j@tib.bs>