### PR TITLE
Fix issues writing to filesystems that don't support chmod

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -439,10 +439,12 @@ int copy_file(const std::string &from, const std::string &to)
     // and copying again
     if (ec.value() == boost::system::errc::permission_denied
             && boost::filesystem::exists(target)) {
+        ec.clear();
         boost::filesystem::permissions(target, perms, ec);
         // if we can't set permissions our copy will fail again so don't try
         if (!is_ok(ec))
             return -1;
+        ec.clear();
         boost::filesystem::copy_file(source, target, boost::filesystem::copy_option::overwrite_if_exists, ec);
         return (is_ok(ec) ? 0 : -1);
     }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -439,11 +439,7 @@ int copy_file(const std::string &from, const std::string &to)
     // and copying again
     if (ec.value() == boost::system::errc::permission_denied
             && boost::filesystem::exists(target)) {
-        ec.clear();
         boost::filesystem::permissions(target, perms, ec);
-        // if we can't set permissions our copy will fail again so don't try
-        if (!is_ok(ec))
-            return -1;
         ec.clear();
         boost::filesystem::copy_file(source, target, boost::filesystem::copy_option::overwrite_if_exists, ec);
         return (is_ok(ec) ? 0 : -1);


### PR DESCRIPTION
This fixes #2521 which happens because the attempted permissions change fails if you use a VFAT filesystem on Linux (which doesn't support permissions). So, this changeset makes it so that PrusaSlicer just tries to write the file, and if it fails due to permissions, tries to fix it. This avoids introducing a regression in the functionality (which I saw a fixed issue for) of the slicer fixing your filesystem permissions if you have a file that you own but you don't have permissions for.

I have not written unit tests for this mostly out of unfamiliarity with the test infrastructure. If anyone wants to give me an overview of how to go about doing that (if it's needed), that would be great.

Behaviours:
- `touch f.gcode; chmod 000 f.gcode`, then saving over it *still works*
- Writing g code to filesystems that don't support `chmod()` *now* works

a49aeabb addresses the Boost [error reporting](https://www.boost.org/doc/libs/1_69_0/libs/filesystem/doc/reference.html#Error-reporting), which is documented as clearing the `error_code` if the call succeeds, but it doesn't seem to actually do that. I don't know why this is happening and it might be a Boost bug. Anyway we clear it on each filesystem call for this reason.