### PR TITLE
Additional Top/Bottom Infill Angle parameters

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -135,9 +135,10 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		                    (surface.is_top() ? erTopSolidInfill : erSolidInfill) :
 		                    erInternalInfill);
 		        params.bridge_angle = float(surface.bridge_angle);
-		        params.angle 		= float(Geometry::deg2rad(layerm.region()->config().fill_angle.value));
-		        
-		        // calculate the actual flow we'll be using for this infill
+		        params.angle = float(Geometry::deg2rad(!surface.is_external() ? layerm.region()->config().fill_angle.value :
+								(surface.is_top() ? layerm.region()->config().top_fill_angle.value : layerm.region()->config().bottom_fill_angle.value)));
+
+			// calculate the actual flow we'll be using for this infill
 		        params.flow = layerm.region()->flow(
 		            extrusion_role,
 		            (surface.thickness == -1) ? layer.height : surface.thickness, 	// extrusion height

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -142,7 +142,9 @@ std::pair<float, Point> Fill::_infill_direction(const Surface *surface) const
         out_angle = surface->bridge_angle;
     } else if (this->layer_id != size_t(-1)) {
         // alternate fill direction
-        out_angle += this->_layer_angle(this->layer_id / surface->thickness_layers);
+        if (!surface->is_top()) {
+            out_angle += this->_layer_angle(this->layer_id / surface->thickness_layers);
+        }
     } else {
 //    	printf("Layer_ID undefined!\n");
     }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -783,6 +783,28 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(45));
 
+    def = this->add("top_fill_angle", coFloat);
+    def->label = L("Top fill angle");
+    def->category = L("Infill");
+    def->tooltip = L("Angle for the top fill orientation. "
+	           "It only affects the top visible layer, but not its adjacent solid shells.");
+    def->sidetext = L("°");
+    def->min = 0;
+    def->max = 360;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(45));
+
+    def = this->add("bottom_fill_angle", coFloat);
+    def->label = L("Bottom fill angle");
+    def->category = L("Infill");
+    def->tooltip = L("Angle for the bottom fill orientation. "
+	           "It only affects the bottom external visible layer, but not its adjacent solid shells.");
+    def->sidetext = L("°");
+    def->min = 0;
+    def->max = 360;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(45));
+
     def = this->add("fill_density", coPercent);
     def->gui_type = "f_enum_open";
     def->gui_flags = "show_value";

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -477,6 +477,8 @@ public:
     ConfigOptionBool                external_perimeters_first;
     ConfigOptionBool                extra_perimeters;
     ConfigOptionFloat               fill_angle;
+    ConfigOptionFloat               top_fill_angle;
+    ConfigOptionFloat               bottom_fill_angle;
     ConfigOptionPercent             fill_density;
     ConfigOptionEnum<InfillPattern> fill_pattern;
     ConfigOptionFloat               gap_fill_speed;
@@ -522,6 +524,8 @@ protected:
         OPT_PTR(external_perimeters_first);
         OPT_PTR(extra_perimeters);
         OPT_PTR(fill_angle);
+        OPT_PTR(top_fill_angle);
+        OPT_PTR(bottom_fill_angle);
         OPT_PTR(fill_density);
         OPT_PTR(fill_pattern);
         OPT_PTR(gap_fill_speed);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -521,6 +521,8 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "bottom_fill_pattern"
             || opt_key == "external_fill_link_max_length"
             || opt_key == "fill_angle"
+            || opt_key == "top_fill_angle"
+            || opt_key == "bottom_fill_angle"
             || opt_key == "fill_pattern"
             || opt_key == "fill_link_max_length"
             || opt_key == "top_infill_extrusion_width"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -246,8 +246,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     bool has_bottom_solid_infill = config->opt_int("bottom_solid_layers") > 0;
     bool has_solid_infill 		 = has_top_solid_infill || has_bottom_solid_infill;
     // solid_infill_extruder uses the same logic as in Print::extruders()
-    for (auto el : { "top_fill_pattern", "bottom_fill_pattern", "infill_first", "solid_infill_extruder",
-                    "solid_infill_extrusion_width", "solid_infill_speed" })
+    for (auto el : { "top_fill_pattern", "bottom_fill_pattern", "top_fill_angle", "bottom_fill_angle",
+                     "infill_first", "solid_infill_extruder", "solid_infill_extrusion_width", "solid_infill_speed" })
         toggle_field(el, has_solid_infill);
 
     for (auto el : { "fill_angle", "bridge_angle", "infill_extrusion_width",

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -404,8 +404,8 @@ const std::vector<std::string>& Preset::print_options()
         "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
         "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs",
         "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
-        "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
-        "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", "max_print_speed",
+        "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "top_fill_angle", "bottom_fill_angle",
+        "bridge_angle", "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", "max_print_speed",
         "max_volumetric_speed",
 #ifdef HAS_PRESSURE_EQUALIZER
         "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1169,6 +1169,8 @@ void TabPrint::build()
         optgroup = page->new_optgroup(_(L("Advanced")));
         optgroup->append_single_option_line("solid_infill_every_layers");
         optgroup->append_single_option_line("fill_angle");
+        optgroup->append_single_option_line("top_fill_angle");
+        optgroup->append_single_option_line("bottom_fill_angle");
         optgroup->append_single_option_line("solid_infill_below_area");
         optgroup->append_single_option_line("bridge_angle");
         optgroup->append_single_option_line("only_retract_when_crossing_perimeters");


### PR DESCRIPTION
Although the slicer allows to select the top/bottom solid infill pattern, the very same infill angle is used for all layers. This, combined with the fill direction alternation, makes sometimes impossible to unify the surface layer pattern. My pull request aims to split the common "fill_angle" parameter into three:

1. The well known "fill_angle" is now used for all inner infills.
2. The new "top_fill_angle" specifies the infill angle for the top surface layer.
3. The additional "bottom_fill_angle" can be used to set the infill angle of the base layer.

I hope you will find this addition useful.