### PR TITLE
Remove semi-duplicate string_printf template

### DIFF
--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -230,21 +230,8 @@ static inline bool is_approx(Number value, Number test_value)
     return std::fabs(double(value) - double(test_value)) < double(EPSILON);
 }
 
-template<class...Args>
-std::string string_printf(const char *const fmt, Args &&...args)
-{
-    static const size_t INITIAL_LEN = 1024;
-    std::vector<char> buffer(INITIAL_LEN, '\0');
-    
-    int bufflen = snprintf(buffer.data(), INITIAL_LEN - 1, fmt, std::forward<Args>(args)...);
-    
-    if (bufflen >= int(INITIAL_LEN)) {
-        buffer.resize(size_t(bufflen) + 1);
-        snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
-    }
-    
-    return std::string(buffer.begin(), buffer.begin() + bufflen);
-}
+std::string string_printf(const char *const format, ...)
+    __attribute__ ((format (printf, 1, 2)));
 
 } // namespace Slic3r
 

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -578,7 +578,7 @@ namespace PerlUtils {
 };
 
 
-std::string string_printf(const char *format, ...)
+std::string string_printf(const char *const format, ...)
 {
     va_list args1;
     va_start(args1, format);
@@ -591,6 +591,7 @@ std::string string_printf(const char *format, ...)
     std::string res(needed_size, '\0');
     ::vsnprintf(&res.front(), res.size(), format, args2);
     va_end(args2);
+	res.resize(needed_size-1);
 
     return res;
 }


### PR DESCRIPTION
The templated version doesn't work with gcc's -Werror=format-security

Long-term, we should use fmt::format (c++11) or std::string::format (c++20).

Closes:#3592.