### PR TITLE
Replace "mm3/s" with "mm³/s" in the localizations

### DIFF
--- a/resources/localization/cs/PrusaSlicer_cs.po
+++ b/resources/localization/cs/PrusaSlicer_cs.po
@@ -7308,7 +7308,7 @@ msgstr "Objemový průtok"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Objemový průtok (mm3/s)"
+msgstr "Objemový průtok (mm³/s)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -7306,7 +7306,7 @@ msgstr "Volumetrische Flussrate"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Volumetrische Flussrate (mm3/s)"
+msgstr "Volumetrische Flussrate (mm³/s)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/es/PrusaSlicer_es.po
+++ b/resources/localization/es/PrusaSlicer_es.po
@@ -7306,7 +7306,7 @@ msgstr "Tasa de caudal volumétrico"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Tasa de flujo volumétrico (mm3/seg)"
+msgstr "Tasa de flujo volumétrico (mm³/seg)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/fr/PrusaSlicer_fr.po
+++ b/resources/localization/fr/PrusaSlicer_fr.po
@@ -7306,7 +7306,7 @@ msgstr "Débit volumétrique"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Débit volumétrique (mm3/s)"
+msgstr "Débit volumétrique (mm³/s)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -7306,7 +7306,7 @@ msgstr "Flusso volumetrico"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Flusso volumetrico (mm3/s)"
+msgstr "Flusso volumetrico (mm³/s)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/ko/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko/PrusaSlicer_ko_KR.po
@@ -8955,7 +8955,7 @@ msgstr "속도 (mm/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "용적 유량값 (mm3/s)"
+msgstr "용적 유량값 (mm³/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:493
 msgid "Default print color"

--- a/resources/localization/pl/PrusaSlicer_pl.po
+++ b/resources/localization/pl/PrusaSlicer_pl.po
@@ -7310,7 +7310,7 @@ msgstr "Objętościowa wartość przepływu"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Objętościowy współczynnik przepływu (mm3/s)"
+msgstr "Objętościowy współczynnik przepływu (mm³/s)"
 
 #: src/slic3r/GUI/RammingChart.cpp:81
 msgid "Volumetric speed"

--- a/resources/localization/tr/PrusaSlicer_tr.po
+++ b/resources/localization/tr/PrusaSlicer_tr.po
@@ -7144,7 +7144,7 @@ msgstr "Hız (mm / s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "Hacimsel akış hızı (mm3/s)"
+msgstr "Hacimsel akış hızı (mm³/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:491
 msgid "Default print color"

--- a/resources/localization/zh_cn/PrusaSlicer_zh_CN.po
+++ b/resources/localization/zh_cn/PrusaSlicer_zh_CN.po
@@ -8867,7 +8867,7 @@ msgstr "回退速度(mm/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:386
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "体积流量 (mm3/s)"
+msgstr "体积流量 (mm³/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:477
 msgid "Default print color"

--- a/resources/localization/zh_tw/PrusaSlicer_zh_TW.po
+++ b/resources/localization/zh_tw/PrusaSlicer_zh_TW.po
@@ -7580,7 +7580,7 @@ msgstr "回退速度(mm/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:402
 msgid "Volumetric flow rate (mm3/s)"
-msgstr "體積流量 (mm3/s)"
+msgstr "體積流量 (mm³/s)"
 
 #: src/libslic3r/GCode/PreviewData.cpp:491
 msgid "Default print color"


### PR DESCRIPTION
This text is used in the plater legend for the Volumetric flow rate.