### PR TITLE
Bugfix: Solid infill failed to generate in some cases

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2396,7 +2396,10 @@ void PrintObject::discover_horizontal_shells()
                                     // is grown, and that little space is an internal solid shell so 
                                     // it triggers this too_narrow logic.)
                                     internal));
-                            solid = new_internal_solid;
+
+                            // grow the solid region to be supported for the next layer to include the extra
+                            // area generated here
+                            polygons_append(solid, new_internal_solid);
                         }
                     }
                     


### PR DESCRIPTION
The code to detect too narrow infill did reset the supporting polygon causing the supported area to shrink in some cases. This lead to missing infill on subsequent layers. This diff changes the logic to append instead of replacing the polygon which resolves the issue.

Before:
![slicingerror-small](https://user-images.githubusercontent.com/3725313/71567360-47a7b400-2a73-11ea-8c9b-73dc46ee7ef1.gif)

After:
![fixed-small](https://user-images.githubusercontent.com/3725313/71567364-51c9b280-2a73-11ea-964a-8d793b966ff3.gif)

