### PR TITLE
Also search vendor directory for printer profile resources.

### DIFF
--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -338,8 +338,11 @@ static std::string system_print_bed_model(const Preset &preset)
 {
 	std::string out;
 	const VendorProfile::PrinterModel *pm = PresetUtils::system_printer_model(preset);
-	if (pm != nullptr && ! pm->bed_model.empty())
+	if (pm != nullptr && ! pm->bed_model.empty()) {
+	    out = Slic3r::data_dir() + "/vendor/" + preset.vendor->id + "/" + pm->bed_model;
+	    if (! boost::filesystem::exists(boost::filesystem::path(out)))
 		out = Slic3r::resources_dir() + "/profiles/" + preset.vendor->id + "/" + pm->bed_model;
+	}
 	return out;
 }
 
@@ -347,8 +350,11 @@ static std::string system_print_bed_texture(const Preset &preset)
 {
 	std::string out;
 	const VendorProfile::PrinterModel *pm = PresetUtils::system_printer_model(preset);
-	if (pm != nullptr && ! pm->bed_texture.empty())
+	if (pm != nullptr && ! pm->bed_texture.empty()) {
+	    out = Slic3r::data_dir() + "/vendor/" + preset.vendor->id + "/" + pm->bed_texture;
+	    if (! boost::filesystem::exists(boost::filesystem::path(out)))
 		out = Slic3r::resources_dir() + "/profiles/" + preset.vendor->id + "/" + pm->bed_texture;
+	}
 	return out;
 }
 

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -188,22 +188,28 @@ PrinterPicker::PrinterPicker(wxWindow *parent, const VendorProfile &vendor, wxSt
 
         wxBitmap bitmap;
         int bitmap_width = 0;
-        const wxString bitmap_file = GUI::from_u8(Slic3r::resources_dir() + "/profiles/" + vendor.id + "/" + model.id + "_thumbnail.png");
-        if (wxFileExists(bitmap_file)) {
+	const wxString bitmap_file = GUI::from_u8(Slic3r::data_dir() + "/vendor/" + vendor.id + "/" + model.id + "_thumbnail.png");
+	if (wxFileExists(bitmap_file)) {
             bitmap.LoadFile(bitmap_file, wxBITMAP_TYPE_PNG);
             bitmap_width = bitmap.GetWidth();
         } else {
-            BOOST_LOG_TRIVIAL(warning) << boost::format("Can't find bitmap file `%1%` for vendor `%2%`, printer `%3%`, using placeholder icon instead")
-                % bitmap_file
-                % vendor.id
-                % model.id;
+ 	    const wxString bitmap_file = GUI::from_u8(Slic3r::resources_dir() + "/profiles/" + vendor.id + "/" + model.id + "_thumbnail.png");
+	    if (wxFileExists(bitmap_file)) {
+		bitmap.LoadFile(bitmap_file, wxBITMAP_TYPE_PNG);
+		bitmap_width = bitmap.GetWidth();
+	    } else {
+		BOOST_LOG_TRIVIAL(warning) << boost::format("Can't find bitmap file `%1%` for vendor `%2%`, printer `%3%`, using placeholder icon instead")
+		    % bitmap_file
+		    % vendor.id
+		    % model.id;
 
-            const wxString placeholder_file = GUI::from_u8(Slic3r::var(PRINTER_PLACEHOLDER));
-            if (wxFileExists(placeholder_file)) {
-                bitmap.LoadFile(placeholder_file, wxBITMAP_TYPE_PNG);
-                bitmap_width = bitmap.GetWidth();
-            }
-        }
+		const wxString placeholder_file = GUI::from_u8(Slic3r::var(PRINTER_PLACEHOLDER));
+		if (wxFileExists(placeholder_file)) {
+		    bitmap.LoadFile(placeholder_file, wxBITMAP_TYPE_PNG);
+		    bitmap_width = bitmap.GetWidth();
+		}
+	    }
+	}
 
         auto *title = new wxStaticText(this, wxID_ANY, model.name, wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
         title->SetFont(font_name);


### PR DESCRIPTION
A few small changes to search the `<data_dir>/vendor` directory in the same fashion as the `<resources_dir>/profiles` directory when looking for thumbnail, bed_model, and bed_texture files. This patch allows a complete, "Config Wizard"-friendly custom vendor profile to be placed in the (user's configuration) vendor directory -- useful for one-off vendor profiles not directly supported by PrusaSlicer and PrusaSlicer-settings.

Along with pull request #4129, may resolve issues #2306, #2560, and #3398.