### PR TITLE
Update the default `output_filename_format` parameter for the SL1 profiles to include more information

### DIFF
--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2835,7 +2835,7 @@ filament_density = 1.27
 [sla_print:*common*]
 compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_SL1.*/
 layer_height = 0.05
-output_filename_format = [input_filename_base].sl1
+output_filename_format = [input_filename_base]_[layer_height]mm_[exposure_time]s_[printer_model]_[print_time].sl1
 pad_edge_radius = 0.5
 pad_enable = 1
 pad_max_merge_distance = 50

--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2835,7 +2835,7 @@ filament_density = 1.27
 [sla_print:*common*]
 compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_SL1.*/
 layer_height = 0.05
-output_filename_format = [input_filename_base]_[layer_height]mm_[exposure_time]s_[printer_model]_[print_time].sl1
+output_filename_format = {input_filename_base}_{layer_height}mm_{exposure_time}s_{printer_model}_{print_time}.sl1
 pad_edge_radius = 0.5
 pad_enable = 1
 pad_max_merge_distance = 50


### PR DESCRIPTION
# What

Updates the default `output_filename_format` parameter for the SL1 profiles to include more information and better match the filename format of the FDM profiles which is currently `{input_filename_base}_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode`

# Why

The default `output_filename_format` for SLA profiles lacks the same level of info as the defaults for FDM profiles. Currently the default is set to include only the `input_filename_base` whereas the FDM profiles include additional info such as layer height and print time. I can imagine an argument against this since the SL1 printer displays much more info about a print before it is started than the MK3 does, however it I would argue that it is still useful to have this information in the filename by default for ease of comparing files on disk when they are not being viewed on the SL1 display.

# How

Changes the default value for the `output_filename_format` under SLA common config from `[input_filename_base].sl1` to `{input_filename_base}_{layer_height}mm_{exposure_time}s_{printer_model}_{print_time}.sl1`

Fixes https://github.com/prusa3d/PrusaSlicer/issues/3485