### PR TITLE
#3550 - Leave purge volumes enabled.

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -899,7 +899,7 @@ void Tab::update_wiping_button_visibility() {
 
     auto wiping_dialog_button = wxGetApp().sidebar().get_wiping_dialog_button();
     if (wiping_dialog_button) {
-        wiping_dialog_button->Show(wipe_tower_enabled && multiple_extruders);
+        wiping_dialog_button->Show(multiple_extruders);
         wiping_dialog_button->GetParent()->Layout();
     }
 }


### PR DESCRIPTION
Small tweak to implement #3550  so custom toolchange gcode and post-processing scripts can benefit from easily editable purge volumes. Button is still hidden if there is no multiple extruder configuration.