### PR TITLE
"None" is defined as zero in X11.h

### DIFF
--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -434,7 +434,7 @@ void Bed3D::render_texture(bool bottom, GLCanvas3D& canvas) const
             // generate a temporary lower resolution texture to show while no main texture levels have been compressed
             if ((m_temp_texture.get_id() == 0) || (m_temp_texture.get_source() != m_texture_filename))
             {
-                if (!m_temp_texture.load_from_file(m_texture_filename, false, GLTexture::None, false))
+                if (!m_temp_texture.load_from_file(m_texture_filename, false, GLTexture::None_, false))
                 {
                     render_default(bottom);
                     return;

--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -369,7 +369,7 @@ void GLTexture::render_sub_texture(unsigned int tex_id, float left, float right,
 
 bool GLTexture::load_from_png(const std::string& filename, bool use_mipmaps, ECompressionType compression_type, bool apply_anisotropy)
 {
-    bool compression_enabled = (compression_type != None) && GLEW_EXT_texture_compression_s3tc;
+    bool compression_enabled = (compression_type != None_) && GLEW_EXT_texture_compression_s3tc;
 
     // Load a PNG with an alpha channel.
     wxImage image;

--- a/src/slic3r/GUI/GLTexture.hpp
+++ b/src/slic3r/GUI/GLTexture.hpp
@@ -57,7 +57,7 @@ namespace GUI {
     public:
         enum ECompressionType : unsigned char
         {
-            None,
+            None_,
             SingleThreaded,
             MultiThreaded
         };

--- a/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
@@ -57,7 +57,7 @@ namespace CommonGizmosDataObjects {
 // Each gizmo can tell which of the data it wants to use through
 // on_get_requirements() method.
 enum class CommonGizmosDataID {
-    None                 = 0,
+    None_                = 0,
     SelectionInfo        = 1 << 0,
     InstancesHider       = 1 << 1,
     HollowedMesh         = 1 << 2,


### PR DESCRIPTION
This X11 header gets included on my system (admittedly an eclectic mix of Debian testing and unstable).

The constant is (a) unused and (b) zero, so this change will not have any adverse effect.