### PR TITLE
Update BitmapCache.hpp

### DIFF
--- a/src/slic3r/GUI/BitmapCache.hpp
+++ b/src/slic3r/GUI/BitmapCache.hpp
@@ -6,6 +6,7 @@
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP
     #include <wx/wx.h>
+#include <vector>
 #endif
 
 namespace Slic3r { namespace GUI {


### PR DESCRIPTION
PrusaSlicer/src/slic3r/GUI/BitmapCache.hpp:9:1: «std::vector» is defined in header «<vector>»; did you forget to «#include <vector>»?