### PR TITLE
Add variable-width infill as proposed by CNC Kitchen

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <memory>
 
+#include "../libslic3r.h"
+
 #include "../ClipperUtils.hpp"
 #include "../Geometry.hpp"
 #include "../Layer.hpp"
@@ -10,6 +12,10 @@
 #include "../Surface.hpp"
 
 #include "FillBase.hpp"
+
+// What length of segments the infill should be divided into to allow a gradient to be applied to them, in millimetres:
+#define GRADIENT_INFILL_MAX_SEGMENT_LEN scale_(1.0)
+#define GRADIENT_INFILL_MAX_SEGMENT_LEN_SQR (GRADIENT_INFILL_MAX_SEGMENT_LEN * GRADIENT_INFILL_MAX_SEGMENT_LEN)
 
 namespace Slic3r {
 
@@ -37,6 +43,11 @@ struct SurfaceFillParams
     // Don't adjust spacing to fill the space evenly.
     bool        	dont_adjust = false;
 
+    // Gradient infill
+    bool            gradient_fill = false;
+    double          gradient_fill_min = 0.5, gradient_fill_max = 2;
+    double          gradient_fill_thickness = 6;
+    
     // width, height of extrusion, nozzle diameter, is bridge
     // For the output, for fill generator.
     Flow 			flow = Flow(0.f, 0.f, 0.f, false);
@@ -71,6 +82,10 @@ struct SurfaceFillParams
 		RETURN_COMPARE_NON_EQUAL(flow.nozzle_diameter);
 		RETURN_COMPARE_NON_EQUAL_TYPED(unsigned, flow.bridge);
 		RETURN_COMPARE_NON_EQUAL_TYPED(unsigned, extrusion_role);
+		RETURN_COMPARE_NON_EQUAL_TYPED(unsigned, gradient_fill);
+		RETURN_COMPARE_NON_EQUAL(gradient_fill_min);
+		RETURN_COMPARE_NON_EQUAL(gradient_fill_max);
+		RETURN_COMPARE_NON_EQUAL(gradient_fill_thickness);
 		return false;
 	}
 
@@ -85,7 +100,11 @@ struct SurfaceFillParams
 				this->dont_connect  	== rhs.dont_connect 	&&
 				this->dont_adjust   	== rhs.dont_adjust 		&&
 				this->flow 				== rhs.flow 			&&
-				this->extrusion_role	== rhs.extrusion_role;
+				this->extrusion_role	== rhs.extrusion_role   &&
+				this->gradient_fill   	== rhs.gradient_fill	&&
+				this->gradient_fill_min	== rhs.gradient_fill_min    	        &&
+				this->gradient_fill_max	== rhs.gradient_fill_max	            &&
+				this->gradient_fill_thickness == rhs.gradient_fill_thickness;
 	}
 };
 
@@ -119,14 +138,21 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        params.extruder 	 = layerm.region()->extruder(extrusion_role);
 		        params.pattern 		 = layerm.region()->config().fill_pattern.value;
 		        params.density       = float(layerm.region()->config().fill_density);
-
+		        params.gradient_fill = false;
+		        
 		        if (surface.is_solid()) {
 		            params.density = 100.f;
 		            params.pattern = (surface.is_external() && ! is_bridge) ? 
 						(surface.is_top() ? layerm.region()->config().top_fill_pattern.value : layerm.region()->config().bottom_fill_pattern.value) :
 		                ipRectilinear;
-		        } else if (params.density <= 0)
+		        } else if (params.density <= 0) {
 		            continue;
+		        } else {
+		            params.gradient_fill = layerm.region()->config().gradient_infill;
+		            params.gradient_fill_min = layerm.region()->config().gradient_infill_min.get_abs_value(1);
+		            params.gradient_fill_max = layerm.region()->config().gradient_infill_max.get_abs_value(1);
+		            params.gradient_fill_thickness = layerm.region()->config().gradient_infill_distance;
+		        }
 
 		        params.extrusion_role =
 		            is_bridge ?
@@ -316,6 +342,101 @@ void export_group_fills_to_svg(const char *path, const std::vector<SurfaceFill> 
 }
 #endif
 
+static void applyGradientInfill(ExtrusionEntitiesPtr &dst, Polylines &&polylines, double mm3_per_mm, 
+    float width, float height, float maxWidth, const ExPolygon &boundary, const SurfaceFillParams &params)
+{
+    for (Polyline &polyline : polylines) {
+        if (!polyline.is_valid()) {
+            continue;
+        }
+
+        // Chunk the line into fragments of at most GRADIENT_INFILL_MAX_SEGMENT_LEN long
+        Polyline newLine;
+        newLine.points.reserve(polyline.points.size());
+        
+        newLine.append(polyline.points[0]);
+
+        for (int j = 1; j < polyline.points.size(); j++) {
+            Point prevPoint(polyline.points[j - 1]);
+            Point thisPoint(polyline.points[j]);
+
+            auto segment(thisPoint.cast<coordf_t>() - prevPoint.cast<coordf_t>());
+            double segLengthSqr = segment.squaredNorm();
+
+            // Do we need to add intermediate fragments before the end of this segment?
+            if (segLengthSqr > GRADIENT_INFILL_MAX_SEGMENT_LEN_SQR) {
+                int numSegments = ceil(sqrt(segLengthSqr) / GRADIENT_INFILL_MAX_SEGMENT_LEN);
+                
+                for (int seg = 1; seg < numSegments; seg++) {
+                    auto newPoint(prevPoint.cast<coordf_t>() + segment * ((double) seg / numSegments));
+                    newLine.append(Point(newPoint(0), newPoint(1)));
+                }
+            }
+
+            newLine.append(polyline.points[j]);
+        }
+
+        // Compute extrusion widths for each segment of the infill and group similar ones together into ExtrusionPaths
+        ExtrusionPath *extrusionPath = 0;
+        double lastScale = -1;
+        extrusionPath = 0;
+
+        std::vector<const Polygon*> perimeters;
+
+        perimeters.push_back(&boundary.contour);
+        for (const Polygon &p : boundary.holes) {
+            perimeters.push_back(&p);
+        }
+
+        for (int i = 0; i < newLine.points.size() - 1; i++) {
+            Point startPoint(newLine.points[i]);
+            Point endPoint(newLine.points[i + 1]);
+            
+            Point infillSegCenter((startPoint(0) + endPoint(0)) / 2, (startPoint(1) + endPoint(1)) / 2);
+            
+            double distanceToWallSqr = std::numeric_limits<double>::infinity();
+
+            for (const Polygon* perimeterPtr : perimeters) {
+                const Polygon &perimeter = *perimeterPtr;
+                
+                for (int j = 0; j < perimeter.points.size(); j++) {
+                    double dist = Line::distance_to_squared(infillSegCenter, perimeter.points[j],
+                        perimeter.points[(j + 1) % perimeter.points.size()]);
+
+                    if (dist < distanceToWallSqr) {
+                        distanceToWallSqr = dist;
+                    }
+                }
+            }
+            
+            double distanceToWall = unscale<double>(sqrt(distanceToWallSqr));
+            double gradientScale;
+            
+            if (distanceToWall > params.gradient_fill_thickness) {
+                gradientScale = params.gradient_fill_min;
+            } else {
+                gradientScale = (params.gradient_fill_max - params.gradient_fill_min) * (1 - distanceToWall / params.gradient_fill_thickness) + params.gradient_fill_min;
+                // Quantize the scale factor in 5% chunks so we can combine similar line segments together 
+                gradientScale = round(gradientScale * 20) / 20;
+            }
+            
+            // Don't allow the infill to be thicker than the spacing between infill lines
+            gradientScale = fmin(gradientScale, maxWidth / width);
+            
+            if (!extrusionPath || gradientScale != lastScale) {
+                extrusionPath = new ExtrusionPath(erInternalInfill, mm3_per_mm * gradientScale, width * gradientScale, height);
+                dst.push_back(extrusionPath);
+                
+                lastScale = gradientScale;
+                
+                extrusionPath->polyline.append(startPoint);
+            }
+            
+            extrusionPath->polyline.append(endPoint);
+        }
+    }
+}
+
 // friend to Layer
 void Layer::make_fills()
 {
@@ -371,7 +492,7 @@ void Layer::make_fills()
         for (ExPolygon &expoly : surface_fill.expolygons) {
 			// Spacing is modified by the filler to indicate adjustments. Reset it for each expolygon.
 			f->spacing = surface_fill.params.spacing;
-			surface_fill.surface.expolygon = std::move(expoly);
+			surface_fill.surface.expolygon = expoly;
 			Polylines polylines = f->fill_surface(&surface_fill.surface, params);
 	        if (! polylines.empty()) {
 		        // calculate actual flow from spacing (which might have been adjusted by the infill
@@ -392,10 +513,19 @@ void Layer::make_fills()
 		        m_regions[surface_fill.region_id]->fills.entities.push_back(eec);
 		        // Only concentric fills are not sorted.
 		        eec->no_sort = f->no_sort();
-		        extrusion_entities_append_paths(
-		            eec->entities, std::move(polylines),
-		            surface_fill.params.extrusion_role,
-		            flow_mm3_per_mm, float(flow_width), surface_fill.params.flow.height);
+		        
+		        if (surface_fill.params.gradient_fill && surface_fill.params.extrusion_role == erInternalInfill) {
+		            applyGradientInfill(
+		                eec->entities, std::move(polylines),
+		                flow_mm3_per_mm, float(flow_width), surface_fill.params.flow.height, 
+		                f->spacing * 100.0 / surface_fill.params.density,
+		                expoly, surface_fill.params);
+		        } else {
+		            extrusion_entities_append_paths(
+		                eec->entities, std::move(polylines),
+		                surface_fill.params.extrusion_role,
+		                flow_mm3_per_mm, float(flow_width), surface_fill.params.flow.height);
+		        }
 		    }
 		}
     }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -431,6 +431,32 @@ void PrintConfigDef::init_fff_params()
     def->aliases = def_top_fill_pattern->aliases;
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipRectilinear));
 
+    def = this->add("gradient_infill", coBool);
+    def->label = L("Automatically vary infill width");
+    def->category = L("Infill");
+    def->tooltip = L("Automatically vary infill width based on distance from perimeters");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("gradient_infill_min", coFloatOrPercent);
+    def->label = L("Minimum width");
+    def->tooltip = L("Minimum gradient infill width as a percentage of the default width");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloatOrPercent { 50, true });
+
+    def = this->add("gradient_infill_max", coFloatOrPercent);
+    def->label = L("Maximum width");
+    def->tooltip = L("Maximum gradient infill width as a percentage of the default width");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloatOrPercent { 250, true });
+
+    def = this->add("gradient_infill_distance", coFloat);
+    def->label = L("Gradient transition distance");
+    def->tooltip = L("The distance over which the gradient should transition from max to min width");
+    def->sidetext = L("mm");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloat { 6 });
+
     def = this->add("external_perimeter_extrusion_width", coFloatOrPercent);
     def->label = L("External perimeters");
     def->category = L("Extrusion Width");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -505,6 +505,11 @@ public:
     ConfigOptionInt                 infill_every_layers;
     ConfigOptionFloatOrPercent      infill_overlap;
     ConfigOptionFloat               infill_speed;
+    // Gradient infill
+    ConfigOptionBool                gradient_infill;
+    ConfigOptionFloatOrPercent      gradient_infill_min;
+    ConfigOptionFloatOrPercent      gradient_infill_max;
+    ConfigOptionFloat               gradient_infill_distance;
     // Detect bridging perimeters
     ConfigOptionBool                overhangs;
     ConfigOptionInt                 perimeter_extruder;
@@ -548,6 +553,10 @@ protected:
         OPT_PTR(infill_every_layers);
         OPT_PTR(infill_overlap);
         OPT_PTR(infill_speed);
+        OPT_PTR(gradient_infill);
+        OPT_PTR(gradient_infill_min);
+        OPT_PTR(gradient_infill_max);
+        OPT_PTR(gradient_infill_distance);
         OPT_PTR(overhangs);
         OPT_PTR(perimeter_extruder);
         OPT_PTR(perimeter_extrusion_width);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -521,7 +521,11 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "fill_pattern"
             || opt_key == "fill_link_max_length"
             || opt_key == "top_infill_extrusion_width"
-            || opt_key == "first_layer_extrusion_width") {
+            || opt_key == "first_layer_extrusion_width"
+            || opt_key == "gradient_infill"
+            || opt_key == "gradient_infill_min"
+            || opt_key == "gradient_infill_max"
+            || opt_key == "gradient_infill_distance") {
             steps.emplace_back(posInfill);
         } else if (
                opt_key == "fill_density"

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -382,6 +382,7 @@ const std::vector<std::string>& Preset::print_options()
         "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs",
         "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
         "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
+        "gradient_infill", "gradient_infill_min", "gradient_infill_max", "gradient_infill_distance",
         "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", "max_print_speed",
         "max_volumetric_speed",
 #ifdef HAS_PRESSURE_EQUALIZER

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1074,6 +1074,12 @@ void TabPrint::build()
         optgroup->append_single_option_line("fill_pattern");
         optgroup->append_single_option_line("top_fill_pattern");
         optgroup->append_single_option_line("bottom_fill_pattern");
+    
+        optgroup = page->new_optgroup(_(L("Variable width infill")));
+        optgroup->append_single_option_line("gradient_infill");
+        optgroup->append_single_option_line("gradient_infill_min");
+        optgroup->append_single_option_line("gradient_infill_max");
+        optgroup->append_single_option_line("gradient_infill_distance");
 
         optgroup = page->new_optgroup(_(L("Reducing printing time")));
         optgroup->append_single_option_line("infill_every_layers");


### PR DESCRIPTION
This PR (code by @thenickdude) adds variable-width infill as proposed by [CNC Kitchen](https://www.cnckitchen.com/blog). 

More information and video:
https://www.cnckitchen.com/blog/gradient-infill-for-3d-prints

![](https://images.squarespace-cdn.com/content/v1/5d88f1f13db677155dee50fa/1578651367251-UL24VNVBEXIBTCRI9BJR/ke17ZwdGBToddI8pDm48kNvT88LknE-K9M4pGNO0Iqd7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UbeDbaZv1s3QfpIA4TYnL5Qao8BosUKjCVjCf8TKewJIH3bqxw7fF48mhrq5Ulr0Hg/vlcsnap-2020-01-10-11h15m40s688.png?format=1500w)

Source: https://www.cnckitchen.com/blog/gradient-infill-for-3d-prints

(I am not the author, just sending this PR so that Prusa developers can review @thenickdude's code contribution.)