### PR TITLE
Add fan speed visualization in preview

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -116,15 +116,17 @@ public:
     unsigned int extruder_id;
     // Id of the color, used for visualization purposed in the color printing case.
     unsigned int cp_color_id;
+    // Fan speed for the extrusion, used for visualization purposes.
+    float fan_speed;
 
-    ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), feedrate(0.0f), extruder_id(0), cp_color_id(0), m_role(role) {};
-    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), feedrate(0.0f), extruder_id(0), cp_color_id(0), m_role(role) {};
-    ExtrusionPath(const ExtrusionPath &rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), feedrate(rhs.feedrate), extruder_id(rhs.extruder_id), cp_color_id(rhs.cp_color_id), m_role(rhs.m_role) {}
-    ExtrusionPath(ExtrusionPath &&rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), feedrate(rhs.feedrate), extruder_id(rhs.extruder_id), cp_color_id(rhs.cp_color_id), m_role(rhs.m_role) {}
+    ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), feedrate(0.0f), extruder_id(0), cp_color_id(0), fan_speed(0.0f), m_role(role) {};
+    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), feedrate(0.0f), extruder_id(0), cp_color_id(0), fan_speed(0.0f), m_role(role) {};
+    ExtrusionPath(const ExtrusionPath &rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), feedrate(rhs.feedrate), extruder_id(rhs.extruder_id), cp_color_id(rhs.cp_color_id), fan_speed(rhs.fan_speed), m_role(rhs.m_role) {}
+    ExtrusionPath(ExtrusionPath &&rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), feedrate(rhs.feedrate), extruder_id(rhs.extruder_id), cp_color_id(rhs.cp_color_id), fan_speed(rhs.fan_speed), m_role(rhs.m_role) {}
 //    ExtrusionPath(ExtrusionRole role, const Flow &flow) : m_role(role), mm3_per_mm(flow.mm3_per_mm()), width(flow.width), height(flow.height), feedrate(0.0f), extruder_id(0) {};
 
-    ExtrusionPath& operator=(const ExtrusionPath &rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->feedrate = rhs.feedrate, this->extruder_id = rhs.extruder_id, this->cp_color_id = rhs.cp_color_id, this->polyline = rhs.polyline; return *this; }
-    ExtrusionPath& operator=(ExtrusionPath &&rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->feedrate = rhs.feedrate, this->extruder_id = rhs.extruder_id, this->cp_color_id = rhs.cp_color_id, this->polyline = std::move(rhs.polyline); return *this; }
+    ExtrusionPath& operator=(const ExtrusionPath &rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->feedrate = rhs.feedrate, this->extruder_id = rhs.extruder_id, this->cp_color_id = rhs.cp_color_id, this->fan_speed = rhs.fan_speed, this->polyline = rhs.polyline; return *this; }
+    ExtrusionPath& operator=(ExtrusionPath &&rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->feedrate = rhs.feedrate, this->extruder_id = rhs.extruder_id, this->cp_color_id = rhs.cp_color_id, this->fan_speed = rhs.fan_speed, this->polyline = std::move(rhs.polyline); return *this; }
 
     ExtrusionPath* clone() const { return new ExtrusionPath (*this); }
     void reverse() { this->polyline.reverse(); }

--- a/src/libslic3r/GCode/Analyzer.cpp
+++ b/src/libslic3r/GCode/Analyzer.cpp
@@ -478,7 +478,8 @@ void GCodeAnalyzer::_processM106(const GCodeReader::GCodeLine& line)
 
 void GCodeAnalyzer::_processM107(const GCodeReader::GCodeLine& line)
 {
-    _set_fan_speed(0.0f);
+    if (!line.has('P')) // The absence of P means the print cooling fan, so ignore anything else.
+        _set_fan_speed(0.0f);
 }
 
 void GCodeAnalyzer::_processM108orM135(const GCodeReader::GCodeLine& line)

--- a/src/libslic3r/GCode/Analyzer.cpp
+++ b/src/libslic3r/GCode/Analyzer.cpp
@@ -41,10 +41,11 @@ GCodeAnalyzer::Metadata::Metadata()
     , width(GCodeAnalyzer::Default_Width)
     , height(GCodeAnalyzer::Default_Height)
     , feedrate(DEFAULT_FEEDRATE)
+    , fan_speed(0.0f)
 {
 }
 
-GCodeAnalyzer::Metadata::Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id/* = 0*/)
+GCodeAnalyzer::Metadata::Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id/* = 0*/, float fan_speed /* = 0.0f*/)
     : extrusion_role(extrusion_role)
     , extruder_id(extruder_id)
     , mm3_per_mm(mm3_per_mm)
@@ -52,6 +53,7 @@ GCodeAnalyzer::Metadata::Metadata(ExtrusionRole extrusion_role, unsigned int ext
     , height(height)
     , feedrate(feedrate)
     , cp_color_id(cp_color_id)
+    , fan_speed(fan_speed)
 {
 }
 
@@ -78,12 +80,15 @@ bool GCodeAnalyzer::Metadata::operator != (const GCodeAnalyzer::Metadata& other)
     if (cp_color_id != other.cp_color_id)
         return true;
 
+    if (fan_speed != other.fan_speed)
+        return true;
+
     return false;
 }
 
-GCodeAnalyzer::GCodeMove::GCodeMove(GCodeMove::EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id/* = 0*/)
+GCodeAnalyzer::GCodeMove::GCodeMove(GCodeMove::EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id/* = 0*/, float fan_speed)
     : type(type)
-    , data(extrusion_role, extruder_id, mm3_per_mm, width, height, feedrate, cp_color_id)
+    , data(extrusion_role, extruder_id, mm3_per_mm, width, height, feedrate, cp_color_id, fan_speed)
     , start_position(start_position)
     , end_position(end_position)
     , delta_extruder(delta_extruder)
@@ -135,6 +140,7 @@ void GCodeAnalyzer::reset()
     _set_start_extrusion(DEFAULT_START_EXTRUSION);
     _reset_axes_position();
     _reset_cached_position();
+    _set_fan_speed(0.0f);
 
     m_moves_map.clear();
     m_extruder_offsets.clear();
@@ -257,6 +263,16 @@ void GCodeAnalyzer::_process_gcode_line(GCodeReader&, const GCodeReader::GCodeLi
                 case 83: // Set extruder to relative mode
                     {
                         _processM83(line);
+                        break;
+                    }
+                case 106: // Set fan speed
+                    {
+                        _processM106(line);
+                        break;
+                    }
+                case 107: // Disable fan
+                    {
+                        _processM107(line);
                         break;
                     }
                 case 108:
@@ -446,6 +462,23 @@ void GCodeAnalyzer::_processM82(const GCodeReader::GCodeLine& line)
 void GCodeAnalyzer::_processM83(const GCodeReader::GCodeLine& line)
 {
     _set_e_local_positioning_type(Relative);
+}
+
+void GCodeAnalyzer::_processM106(const GCodeReader::GCodeLine& line)
+{
+    float new_fan_speed;
+    if (!line.has('P')) { // The absence of P means the print cooling fan, so ignore anything else.
+        if (line.has_value('S', new_fan_speed))
+            _set_fan_speed((100.0f / 256) * new_fan_speed);
+        else
+            _set_fan_speed(100.0f);
+    }
+
+}
+
+void GCodeAnalyzer::_processM107(const GCodeReader::GCodeLine& line)
+{
+    _set_fan_speed(0.0f);
 }
 
 void GCodeAnalyzer::_processM108orM135(const GCodeReader::GCodeLine& line)
@@ -726,6 +759,16 @@ float GCodeAnalyzer::_get_feedrate() const
     return m_state.data.feedrate;
 }
 
+void GCodeAnalyzer::_set_fan_speed(float fan_speed_percentage)
+{
+    m_state.data.fan_speed = fan_speed_percentage;
+}
+
+float GCodeAnalyzer::_get_fan_speed() const
+{
+    return m_state.data.fan_speed;
+}
+
 void GCodeAnalyzer::_set_axis_position(EAxis axis, float position)
 {
     m_state.position[axis] = position;
@@ -798,7 +841,7 @@ void GCodeAnalyzer::_store_move(GCodeAnalyzer::GCodeMove::EType type)
 
     Vec3d start_position = _get_start_position() + extruder_offset;
     Vec3d end_position = _get_end_position() + extruder_offset;
-    it->second.emplace_back(type, _get_extrusion_role(), extruder_id, _get_mm3_per_mm(), _get_width(), _get_height(), _get_feedrate(), start_position, end_position, _get_delta_extrusion(), _get_cp_color_id());
+    it->second.emplace_back(type, _get_extrusion_role(), extruder_id, _get_mm3_per_mm(), _get_width(), _get_height(), _get_feedrate(), start_position, end_position, _get_delta_extrusion(), _get_cp_color_id(), _get_fan_speed());
 }
 
 bool GCodeAnalyzer::_is_valid_extrusion_role(int value) const
@@ -835,6 +878,7 @@ void GCodeAnalyzer::_calc_gcode_preview_extrusion_layers(GCodePreviewData& previ
                 path.feedrate = data.feedrate;
                 path.extruder_id = data.extruder_id;
                 path.cp_color_id = data.cp_color_id;
+                path.fan_speed = data.fan_speed;
 
                 get_layer_at_z(preview_data.extrusion.layers, z).paths.push_back(path);
             }
@@ -854,6 +898,7 @@ void GCodeAnalyzer::_calc_gcode_preview_extrusion_layers(GCodePreviewData& previ
     GCodePreviewData::Range width_range;
     GCodePreviewData::Range feedrate_range;
     GCodePreviewData::Range volumetric_rate_range;
+    GCodePreviewData::Range fan_speed_range;
 
     // to avoid to call the callback too often
     unsigned int cancel_callback_threshold = (unsigned int)std::max((int)extrude_moves->second.size() / 25, 1);
@@ -888,6 +933,7 @@ void GCodeAnalyzer::_calc_gcode_preview_extrusion_layers(GCodePreviewData& previ
             width_range.update_from(move.data.width);
             feedrate_range.update_from(move.data.feedrate);
             volumetric_rate_range.update_from(volumetric_rate);
+            fan_speed_range.update_from(move.data.fan_speed);
         }
         else
             // append end vertex of the move to current polyline
@@ -906,6 +952,7 @@ void GCodeAnalyzer::_calc_gcode_preview_extrusion_layers(GCodePreviewData& previ
     preview_data.ranges.width.update_from(width_range);
     preview_data.ranges.feedrate.update_from(feedrate_range);
     preview_data.ranges.volumetric_rate.update_from(volumetric_rate_range);
+    preview_data.ranges.fan_speed.update_from(fan_speed_range);
 
     // we need to sort the layers by their z as they can be shuffled in case of sequential prints
     std::sort(preview_data.extrusion.layers.begin(), preview_data.extrusion.layers.end(), [](const GCodePreviewData::Extrusion::Layer& l1, const GCodePreviewData::Extrusion::Layer& l2)->bool { return l1.z < l2.z; });

--- a/src/libslic3r/GCode/Analyzer.cpp
+++ b/src/libslic3r/GCode/Analyzer.cpp
@@ -45,7 +45,7 @@ GCodeAnalyzer::Metadata::Metadata()
 {
 }
 
-GCodeAnalyzer::Metadata::Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id/* = 0*/, float fan_speed /* = 0.0f*/)
+GCodeAnalyzer::Metadata::Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id, float fan_speed)
     : extrusion_role(extrusion_role)
     , extruder_id(extruder_id)
     , mm3_per_mm(mm3_per_mm)
@@ -86,7 +86,7 @@ bool GCodeAnalyzer::Metadata::operator != (const GCodeAnalyzer::Metadata& other)
     return false;
 }
 
-GCodeAnalyzer::GCodeMove::GCodeMove(GCodeMove::EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id/* = 0*/, float fan_speed)
+GCodeAnalyzer::GCodeMove::GCodeMove(GCodeMove::EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id, float fan_speed)
     : type(type)
     , data(extrusion_role, extruder_id, mm3_per_mm, width, height, feedrate, cp_color_id, fan_speed)
     , start_position(start_position)

--- a/src/libslic3r/GCode/Analyzer.cpp
+++ b/src/libslic3r/GCode/Analyzer.cpp
@@ -467,7 +467,9 @@ void GCodeAnalyzer::_processM83(const GCodeReader::GCodeLine& line)
 void GCodeAnalyzer::_processM106(const GCodeReader::GCodeLine& line)
 {
     float new_fan_speed;
-    if (!line.has('P')) { // The absence of P means the print cooling fan, so ignore anything else.
+    float extruder_id = 0;
+
+    if (!line.has_value('P', extruder_id) || unsigned(extruder_id) == _get_extruder_id()) {
         if (line.has_value('S', new_fan_speed))
             _set_fan_speed((100.0f / 256) * new_fan_speed);
         else
@@ -478,7 +480,9 @@ void GCodeAnalyzer::_processM106(const GCodeReader::GCodeLine& line)
 
 void GCodeAnalyzer::_processM107(const GCodeReader::GCodeLine& line)
 {
-    if (!line.has('P')) // The absence of P means the print cooling fan, so ignore anything else.
+    float extruder_id = 0;
+
+    if (!line.has_value('P', extruder_id) || unsigned(extruder_id) == _get_extruder_id())
         _set_fan_speed(0.0f);
 }
 

--- a/src/libslic3r/GCode/Analyzer.cpp
+++ b/src/libslic3r/GCode/Analyzer.cpp
@@ -469,6 +469,9 @@ void GCodeAnalyzer::_processM106(const GCodeReader::GCodeLine& line)
     float new_fan_speed;
     float extruder_id = 0;
 
+    // This tries to track the correct fan. It could miss using P to set a fan not currently active
+    // that later becomes active. However, that seems like a very rare corner case for an unlikely
+    // printer configuration, so I chose to keep the code simple and not handle it.
     if (!line.has_value('P', extruder_id) || unsigned(extruder_id) == _get_extruder_id()) {
         if (line.has_value('S', new_fan_speed))
             _set_fan_speed((100.0f / 256) * new_fan_speed);
@@ -482,6 +485,7 @@ void GCodeAnalyzer::_processM107(const GCodeReader::GCodeLine& line)
 {
     float extruder_id = 0;
 
+    // See _processM106 above to understand the logic.
     if (!line.has_value('P', extruder_id) || unsigned(extruder_id) == _get_extruder_id())
         _set_fan_speed(0.0f);
 }

--- a/src/libslic3r/GCode/Analyzer.hpp
+++ b/src/libslic3r/GCode/Analyzer.hpp
@@ -58,7 +58,7 @@ public:
         float fan_speed; // percentage
 
         Metadata();
-        Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id = 0, float fan_speed = 0.0f);
+        Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id, float fan_speed);
 
         bool operator != (const Metadata& other) const;
     };
@@ -82,7 +82,7 @@ public:
         Vec3d end_position;
         float delta_extruder;
 
-        GCodeMove(EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id = 0, float fan_speed = 0);
+        GCodeMove(EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id, float fan_speed);
         GCodeMove(EType type, const Metadata& data, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder);
     };
 

--- a/src/libslic3r/GCode/Analyzer.hpp
+++ b/src/libslic3r/GCode/Analyzer.hpp
@@ -55,9 +55,10 @@ public:
         float height;    // mm
         float feedrate;  // mm/s
         unsigned int cp_color_id;
+        float fan_speed; // percentage
 
         Metadata();
-        Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id = 0);
+        Metadata(ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, unsigned int cp_color_id = 0, float fan_speed = 0.0f);
 
         bool operator != (const Metadata& other) const;
     };
@@ -81,7 +82,7 @@ public:
         Vec3d end_position;
         float delta_extruder;
 
-        GCodeMove(EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id = 0);
+        GCodeMove(EType type, ExtrusionRole extrusion_role, unsigned int extruder_id, double mm3_per_mm, float width, float height, float feedrate, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder, unsigned int cp_color_id = 0, float fan_speed = 0);
         GCodeMove(EType type, const Metadata& data, const Vec3d& start_position, const Vec3d& end_position, float delta_extruder);
     };
 
@@ -171,6 +172,12 @@ private:
     // Set extruder to relative mode
     void _processM83(const GCodeReader::GCodeLine& line);
 
+    // Set fan speed
+    void _processM106(const GCodeReader::GCodeLine& line);
+
+    // Disable fan
+    void _processM107(const GCodeReader::GCodeLine& line);
+
     // Set tool (MakerWare and Sailfish flavor)
     void _processM108orM135(const GCodeReader::GCodeLine& line);
 
@@ -232,6 +239,9 @@ private:
 
     void _set_feedrate(float feedrate_mm_sec);
     float _get_feedrate() const;
+
+    void _set_fan_speed(float fan_speed_percentage);
+    float _get_fan_speed() const;
 
     void _set_axis_position(EAxis axis, float position);
     float _get_axis_position(EAxis axis) const;

--- a/src/libslic3r/GCode/PreviewData.cpp
+++ b/src/libslic3r/GCode/PreviewData.cpp
@@ -265,6 +265,7 @@ void GCodePreviewData::set_default()
     ::memcpy((void*)ranges.height.colors, (const void*)Range::Default_Colors, Range::Colors_Count * sizeof(Color));
     ::memcpy((void*)ranges.width.colors, (const void*)Range::Default_Colors, Range::Colors_Count * sizeof(Color));
     ::memcpy((void*)ranges.feedrate.colors, (const void*)Range::Default_Colors, Range::Colors_Count * sizeof(Color));
+    ::memcpy((void*)ranges.fan_speed.colors, (const void*)Range::Default_Colors, Range::Colors_Count * sizeof(Color));
     ::memcpy((void*)ranges.volumetric_rate.colors, (const void*)Range::Default_Colors, Range::Colors_Count * sizeof(Color));
 
     extrusion.set_default();
@@ -309,6 +310,11 @@ GCodePreviewData::Color GCodePreviewData::get_width_color(float width) const
 GCodePreviewData::Color GCodePreviewData::get_feedrate_color(float feedrate) const
 {
     return ranges.feedrate.get_color_at(feedrate);
+}
+
+GCodePreviewData::Color GCodePreviewData::get_fan_speed_color(float fan_speed) const
+{
+    return ranges.fan_speed.get_color_at(fan_speed);
 }
 
 GCodePreviewData::Color GCodePreviewData::get_volumetric_rate_color(float rate) const
@@ -388,6 +394,8 @@ std::string GCodePreviewData::get_legend_title() const
         return L("Tool");
     case Extrusion::ColorPrint:
         return L("Color Print");
+    case Extrusion::FanSpeed:
+        return L("Fan Speed");
     case Extrusion::Num_View_Types:
         break; // just to supress warning about non-handled value
     }
@@ -492,6 +500,11 @@ GCodePreviewData::LegendItemsList GCodePreviewData::get_legend_items(const std::
 //                 items.emplace_back((boost::format(Slic3r::I18N::translate(L("%.2f - %.2f mm"))) %  cp_values[i-1] % cp_values[i]).str(), color);
                 items.emplace_back(id_str + (boost::format(Slic3r::I18N::translate(L("%.2f - %.2f mm"))) % cp_values[i - 1].second% cp_values[i].first).str(), color);
             }
+            break;
+        }
+    case Extrusion::FanSpeed:
+        {
+            Helper::FillListFromRange(items, ranges.fan_speed, 0, 1.0f);
             break;
         }
     case Extrusion::Num_View_Types:

--- a/src/libslic3r/GCode/PreviewData.hpp
+++ b/src/libslic3r/GCode/PreviewData.hpp
@@ -54,6 +54,8 @@ public:
         Range feedrate;
         // Color mapping by volumetric extrusion rate.
         Range volumetric_rate;
+        // Color mapping by fan speed.
+        Range fan_speed;
     };
 
     struct LegendItem
@@ -77,6 +79,7 @@ public:
             VolumetricRate,
             Tool,
             ColorPrint,
+            FanSpeed,
             Num_View_Types
         };
 
@@ -206,6 +209,7 @@ public:
     Color get_height_color(float height) const;
     Color get_width_color(float width) const;
     Color get_feedrate_color(float feedrate) const;
+    Color get_fan_speed_color(float fan_speed) const;
     Color get_volumetric_rate_color(float rate) const;
 
     void set_extrusion_role_color(const std::string& role_name, float red, float green, float blue, float alpha);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5008,6 +5008,8 @@ void GLCanvas3D::_load_gcode_extrusion_paths(const GCodePreviewData& preview_dat
                 return (float)path.extruder_id;
             case GCodePreviewData::Extrusion::ColorPrint:
                 return (float)path.cp_color_id;
+            case GCodePreviewData::Extrusion::FanSpeed:
+                return path.fan_speed;
             default:
                 return 0.0f;
             }
@@ -5048,6 +5050,8 @@ void GLCanvas3D::_load_gcode_extrusion_paths(const GCodePreviewData& preview_dat
 
                 return color;
             }
+            case GCodePreviewData::Extrusion::FanSpeed:
+                return data.get_fan_speed_color(value);
             default:
                 return GCodePreviewData::Color::Dummy;
             }

--- a/src/slic3r/GUI/GUI_Preview.cpp
+++ b/src/slic3r/GUI/GUI_Preview.cpp
@@ -224,6 +224,7 @@ bool Preview::init(wxWindow* parent, Bed3D& bed, Camera& camera, GLToolbar& view
     m_choice_view_type->Append(_(L("Volumetric flow rate")));
     m_choice_view_type->Append(_(L("Tool")));
     m_choice_view_type->Append(_(L("Color Print")));
+    m_choice_view_type->Append(_(L("Fan Speed")));
     m_choice_view_type->SetSelection(0);
 
     m_label_show_features = new wxStaticText(this, wxID_ANY, _(L("Show")));


### PR DESCRIPTION
This adds an option to preview fan speed as requested in issue #1491.
I needed this to verify that patch #2921 generates correct output.