### PR TITLE
Add toggle all option to Preview > Show > Feature Types

### DIFF
--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -282,9 +282,9 @@ void create_combochecklist(wxComboCtrl* comboCtrl, std::string text, std::string
     }
 }
 
-int combochecklist_get_flags(wxComboCtrl* comboCtrl)
+unsigned int combochecklist_get_flags(wxComboCtrl* comboCtrl)
 {
-    int flags = 0;
+    unsigned int flags = 0;
 
     wxCheckListBoxComboPopup* popup = wxDynamicCast(comboCtrl->GetPopupControl(), wxCheckListBoxComboPopup);
     if (popup != nullptr)
@@ -292,6 +292,24 @@ int combochecklist_get_flags(wxComboCtrl* comboCtrl)
         for (unsigned int i = 0; i < popup->GetCount(); ++i)
         {
             if (popup->IsChecked(i))
+                flags |= 1 << i;
+        }
+    }
+
+    return flags;
+}
+
+unsigned int combochecklist_set_flags(wxComboCtrl* comboCtrl, bool flag_value)
+{
+    unsigned int flags = 0;
+
+    wxCheckListBoxComboPopup* popup = wxDynamicCast(comboCtrl->GetPopupControl(), wxCheckListBoxComboPopup);
+    if (popup != nullptr)
+    {
+        for (unsigned int i = 0; i < popup->GetCount(); ++i)
+        {
+            popup->Check(i, flag_value);
+            if (flag_value) 
                 flags |= 1 << i;
         }
     }

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -50,7 +50,8 @@ void create_combochecklist(wxComboCtrl* comboCtrl, std::string text, std::string
 
 // Returns the current state of the items listed in the wxCheckListBoxComboPopup contained in the given wxComboCtrl,
 // encoded inside an int.
-int combochecklist_get_flags(wxComboCtrl* comboCtrl);
+unsigned int combochecklist_get_flags(wxComboCtrl* comboCtrl);
+unsigned int combochecklist_set_flags(wxComboCtrl* comboCtrl, bool flag_value);
 
 // wxString conversions:
 

--- a/src/slic3r/GUI/GUI_Preview.hpp
+++ b/src/slic3r/GUI/GUI_Preview.hpp
@@ -100,6 +100,7 @@ class Preview : public wxPanel
 
     bool m_loaded;
     bool m_enabled;
+    bool m_toggle_state_combochecklist_features;
 
     DoubleSlider* m_slider {nullptr};
 


### PR DESCRIPTION
Patch from Issue #3112

Because of event double firing (Issue #3076) I had to hold onto toggle state and workaround it. I highly doubt this PR will be merged as-is because of that but I hope the feature idea lives on in some implementation.