### PR TITLE
Add dependency on -ldl to hidapi (for dlclose) on linux

### DIFF
--- a/src/hidapi/CMakeLists.txt
+++ b/src/hidapi/CMakeLists.txt
@@ -15,5 +15,5 @@ add_library(hidapi STATIC ${HIDAPI_IMPL})
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	# Don't link the udev library, as there are two versions out there (libudev.so.0, libudev.so.1), so they are linked explicitely.
 #	target_link_libraries(hidapi udev)
-	target_link_libraries(hidapi)
+	target_link_libraries(hidapi dl)
 endif()


### PR DESCRIPTION
Fixes build on the current master on linux.