### PR TITLE
Mmu extruder temperature changes

### DIFF
--- a/doc/How to build - Windows.md
+++ b/doc/How to build - Windows.md
@@ -14,6 +14,9 @@ Thank you for understanding.
 
 # Building PrusaSlicer on Microsoft Windows
 
+You can use the free [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/) or use
+CMake from the command line.  
+
 ~~The currently supported way of building PrusaSlicer on Windows is with CMake and MS Visual Studio 2013.
 You can use the free [Visual Studio 2013 Community Edition](https://www.visualstudio.com/vs/older-downloads/).
 CMake installer can be downloaded from [the official website](https://cmake.org/download/).~~
@@ -24,9 +27,18 @@ _Note:_ Thanks to [**@supermerill**](https://github.com/supermerill) for testing
 
 ### Dependencies
 
-On Windows PrusaSlicer is built against statically built libraries.
-~~We provide a prebuilt package of all the needed dependencies. This package only works on Visual Studio 2013, so~~ if you are using a newer version of Visual Studio, you need to compile the dependencies yourself as per [below](#building-the-dependencies-package-yourself).
-The package comes in a several variants:
+On Windows PrusaSlicer is built against statically built libraries. 
+At this time you need to create these with the instructions [below](#building-the-dependencies-package-yourself).. 
+
+When the dependiencis are built their destination is specified to CMake using -DDESTDIR="\<your path\>". It can be anywhere.  
+
+By default VS 2019 will create a 64 bit Debug variant.
+ 
+~~We provide a prebuilt package of all the needed dependencies. This package only works on 
+Visual Studio 2013, so if you are using a newer version of Visual Studio, 
+you need to compile the dependencies yourself as per 
+[below](#building-the-dependencies-package-yourself).
+The package comes in a several variants:~~
 
   - ~~64 bit, Release mode only (41 MB, 578 MB unpacked)~~
   - ~~64 bit, Release and Debug mode (88 MB, 1.3 GB unpacked)~~
@@ -35,32 +47,54 @@ The package comes in a several variants:
 
 When unsure, use the _Release mode only_ variant, the _Release and Debug_ variant is only needed for debugging & development.
 
-If you're unsure where to unpack the package, unpack it into `C:\local\` (but it can really be anywhere).
+~~If you're unsure where to unpack the package, unpack it into `C:\local\` (but it can really be anywhere).~~
 
-Alternatively you can also compile the dependencies yourself, see below.
+~~Alternatively you can also compile the dependencies yourself, see below.~~
 
 ### Building PrusaSlicer with Visual Studio
 
 First obtain the PrusaSlicer sources via either git or by extracting the source archive.
 
-Then you will need to note down the so-called 'prefix path' to the dependencies, this is the location of the dependencies packages + `\usr\local` appended.
-For example on 64 bits this would be `C:\local\destdir-64\usr\local`. The prefix path will need to be passed to CMake.
+The 'prefix path' to the dependencies is "\<your path\>" with "\usr\local" appended.  For example, if \<your path\> is "c:\local\lib64" the
+CMAKE_PREFIX_PATH is "c:\local\lib64\usr\local" 
 
+#### Command Line Build
 When ready, open the relevant Visual Studio command line and `cd` into the directory with PrusaSlicer sources.
 Use these commands to prepare Visual Studio solution file:
 
     mkdir build
     cd build
-    cmake .. -G "Visual Studio 12 Win64" -DCMAKE_PREFIX_PATH="<insert prefix path here>"
+    cmake ..\.. -G "Visual Studio 16" -A x64 -DCMAKE_PREFIX_PATH="<insert prefix path here>"
+    msbuild /m /P:Configuration=Debug ALL_BUILD.vcxproj
 
-Note that if you're building a 32-bit variant, you will need to change the `"Visual Studio 12 Win64"` to just `"Visual Studio 12"`.
+Note that if you're building a 32-bit variant, you will need to change the `"Visual Studio 16" -A x64` to `"Visual Studio 16" -A Win32`.
 
-Conversely, if you're using Visual Studio version other than 2013, the version number will need to be changed accordingly.
+If `cmake` finishes without errors run the msbuild command using ALL_BUILD.vcxproj.
 
-If `cmake` has finished without errors, go to the build directory and open the `PrusaSlicer.sln` solution file in Visual Studio.
+#### Visual Studio Setup
+Open PrusaSlicer.sln  in /PrusaSlicer/src/build folder.
+
+By default Visual Studio 2019 uses Ninja. You need to change this to "Visual Studio 16 Win64" (or what you want to build) and specify the CMAKE_PREFIX_PATH used for the dependancies.  
+Access the configuration by clicking the down arrow next to "x64-Debug" (or whatever you built) and selecting "Manage Configurations..." to expose the CMake Settings.
+
+ - In 'CMake Command Arguments' enter:
+
+    - -DCMAKE_PREFIX_PATH="c:\local\lib64\usr\local".  
+ - Click on "Show Advanced settings" if they are not visable and 
+ 
+    - select "Visual Studio 16 2019 Win64" for the CMake Generator.
+
+Save the changes by clicking the 'Save' icon or File->Save All.
+
+
+When you save it will trigger CMake to run and you shouldn't see errors. Once CMake has completed you should be ready to make changes and debug.  NOTE: There is an error I have to ignore.
+
+Navigate to the 'src/build' build directory (you will have to 'Show all files') and open the `PrusaSlicer.sln` solution file in Visual Studio.
 Before building, make sure you're building the right project (use one of those starting with `PrusaSlicer_app_...`) and that you're building
 with the right configuration, i.e. _Release_ vs. _Debug_. When unsure, choose _Release_.
 Note that you won't be able to build a _Debug_ variant against a _Release_-only dependencies package.
+
+
 
 #### Installing using the `INSTALL` project
 
@@ -96,7 +130,7 @@ Then `cd` into the `deps` directory and use these commands to build:
 
     mkdir build
     cd build
-    cmake .. -G "Visual Studio 12 Win64" -DDESTDIR="C:\local\destdir-custom"
+    cmake .. -G "Visual Studio 16" -A x64 -DDESTDIR="C:\local\lib64"
     msbuild /m ALL_BUILD.vcxproj
 
 You can also use the Visual Studio GUI or other generators as mentioned above.

--- a/doc/How to build - Windows.md
+++ b/doc/How to build - Windows.md
@@ -14,9 +14,6 @@ Thank you for understanding.
 
 # Building PrusaSlicer on Microsoft Windows
 
-You can use the free [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/) or use
-CMake from the command line.  
-
 ~~The currently supported way of building PrusaSlicer on Windows is with CMake and MS Visual Studio 2013.
 You can use the free [Visual Studio 2013 Community Edition](https://www.visualstudio.com/vs/older-downloads/).
 CMake installer can be downloaded from [the official website](https://cmake.org/download/).~~
@@ -27,18 +24,9 @@ _Note:_ Thanks to [**@supermerill**](https://github.com/supermerill) for testing
 
 ### Dependencies
 
-On Windows PrusaSlicer is built against statically built libraries. 
-At this time you need to create these with the instructions [below](#building-the-dependencies-package-yourself).. 
-
-When the dependiencis are built their destination is specified to CMake using -DDESTDIR="\<your path\>". It can be anywhere.  
-
-By default VS 2019 will create a 64 bit Debug variant.
- 
-~~We provide a prebuilt package of all the needed dependencies. This package only works on 
-Visual Studio 2013, so if you are using a newer version of Visual Studio, 
-you need to compile the dependencies yourself as per 
-[below](#building-the-dependencies-package-yourself).
-The package comes in a several variants:~~
+On Windows PrusaSlicer is built against statically built libraries.
+~~We provide a prebuilt package of all the needed dependencies. This package only works on Visual Studio 2013, so~~ if you are using a newer version of Visual Studio, you need to compile the dependencies yourself as per [below](#building-the-dependencies-package-yourself).
+The package comes in a several variants:
 
   - ~~64 bit, Release mode only (41 MB, 578 MB unpacked)~~
   - ~~64 bit, Release and Debug mode (88 MB, 1.3 GB unpacked)~~
@@ -47,54 +35,32 @@ The package comes in a several variants:~~
 
 When unsure, use the _Release mode only_ variant, the _Release and Debug_ variant is only needed for debugging & development.
 
-~~If you're unsure where to unpack the package, unpack it into `C:\local\` (but it can really be anywhere).~~
+If you're unsure where to unpack the package, unpack it into `C:\local\` (but it can really be anywhere).
 
-~~Alternatively you can also compile the dependencies yourself, see below.~~
+Alternatively you can also compile the dependencies yourself, see below.
 
 ### Building PrusaSlicer with Visual Studio
 
 First obtain the PrusaSlicer sources via either git or by extracting the source archive.
 
-The 'prefix path' to the dependencies is "\<your path\>" with "\usr\local" appended.  For example, if \<your path\> is "c:\local\lib64" the
-CMAKE_PREFIX_PATH is "c:\local\lib64\usr\local" 
+Then you will need to note down the so-called 'prefix path' to the dependencies, this is the location of the dependencies packages + `\usr\local` appended.
+For example on 64 bits this would be `C:\local\destdir-64\usr\local`. The prefix path will need to be passed to CMake.
 
-#### Command Line Build
 When ready, open the relevant Visual Studio command line and `cd` into the directory with PrusaSlicer sources.
 Use these commands to prepare Visual Studio solution file:
 
     mkdir build
     cd build
-    cmake ..\.. -G "Visual Studio 16" -A x64 -DCMAKE_PREFIX_PATH="<insert prefix path here>"
-    msbuild /m /P:Configuration=Debug ALL_BUILD.vcxproj
+    cmake .. -G "Visual Studio 12 Win64" -DCMAKE_PREFIX_PATH="<insert prefix path here>"
 
-Note that if you're building a 32-bit variant, you will need to change the `"Visual Studio 16" -A x64` to `"Visual Studio 16" -A Win32`.
+Note that if you're building a 32-bit variant, you will need to change the `"Visual Studio 12 Win64"` to just `"Visual Studio 12"`.
 
-If `cmake` finishes without errors run the msbuild command using ALL_BUILD.vcxproj.
+Conversely, if you're using Visual Studio version other than 2013, the version number will need to be changed accordingly.
 
-#### Visual Studio Setup
-Open PrusaSlicer.sln  in /PrusaSlicer/src/build folder.
-
-By default Visual Studio 2019 uses Ninja. You need to change this to "Visual Studio 16 Win64" (or what you want to build) and specify the CMAKE_PREFIX_PATH used for the dependancies.  
-Access the configuration by clicking the down arrow next to "x64-Debug" (or whatever you built) and selecting "Manage Configurations..." to expose the CMake Settings.
-
- - In 'CMake Command Arguments' enter:
-
-    - -DCMAKE_PREFIX_PATH="c:\local\lib64\usr\local".  
- - Click on "Show Advanced settings" if they are not visable and 
- 
-    - select "Visual Studio 16 2019 Win64" for the CMake Generator.
-
-Save the changes by clicking the 'Save' icon or File->Save All.
-
-
-When you save it will trigger CMake to run and you shouldn't see errors. Once CMake has completed you should be ready to make changes and debug.  NOTE: There is an error I have to ignore.
-
-Navigate to the 'src/build' build directory (you will have to 'Show all files') and open the `PrusaSlicer.sln` solution file in Visual Studio.
+If `cmake` has finished without errors, go to the build directory and open the `PrusaSlicer.sln` solution file in Visual Studio.
 Before building, make sure you're building the right project (use one of those starting with `PrusaSlicer_app_...`) and that you're building
 with the right configuration, i.e. _Release_ vs. _Debug_. When unsure, choose _Release_.
 Note that you won't be able to build a _Debug_ variant against a _Release_-only dependencies package.
-
-
 
 #### Installing using the `INSTALL` project
 
@@ -130,7 +96,7 @@ Then `cd` into the `deps` directory and use these commands to build:
 
     mkdir build
     cd build
-    cmake .. -G "Visual Studio 16" -A x64 -DDESTDIR="C:\local\lib64"
+    cmake .. -G "Visual Studio 12 Win64" -DDESTDIR="C:\local\destdir-custom"
     msbuild /m ALL_BUILD.vcxproj
 
 You can also use the Visual Studio GUI or other generators as mentioned above.

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -608,7 +608,13 @@ std::vector<WipeTower::ToolChangeResult> WipeTower::prime(
         m_left_to_right = true;
         toolchange_Change(writer, tool, m_filpar[tool].material); // Select the tool, set a speed override for soluble and flex materials.
         toolchange_Load(writer, cleaning_box); // Prime the tool.
-        if (idx_tool + 1 == tools.size()) {
+		// Moving to a lower temperature doesn't happen until it is time to purge
+		if (m_filpar[m_current_tool].first_layer_temperature != m_old_temperature ) {  
+			writer.set_extruder_temp(m_filpar[m_current_tool].first_layer_temperature);
+			m_old_temperature = m_filpar[m_current_tool].first_layer_temperature;
+		}
+
+		if (idx_tool + 1 == tools.size()) {
             // Last tool should not be unloaded, but it should be wiped enough to become of a pure color.
             toolchange_Wipe(writer, cleaning_box, wipe_volumes[tools[idx_tool-1]][tool]);
         } else {
@@ -672,6 +678,8 @@ WipeTower::ToolChangeResult WipeTower::tool_change(unsigned int tool, bool last_
 		return toolchange_Brim();
 
     int old_tool = m_current_tool;
+	int next_tool = tool != (unsigned int)(-1) ? tool : m_current_tool;
+	int next_temp = m_is_first_layer ? m_filpar[next_tool].first_layer_temperature : m_filpar[next_tool].temperature;
 
 	float wipe_area = 0.f;
 	bool last_change_in_layer = false;
@@ -723,16 +731,21 @@ WipeTower::ToolChangeResult WipeTower::tool_change(unsigned int tool, bool last_
 		writer.set_extruder_trimpot(750);
 
     // Ram the hot material out of the melt zone, retract the filament into the cooling tubes and let it cool.
-    if (tool != (unsigned int)-1){ 			// This is not the last change.
-        toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material,
-                          m_is_first_layer ? m_filpar[tool].first_layer_temperature : m_filpar[tool].temperature);
-        toolchange_Change(writer, tool, m_filpar[tool].material); // Change the tool, set a speed override for soluble and flex materials.
-        toolchange_Load(writer, cleaning_box);
-        writer.travel(writer.x(), writer.y()-m_perimeter_width); // cooling and loading were done a bit down the road
-        toolchange_Wipe(writer, cleaning_box, wipe_volume);     // Wipe the newly loaded filament until the end of the assigned wipe area.
-        ++ m_num_tool_changes;
-    } else
-        toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material, m_filpar[m_current_tool].temperature);
+	toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material, next_temp); 
+
+	if (tool != (unsigned int)-1) { 			// This is not the last change.
+		toolchange_Change(writer, tool, m_filpar[tool].material); // Change the tool, set a speed override for soluble and flex materials.
+		toolchange_Load(writer, cleaning_box);
+		writer.travel(writer.x(), writer.y() - m_perimeter_width); // cooling and loading were done a bit down the road
+		// Moving to a lower temperature doesn't happen until it is time to purge so make sure it is applied if necessary
+		if (m_old_temperature != next_temp) { 
+			writer.set_extruder_temp(next_temp);
+			m_old_temperature = next_temp;
+		}
+		toolchange_Wipe(writer, cleaning_box, wipe_volume);     // Wipe the newly loaded filament until the end of the assigned wipe area.
+		++m_num_tool_changes;
+	}
+
 
     m_depth_traversed += wipe_area;
 
@@ -947,12 +960,6 @@ void WipeTower::toolchange_Unload(
               .travel(old_x, writer.y()) // in case previous move was shortened to limit feedrate*/
               .resume_preview();
     }
-    if (new_temperature != 0 && (new_temperature != m_old_temperature || m_is_first_layer) ) { 	// Set the extruder temperature, but don't wait.
-        // If the required temperature is the same as last time, don't emit the M104 again (if user adjusted the value, it would be reset)
-        // However, always change temperatures on the first layer (this is to avoid issues with priming lines turned off).
-		writer.set_extruder_temp(new_temperature, false);
-        m_old_temperature = new_temperature;
-    }
 
     // Cooling:
     const int& number_of_moves = m_filpar[m_current_tool].cooling_moves;
@@ -982,6 +989,13 @@ void WipeTower::toolchange_Unload(
 	// this is to align ramming and future wiping extrusions, so the future y-steps can be uniform from the start:
     // the perimeter_width will later be subtracted, it is there to not load while moving over just extruded material
 	writer.travel(end_of_ramming.x(), end_of_ramming.y() + (y_step/m_extra_spacing-m_perimeter_width) / 2.f + m_perimeter_width, 2400.f);
+
+	if (new_temperature != 0 && (new_temperature > m_old_temperature || m_is_first_layer)) { 	// Set the extruder temperature, but don't wait.
+	// If the required temperature is the same as (OR LOWER than) last time don't emit the M104 again (if user adjusted the value, it would be reset)
+	// However, always change temperatures on the first layer (this is to avoid issues with priming lines turned off).
+		writer.set_extruder_temp(new_temperature, false);
+		m_old_temperature = new_temperature;
+	}
 
 	writer.resume_preview()
 		  .flush_planner_queue();

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -608,13 +608,7 @@ std::vector<WipeTower::ToolChangeResult> WipeTower::prime(
         m_left_to_right = true;
         toolchange_Change(writer, tool, m_filpar[tool].material); // Select the tool, set a speed override for soluble and flex materials.
         toolchange_Load(writer, cleaning_box); // Prime the tool.
-		// Moving to a lower temperature doesn't happen until it is time to purge
-		if (m_filpar[m_current_tool].first_layer_temperature != m_old_temperature ) {  
-			writer.set_extruder_temp(m_filpar[m_current_tool].first_layer_temperature);
-			m_old_temperature = m_filpar[m_current_tool].first_layer_temperature;
-		}
-
-		if (idx_tool + 1 == tools.size()) {
+        if (idx_tool + 1 == tools.size()) {
             // Last tool should not be unloaded, but it should be wiped enough to become of a pure color.
             toolchange_Wipe(writer, cleaning_box, wipe_volumes[tools[idx_tool-1]][tool]);
         } else {
@@ -678,8 +672,6 @@ WipeTower::ToolChangeResult WipeTower::tool_change(unsigned int tool, bool last_
 		return toolchange_Brim();
 
     int old_tool = m_current_tool;
-	int next_tool = tool != (unsigned int)(-1) ? tool : m_current_tool;
-	int next_temp = m_is_first_layer ? m_filpar[next_tool].first_layer_temperature : m_filpar[next_tool].temperature;
 
 	float wipe_area = 0.f;
 	bool last_change_in_layer = false;
@@ -731,21 +723,16 @@ WipeTower::ToolChangeResult WipeTower::tool_change(unsigned int tool, bool last_
 		writer.set_extruder_trimpot(750);
 
     // Ram the hot material out of the melt zone, retract the filament into the cooling tubes and let it cool.
-	toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material, next_temp); 
-
-	if (tool != (unsigned int)-1) { 			// This is not the last change.
-		toolchange_Change(writer, tool, m_filpar[tool].material); // Change the tool, set a speed override for soluble and flex materials.
-		toolchange_Load(writer, cleaning_box);
-		writer.travel(writer.x(), writer.y() - m_perimeter_width); // cooling and loading were done a bit down the road
-		// Moving to a lower temperature doesn't happen until it is time to purge so make sure it is applied if necessary
-		if (m_old_temperature != next_temp) { 
-			writer.set_extruder_temp(next_temp);
-			m_old_temperature = next_temp;
-		}
-		toolchange_Wipe(writer, cleaning_box, wipe_volume);     // Wipe the newly loaded filament until the end of the assigned wipe area.
-		++m_num_tool_changes;
-	}
-
+    if (tool != (unsigned int)-1){ 			// This is not the last change.
+        toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material,
+                          m_is_first_layer ? m_filpar[tool].first_layer_temperature : m_filpar[tool].temperature);
+        toolchange_Change(writer, tool, m_filpar[tool].material); // Change the tool, set a speed override for soluble and flex materials.
+        toolchange_Load(writer, cleaning_box);
+        writer.travel(writer.x(), writer.y()-m_perimeter_width); // cooling and loading were done a bit down the road
+        toolchange_Wipe(writer, cleaning_box, wipe_volume);     // Wipe the newly loaded filament until the end of the assigned wipe area.
+        ++ m_num_tool_changes;
+    } else
+        toolchange_Unload(writer, cleaning_box, m_filpar[m_current_tool].material, m_filpar[m_current_tool].temperature);
 
     m_depth_traversed += wipe_area;
 
@@ -960,6 +947,12 @@ void WipeTower::toolchange_Unload(
               .travel(old_x, writer.y()) // in case previous move was shortened to limit feedrate*/
               .resume_preview();
     }
+    if (new_temperature != 0 && (new_temperature != m_old_temperature || m_is_first_layer) ) { 	// Set the extruder temperature, but don't wait.
+        // If the required temperature is the same as last time, don't emit the M104 again (if user adjusted the value, it would be reset)
+        // However, always change temperatures on the first layer (this is to avoid issues with priming lines turned off).
+		writer.set_extruder_temp(new_temperature, false);
+        m_old_temperature = new_temperature;
+    }
 
     // Cooling:
     const int& number_of_moves = m_filpar[m_current_tool].cooling_moves;
@@ -989,13 +982,6 @@ void WipeTower::toolchange_Unload(
 	// this is to align ramming and future wiping extrusions, so the future y-steps can be uniform from the start:
     // the perimeter_width will later be subtracted, it is there to not load while moving over just extruded material
 	writer.travel(end_of_ramming.x(), end_of_ramming.y() + (y_step/m_extra_spacing-m_perimeter_width) / 2.f + m_perimeter_width, 2400.f);
-
-	if (new_temperature != 0 && (new_temperature > m_old_temperature || m_is_first_layer)) { 	// Set the extruder temperature, but don't wait.
-	// If the required temperature is the same as (OR LOWER than) last time don't emit the M104 again (if user adjusted the value, it would be reset)
-	// However, always change temperatures on the first layer (this is to avoid issues with priming lines turned off).
-		writer.set_extruder_temp(new_temperature, false);
-		m_old_temperature = new_temperature;
-	}
 
 	writer.resume_preview()
 		  .flush_planner_queue();


### PR DESCRIPTION
The MMU currently changes the extruder temperature to the next filament's value when it is unloaded.  The problem with this (issues #2418, #1564, and #1339) is the temperature should not lower until the purge.

Here is my logic:
1) When the temperature of the next filament is greater it is fine to change during the unload, so I changed the unload to only change when the temperature is greater.  NOTE: I also moved the temperature change to a a little later in the unloading cycle to create a better 'user experience'. I expected the temperature to change when the filament starts unloading. 

2) When the temperature of the next filament is lower the temperature is **no longer changed during unloading** so it needs to be **lowered at the start of the purge**.  This means the extruder is up to temperature, at least at the start of the purge, and lowers during the purge since I don't wait.  I am going with the idea it will be close enough and is much better than trying to push the prior filament out at the lower temperature.


