### PR TITLE
Replaced the ^ and ~ characters

### DIFF
--- a/src/slic3r/Utils/ASCIIFolding.cpp
+++ b/src/slic3r/Utils/ASCIIFolding.cpp
@@ -1911,14 +1911,14 @@ static void fold_to_ascii(wchar_t c, OUTPUT_ITERATOR out)
 		    break;
 		case L'\u2038': // [CARET]
 		case L'\uFF3E': // [FULLWIDTH CIRCUMFLEX ACCENT]
-		    *out = '^';
+		    *out = '_';
 		    break;
 		case L'\uFF3F': // [FULLWIDTH LOW LINE]
 		    *out = '_';
 		    break;
 		case L'\u2053': // [SWUNG DASH]
 		case L'\uFF5E': // [FULLWIDTH TILDE]
-		    *out = '~';
+		    *out = '-';
 		    break;
 		default:
 		    *out = c;


### PR DESCRIPTION
Replaced both the ^ and the ~ since the printer has issues with these.
See bug report in issues #2800 