### PR TITLE
Check for a required cereal library header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,8 +392,13 @@ if (NOT GLEW_FOUND)
 endif ()
 
 # Find the Cereal serialization library
+include(CheckIncludeFiles)
 add_library(cereal INTERFACE)
 target_include_directories(cereal INTERFACE include)
+CHECK_INCLUDE_FILES (cereal/cereal.hpp HAVE_CEREAL_H LANGUAGE CXX)
+if (NOT HAVE_CEREAL_H)
+  message(FATAL_ERROR "Cereal library not found. Please install the dependency.")
+endif()
 
 # l10n
 set(L10N_DIR "${SLIC3R_RESOURCES_DIR}/localization")


### PR DESCRIPTION
This closes #3547. I was also experiencing a similar issue when I ran `make install` so I turned that discussion into a PR so that hopefully nobody else has trouble with this. :smiley: 

The cereal library is not explicitly checked for as a dependency, so it would be nice if the library checked and said something about it during configuration.