### PR TITLE
New "Uniform" fill pattern

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -117,20 +117,23 @@ public:
     float width;
     // Height of the extrusion, used for visualization purposes.
     float height;
+    // Flags that the extrusion path is oriented
+    bool no_sort;
 
-    ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), m_role(role) {};
-    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height) : mm3_per_mm(mm3_per_mm), width(width), height(height), m_role(role) {};
-    ExtrusionPath(const ExtrusionPath& rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
-    ExtrusionPath(ExtrusionPath&& rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
-    ExtrusionPath(const Polyline &polyline, const ExtrusionPath &rhs) : polyline(polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
-    ExtrusionPath(Polyline &&polyline, const ExtrusionPath &rhs) : polyline(std::move(polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role) {}
+    ExtrusionPath(ExtrusionRole role) : mm3_per_mm(-1), width(-1), height(-1), m_role(role), no_sort(false) {};
+    ExtrusionPath(ExtrusionRole role, double mm3_per_mm, float width, float height, bool no_sort = false) : mm3_per_mm(mm3_per_mm), width(width), height(height), m_role(role), no_sort(no_sort) {};
+    ExtrusionPath(const ExtrusionPath& rhs) : polyline(rhs.polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role), no_sort(rhs.no_sort) {}
+    ExtrusionPath(ExtrusionPath&& rhs) : polyline(std::move(rhs.polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role), no_sort(rhs.no_sort) {}
+    ExtrusionPath(const Polyline &polyline, const ExtrusionPath &rhs) : polyline(polyline), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role), no_sort(rhs.no_sort) {}
+    ExtrusionPath(Polyline &&polyline, const ExtrusionPath &rhs) : polyline(std::move(polyline)), mm3_per_mm(rhs.mm3_per_mm), width(rhs.width), height(rhs.height), m_role(rhs.m_role), no_sort(rhs.no_sort) {}
 
-    ExtrusionPath& operator=(const ExtrusionPath& rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = rhs.polyline; return *this; }
-    ExtrusionPath& operator=(ExtrusionPath&& rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = std::move(rhs.polyline); return *this; }
+    ExtrusionPath& operator=(const ExtrusionPath& rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = rhs.polyline; this->no_sort = rhs.no_sort; return *this; }
+    ExtrusionPath& operator=(ExtrusionPath&& rhs) { m_role = rhs.m_role; this->mm3_per_mm = rhs.mm3_per_mm; this->width = rhs.width; this->height = rhs.height; this->polyline = std::move(rhs.polyline); this->no_sort = rhs.no_sort; return *this; }
 
 	ExtrusionEntity* clone() const override { return new ExtrusionPath(*this); }
     // Create a new object, initialize it with this object using the move semantics.
 	ExtrusionEntity* clone_move() override { return new ExtrusionPath(std::move(*this)); }
+    bool can_reverse() const override { return !this->no_sort; }
     void reverse() override { this->polyline.reverse(); }
     const Point& first_point() const override { return this->polyline.points.front(); }
     const Point& last_point() const override { return this->polyline.points.back(); }
@@ -301,23 +304,23 @@ inline void extrusion_paths_append(ExtrusionPaths &dst, Polylines &&polylines, E
     polylines.clear();
 }
 
-inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines &polylines, ExtrusionRole role, double mm3_per_mm, float width, float height)
+inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines &polylines, ExtrusionRole role, double mm3_per_mm, float width, float height, bool no_sort = false)
 {
     dst.reserve(dst.size() + polylines.size());
     for (Polyline &polyline : polylines)
         if (polyline.is_valid()) {
-            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
+            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height, no_sort);
             dst.push_back(extrusion_path);
             extrusion_path->polyline = polyline;
         }
 }
 
-inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines &&polylines, ExtrusionRole role, double mm3_per_mm, float width, float height)
+inline void extrusion_entities_append_paths(ExtrusionEntitiesPtr &dst, Polylines &&polylines, ExtrusionRole role, double mm3_per_mm, float width, float height, bool no_sort = false)
 {
     dst.reserve(dst.size() + polylines.size());
     for (Polyline &polyline : polylines)
         if (polyline.is_valid()) {
-            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height);
+            ExtrusionPath *extrusion_path = new ExtrusionPath(role, mm3_per_mm, width, height, no_sort);
             dst.push_back(extrusion_path);
             extrusion_path->polyline = std::move(polyline);
         }

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -390,12 +390,11 @@ void Layer::make_fills()
 		        // Save into layer.
 		        auto *eec = new ExtrusionEntityCollection();
 		        m_regions[surface_fill.region_id]->fills.entities.push_back(eec);
-		        // Only concentric fills are not sorted.
-		        eec->no_sort = f->no_sort();
 		        extrusion_entities_append_paths(
 		            eec->entities, std::move(polylines),
 		            surface_fill.params.extrusion_role,
-		            flow_mm3_per_mm, float(flow_width), surface_fill.params.flow.height);
+		            flow_mm3_per_mm, float(flow_width), surface_fill.params.flow.height,
+                    f->no_sort());
 		    }
 		}
     }

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -37,6 +37,7 @@ Fill* Fill::new_from_type(const InfillPattern type)
     case ipArchimedeanChords:   return new FillArchimedeanChords();
     case ipHilbertCurve:        return new FillHilbertCurve();
     case ipOctagramSpiral:      return new FillOctagramSpiral();
+    case ipUniform:             return new FillUniform();
     default: throw std::invalid_argument("unknown type");
     }
 }

--- a/src/libslic3r/Fill/FillRectilinear2.cpp
+++ b/src/libslic3r/Fill/FillRectilinear2.cpp
@@ -1061,12 +1061,25 @@ bool FillRectilinear2::fill_surface_by_lines(const Surface *surface, const FillP
                     // Even number of intersections with the loops.
                     assert((seg.intersections.size() & 1) == 0);
                     assert(seg.intersections.front().type == SegmentIntersection::OUTER_LOW);
-                    for (size_t i = 0; i < seg.intersections.size(); ++ i) {
 
-                        // In uniform mode, pick the first intersection according to an even/odd rule to set the
-                        // vertical direction in a consistent alternating pattern
-                        if (uniform && (i_vline2 & 1))
-                            i = (i + 1) % seg.intersections.size();
+                    // In uniform mode, pick intersections according to an even/odd rule to set the
+                    // vertical direction in a consistent alternating pattern.
+                    size_t i;
+                    if (uniform) {
+                        // select initial set
+                        i = (i_vline2 & 1);
+                    }
+
+                    for (size_t n = 0; n < seg.intersections.size(); ++ n) {
+                        if (!uniform) {
+                            // iterate normally
+                            i = n;
+                        } else {
+                            // cycle through same parity sets in two passes
+                            i += 2;
+                            if (i >= seg.intersections.size())
+                                i = !(i % 2);
+                        }
 
                         const SegmentIntersection &intrsctn = seg.intersections[i];
                         if (intrsctn.is_outer()) {

--- a/src/libslic3r/Fill/FillRectilinear2.hpp
+++ b/src/libslic3r/Fill/FillRectilinear2.hpp
@@ -18,6 +18,9 @@ public:
 
 protected:
 	bool fill_surface_by_lines(const Surface *surface, const FillParams &params, float angleBase, float pattern_shift, Polylines &polylines_out);
+
+	// Enabled for uniform infill to enforce a consistent filling direction
+	virtual bool _uniform_direction() const { return false; }
 };
 
 class FillGrid2 : public FillRectilinear2
@@ -68,6 +71,16 @@ protected:
     virtual float _layer_angle(size_t idx) const { return 0.f; }
 };
 
+class FillUniform : public FillRectilinear2
+{
+public:
+    virtual Fill* clone() const { return new FillUniform(*this); };
+    virtual ~FillUniform() {}
+    virtual bool no_sort() const { return true; }
+
+protected:
+    virtual bool _uniform_direction() const { return true; }
+};
 
 }; // namespace Slic3r
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -418,11 +418,13 @@ void PrintConfigDef::init_fff_params()
     def->cli = "top-fill-pattern|external-fill-pattern|solid-fill-pattern";
     def->enum_keys_map = &ConfigOptionEnum<InfillPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
+    def->enum_values.push_back("uniform");
     def->enum_values.push_back("concentric");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
     def->enum_values.push_back("octagramspiral");
     def->enum_labels.push_back(L("Rectilinear"));
+    def->enum_labels.push_back(L("Uniform"));
     def->enum_labels.push_back(L("Concentric"));
     def->enum_labels.push_back(L("Hilbert Curve"));
     def->enum_labels.push_back(L("Archimedean Chords"));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -35,7 +35,7 @@ enum PrintHostType {
 
 enum InfillPattern {
     ipRectilinear, ipGrid, ipTriangles, ipStars, ipCubic, ipLine, ipConcentric, ipHoneycomb, ip3DHoneycomb,
-    ipGyroid, ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral, ipCount,
+    ipGyroid, ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral, ipUniform, ipCount,
 };
 
 enum SupportMaterialPattern {
@@ -118,6 +118,7 @@ template<> inline const t_config_enum_values& ConfigOptionEnum<InfillPattern>::g
         keys_map["hilbertcurve"]        = ipHilbertCurve;
         keys_map["archimedeanchords"]   = ipArchimedeanChords;
         keys_map["octagramspiral"]      = ipOctagramSpiral;
+        keys_map["uniform"]             = ipUniform;
     }
     return keys_map;
 }

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -38,7 +38,7 @@ std::vector<std::pair<size_t, bool>> chain_segments_closest_point(std::vector<En
     	// Ignore the starting point as the starting point is considered to be occupied, no end point coud connect to it.
 		size_t next_idx = find_closest_point(kdtree, this_point.pos,
 			[this_idx, &end_points, &could_reverse_func](size_t idx) {
-				return (idx ^ this_idx) > 1 && end_points[idx].chain_id == 0 && ((idx ^ 1) == 0 || could_reverse_func(idx >> 1));
+				return (idx ^ this_idx) > 1 && end_points[idx].chain_id == 0 && ((idx & 1) == 0 || could_reverse_func(idx >> 1));
 		});
 		assert(next_idx < end_points.size());
 		EndPointType &end_point = end_points[next_idx];

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -28,6 +28,7 @@ std::vector<std::pair<size_t, bool>> chain_segments_closest_point(std::vector<En
 	std::vector<std::pair<size_t, bool>> out;
 	out.reserve(num_segments);
 	size_t first_point_idx = &first_point - end_points.data();
+	assert((first_point_idx & 1) == 0 || could_reverse_func(first_point_idx >> 1));
 	out.emplace_back(first_point_idx / 2, (first_point_idx & 1) != 0);
 	first_point.chain_id = 1;
 	size_t this_idx = first_point_idx ^ 1;
@@ -161,11 +162,12 @@ std::vector<std::pair<size_t, bool>> chain_segments_greedy_constrained_reversals
 			std::vector<size_t> m_equivalent_with;
 		} equivalent_chain(num_segments);
 
-		// Find the first end point closest to start_near.
+		// Find the first end point closest to start_near with matching orientation.
 		EndPoint *first_point = nullptr;
 		size_t    first_point_idx = std::numeric_limits<size_t>::max();
 		if (start_near != nullptr) {
-            size_t idx = find_closest_point(kdtree, start_near->template cast<double>());
+            size_t idx = find_closest_point(kdtree, start_near->template cast<double>(),
+                    [&could_reverse_func](size_t idx) { return (idx & 1) == 0 || could_reverse_func(idx >> 1); });
 			assert(idx < end_points.size());
 			first_point = &end_points[idx];
 			first_point->distance_out = 0.;


### PR DESCRIPTION
This PR implements a new infill mode, called (for the lack of a better idea) "Uniform".

"Uniform" is essentially rectilinear infill where the filling direction for the layer is oriented and fixed in a consistent ltr or rtl pattern.

Uniform infill is mostly useful as a top layer to improve its visual appearance by reducing the effect of the different reflections caused by a randomly changing filling direction. This effect is mostly visible with PLA or PETG and gives the printed piece the typical patchwork look on the top we're all used-to. By locking the direction of the infill, the piece looks more "uniform" when viewed from the same angle, giving it a more "polished" look. The piece is either always shiny or always dull, but the patchwork effect is mostly gone.

Some pictures. This is a test piece I printed twice, once with regular "rectilinear" infill on top, and once with "uniform". The material is black PETG, which is annoyingly shiny. In the following pictures the pieces are swapped between the left/right image so you can see the different effects of the reflections better (I couldn't record a good video, sorry). The print using "Uniform" infill is highlighted with a yellow dot, but you can always tell:

![IMG_20200308_202238](https://user-images.githubusercontent.com/1017726/76239709-50b2bf80-6232-11ea-9ca5-51112aa85532.jpg)
![IMG_20200308_202420](https://user-images.githubusercontent.com/1017726/76239714-51e3ec80-6232-11ea-9884-2a89be3780fe.jpg)
![IMG_20200308_202802](https://user-images.githubusercontent.com/1017726/76239715-51e3ec80-6232-11ea-8cf7-cfc06f665b30.jpg)

There are still some minor visible changes (below the letter "L"), but these are due to small changes in temperature while printing (small area getting hotter). Large infill areas are less susceptible to this effect.

The constrained orientation might overall increase the number of travels so "Uniform" is still a trade-off, and might not be worth for matte materials. The increase of travels though is still very minor, generally very close to Rectilinear, and IMHO something you can use almost always as a top layer (as opposed to something much slower, like ironing).

Coming to the details.

We implement Uniform by changing FillRectilinear2. There are only two small changes, so I didn't want to duplicate too much code. We add a new virtual method in FillRectilinear2 to control the new ordering behavior. While filling, the visiting order of the intersections is tweaked to favor an even/odd rule matching the current vertical intersection, which forces fills on the same intersecting line to choose always the same orientation. Similarly, when connecting between vertical lines, only one direction is allowed, forcing the overall fill direction. This change, by itself, is pretty simple. FillUniform is just an empty shell to control this behavior.

The major significant change is that we add "no_sort" (previously only in ExtrustionPathCollection) directly in ExtrustionPath. The problem is that all the individual paths coming from different parts in the same layer are collected in a single ExtrusionPathCollection late during slicing. Fixing the order of all the extrusions would prevent travels to be optimized for _all_ parts. It's sensible (and very useful) to think that one might have only a single ExtrusionPath which needs to be directed while still allowing other parts to be reversed freely, so I opted to do so.

``chain_segments_greedy_constrained_reversals`` already handles these cases. I discovered two small issues with it (fixed in the first two commits) that were required to make it work in all cases. I've seen that there's a ``chain_segments_greedy_constrained_reversals2`` function too, so the fix might need to be applied there as well.

ExtrustionPathCollection still has "no_sort", but with this change it's unused. The flag is set for each ExtrusionPath in Layer::make_fills, which fixes Octagram when combined with other parts. 

Technically, both FillOctagram and FillUniform can still be "reversed" in full without changing their behavior so I didn't remove "no_sort" from ExtrusionPathCollection. However, it's clearly not handled correctly at this moment (we would need to be able to nest PathCollections instead of appending individual extrusions to handle these cases correctly).

I'm open to alternative solutions and/or naming!