### PR TITLE
#3534 - Calculate wipe volumes and expose them in toolchange custom gcode

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1358,6 +1358,9 @@ void GCode::_do_export(Print& print, FILE* file)
     if (! (has_wipe_tower && print.config().single_extruder_multi_material_priming)) {
         // Set initial extruder only after custom start G-code.
         // Ugly hack: Do not set the initial extruder if the extruder is primed using the MMU priming towers at the edge of the print bed.
+        DynamicConfig config;
+        config.set_key_value("extruder_purge_volume",new ConfigOptionFloat(0.0f)); // No wipe volume at initial Tx
+        m_placeholder_parser.set("extruder_purge_volume",new ConfigOptionFloat(0.0f));
         _write(file, this->set_extruder(initial_extruder_id, 0.));
     }
 
@@ -2178,6 +2181,18 @@ void GCode::process_layer(
     std::vector<std::unique_ptr<EdgeGrid::Grid>> lower_layer_edge_grids(layers.size());
     for (unsigned int extruder_id : layer_tools.extruders)
     {
+        int old_extruder_id = m_writer.extruder()->id();
+        std::tuple<float,int,int> key (print_z,old_extruder_id,extruder_id);
+        DynamicConfig config;
+
+        // Lookup the purge volume for this tool change and set it for use in custom gcode.
+        float purge_volume = 0.0f;
+        auto entry = print.tool_ordering().all_purge_volumes().find(key);
+        if (entry!=print.tool_ordering().all_purge_volumes().end())
+            purge_volume = entry->second;
+
+        config.set_key_value("extruder_purge_volume",new ConfigOptionFloat(purge_volume));
+        m_placeholder_parser.set("extruder_purge_volume",new ConfigOptionFloat(purge_volume));
         gcode += (layer_tools.has_wipe_tower && m_wipe_tower) ?
             m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back()) :
             this->set_extruder(extruder_id, print_z);

--- a/src/libslic3r/GCode/ToolOrdering.hpp
+++ b/src/libslic3r/GCode/ToolOrdering.hpp
@@ -158,6 +158,8 @@ public:
     // For a multi-material print, the printing extruders are ordered in the order they shall be primed.
     const std::vector<unsigned int>& all_extruders() const { return m_all_printing_extruders; }
 
+    const std::map<std::tuple<float,int,int>,float>& all_purge_volumes() const { return m_layer_wipe_volumes;}
+
     // Find LayerTools with the closest print_z.
     const LayerTools&	tools_for_layer(coordf_t print_z) const;
     LayerTools&			tools_for_layer(coordf_t print_z) { return const_cast<LayerTools&>(std::as_const(*this).tools_for_layer(print_z)); }
@@ -176,6 +178,7 @@ private:
     void				reorder_extruders(unsigned int last_extruder_id);
     void 				fill_wipe_tower_partitions(const PrintConfig &config, coordf_t object_bottom_z);
     void 				collect_extruder_statistics(bool prime_multi_material);
+    void                calculate_wipe_volumes(const Print &print);
 
     std::vector<LayerTools>    m_layer_tools;
     // First printing extruder, including the multi-material priming sequence.
@@ -184,6 +187,8 @@ private:
     unsigned int               m_last_printing_extruder  = (unsigned int)-1;
     // All extruders, which extrude some material over m_layer_tools.
     std::vector<unsigned int>  m_all_printing_extruders;
+    // A map of required purge volumes, old tool->new. Key is layer_z,old E, New E
+    std::map<std::tuple<float,int,int>,float> m_layer_wipe_volumes;
 
     const PrintConfig*         m_print_config_ptr = nullptr;
 };

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2083,7 +2083,8 @@ void PrintConfigDef::init_fff_params()
     def = this->add("toolchange_gcode", coString);
     def->label = L("Tool change G-code");
     def->tooltip = L("This custom code is inserted before every toolchange. Placeholder variables for all PrusaSlicer settings "
-                     "as well as {previous_extruder} and {next_extruder} can be used. When a tool-changing command "
+                     "as well as {previous_extruder} and {next_extruder} can be used. If the wipe tower is disabled, {extruder_purge_volume} is also"
+                     " available and provides the volume to purged, accounting for any infill/object wiping settings. When a tool-changing command "
                      "which changes to the correct extruder is included (such as T{next_extruder}), PrusaSlicer will emit no other such command. "
                      "It is therefore possible to script custom behaviour both before and after the toolchange.");
     def->multiline = true;


### PR DESCRIPTION
One of the requested features in #3534 which calculates and exposes the purge volume (while accounting for wipe-to-object/infill) to the custom_toolchange gcode. 
Best paired with my other PR/issue (#3550 #3573 ) that enables purge volumes to be set even if the wipe tower is disabled.
