### PR TITLE
Let a horizontal clearance radius of zero mean checking disabled

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1223,7 +1223,7 @@ std::string Print::validate() const
     if (extruders().empty())
         return L("The supplied settings will cause an empty print.");
 
-    if (m_config.complete_objects) {
+    if (m_config.complete_objects && m_config.extruder_clearance_radius.value > 0) {
     	if (! sequential_print_horizontal_clearance_valid(*this))
             return L("Some objects are too close; your extruder will collide with them.");
         if (! sequential_print_vertical_clearance_valid(*this))


### PR DESCRIPTION
This change allows a zero extruder clearance radius to mean no radial clearance checking. There are at least two use cases for this:

1) The ordinary MMU printing procedure means material change at every layer. There are circumstances when this is hard, for example when working with really soft filaments. If support material is low and allows for it, it can be possible to print out all support (supplied as an object) before commencing with the soft material. But this means placing the two objects on top of eachother.

2) Sometimes, for low structures, we can save material switches by printing the different materials as completely separate objects.

Setting radial clearance to zero to achieve this is the first thing at least a couple of people I know tried.