### PR TITLE
coPercent uses 100 as mult and not 1 like for coPercentAndFloat

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3361,6 +3361,11 @@ std::string FullPrintConfig::validate()
         switch (opt->type()) {
         case coFloat:
         case coPercent:
+        {
+            auto* fopt = static_cast<const ConfigOptionPercent*>(opt);
+            out_of_range = fopt->get_abs_value(100) < optdef->min || fopt->get_abs_value(100) > optdef->max;
+            break;
+        }
         case coFloatOrPercent:
         {
             auto *fopt = static_cast<const ConfigOptionFloat*>(opt);


### PR DESCRIPTION
see coPercents to check.
same for max of infill_ratio.