### PR TITLE
Doubled the minimal zoom distance to allow better view of bed models

### DIFF
--- a/src/slic3r/GUI/Camera.cpp
+++ b/src/slic3r/GUI/Camera.cpp
@@ -111,7 +111,7 @@ void Camera::set_zoom(double zoom, const BoundingBoxf3& max_box, int canvas_w, i
     // Don't allow to zoom too far outside the scene.
     double zoom_min = calc_zoom_to_bounding_box_factor(max_box, canvas_w, canvas_h);
     if (zoom_min > 0.0)
-        zoom = std::max(zoom, zoom_min * 0.7);
+        zoom = std::max(zoom, zoom_min * 0.35);
 
     // Don't allow to zoom too close to the scene.
     zoom = std::min(zoom, 100.0);


### PR DESCRIPTION
Doubled the minimal zoom distance to allow better view of bed models because the default distance is too close depending on the bed view model, in my example i use a Full Bear MK3S bed model:

Without the patch:
![without_patch](https://user-images.githubusercontent.com/7167311/65183866-a74df680-da64-11e9-80cc-f7d37ba2f6ec.png)

With the patch:
![with_patch](https://user-images.githubusercontent.com/7167311/65183878-addc6e00-da64-11e9-9250-63bac677c745.png)

Of course feel free to edit/ask if you want to reduce or adjust the value,
Thanks.
