### PR TITLE
Add a preference item to allow updating Presets from non-Prusa sites

### DIFF
--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -84,6 +84,14 @@ void PreferencesDialog::build()
 	option = Option (def, "preset_update");
 	m_optgroup_general->append_single_option_line(option);
 
+	// Please keep in sync with ../Utils/PresetUpdater.cpp
+	def.label = L("Allow updating Presets from non-Prusa sites");
+	def.type = coBool;
+	def.tooltip = L("If enabled, Slic3r will also allow updates of built-in system presets from URLs other than the official Prusa URL.");
+	def.set_default_value(new ConfigOptionBool(app_config->get("preset_update_allow_foreign") == "1"));
+	option = Option (def, "preset_update_allow_foreign");
+	m_optgroup_general->append_single_option_line(option);
+
 	def.label = L("Suppress \" - default - \" presets");
 	def.type = coBool;
 	def.tooltip = L("Suppress \" - default - \" presets in the Print / Filament / Printer "

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -144,6 +144,7 @@ struct PresetUpdater::priv
 
 	bool enabled_version_check;
 	bool enabled_config_update;
+	bool enabled_allow_foreign;
 	std::string version_check_url;
 
 	fs::path cache_path;
@@ -185,6 +186,7 @@ void PresetUpdater::priv::set_download_prefs(AppConfig *app_config)
 	enabled_version_check = app_config->get("version_check") == "1";
 	version_check_url = app_config->version_check_url();
 	enabled_config_update = app_config->get("preset_update") == "1" && !app_config->legacy_datadir();
+	enabled_allow_foreign = app_config->get("preset_update_allow_foreign") == "1";
 }
 
 // Downloads a file (http get operation). Cancels if the Updater is being destroyed.
@@ -302,7 +304,8 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors)
 		const auto idx_url = vendor.config_update_url + "/" + INDEX_FILENAME;
 		const std::string idx_path = (cache_path / (vendor.id + ".idx")).string();
 		const std::string idx_path_temp = idx_path + "-update";
-		//check if idx_url is leading to our site 
+		//check if idx_url is leading to our site
+		if (! enabled_allow_foreign)
 		if (! boost::starts_with(idx_url, "http://files.prusa3d.com/wp-content/uploads/repository/"))
 		{
 			BOOST_LOG_TRIVIAL(warning) << "unsafe url path for vendor \"" << vendor.name << "\" rejected: " << idx_url;


### PR DESCRIPTION
When updating system presets (vendor bundles), the application currently blocks access to any URL that does not match Prusa Research's "official" update URL. This patch adds a preference item that lets the user override this behavior, that is, it allows the application to update system presets from URLs other than the official PrusaResearch URL. Since the user directly controls this new behavior, I think the patch mitigates much of any "security risk" and preserves the intent of the code's original behavior. This change extends the program's "standard" updating process to support experimental, limited-appeal, or one-off vendor profiles that are not directly supported by PrusaSlicer and PrusaSlicer-settings.

Along with pull request #4122, may resolve issues #2306, #2560, and #3398.