### PR TITLE
Add option to turn off inflation of the first layer under supports/rafts

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2104,6 +2104,13 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("support_material_inflate_first_layer", coBool);
+    def->label = L("Inflate first layer");
+    def->category = L("Support material");
+    def->tooltip = L("Inflate the first layer under the support/raft to help stabilize the support column");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("support_material_threshold", coInt);
     def->label = L("Overhang threshold");
     def->category = L("Support material");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -432,6 +432,7 @@ public:
     ConfigOptionFloat               support_material_spacing;
     ConfigOptionFloat               support_material_speed;
     ConfigOptionBool                support_material_synchronize_layers;
+    ConfigOptionBool                support_material_inflate_first_layer;
     // Overhang angle threshold.
     ConfigOptionInt                 support_material_threshold;
     ConfigOptionBool                support_material_with_sheath;
@@ -472,6 +473,7 @@ protected:
         OPT_PTR(support_material_spacing);
         OPT_PTR(support_material_speed);
         OPT_PTR(support_material_synchronize_layers);
+        OPT_PTR(support_material_inflate_first_layer);
         OPT_PTR(support_material_xy_spacing);
         OPT_PTR(support_material_threshold);
         OPT_PTR(support_material_with_sheath);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -514,6 +514,7 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
             || opt_key == "support_material_xy_spacing"
             || opt_key == "support_material_spacing"
             || opt_key == "support_material_synchronize_layers"
+            || opt_key == "support_material_inflate_first_layer"
             || opt_key == "support_material_threshold"
             || opt_key == "support_material_with_sheath"
             || opt_key == "dont_support_bridges"

--- a/src/libslic3r/SupportMaterial.cpp
+++ b/src/libslic3r/SupportMaterial.cpp
@@ -2155,7 +2155,7 @@ PrintObjectSupportMaterial::MyLayersPtr PrintObjectSupportMaterial::generate_raf
 {
     // How much to inflate the support columns to be stable. This also applies to the 1st layer, if no raft layers are to be printed.
     const float inflate_factor_fine      = float(scale_((m_slicing_params.raft_layers() > 1) ? 0.5 : EPSILON));
-    const float inflate_factor_1st_layer = float(scale_(3.)) - inflate_factor_fine;
+    const float inflate_factor_1st_layer = m_object_config->support_material_inflate_first_layer ? float(scale_(3.)) - inflate_factor_fine : 0;
     MyLayer       *contacts      = top_contacts    .empty() ? nullptr : top_contacts    .front();
     MyLayer       *interfaces    = interface_layers.empty() ? nullptr : interface_layers.front();
     MyLayer       *columns_base  = base_layers     .empty() ? nullptr : base_layers     .front();

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -417,7 +417,7 @@ const std::vector<std::string>& Preset::print_options()
         "bridge_acceleration", "first_layer_acceleration", "default_acceleration", "skirts", "skirt_distance", "skirt_height", "draft_shield",
         "min_skirt_length", "brim_width", "support_material", "support_material_auto", "support_material_threshold", "support_material_enforce_layers",
         "raft_layers", "support_material_pattern", "support_material_with_sheath", "support_material_spacing",
-        "support_material_synchronize_layers", "support_material_angle", "support_material_interface_layers",
+        "support_material_synchronize_layers","support_material_inflate_first_layer", "support_material_angle", "support_material_interface_layers",
         "support_material_interface_spacing", "support_material_interface_contact_loops", "support_material_contact_distance",
         "support_material_buildplate_only", "dont_support_bridges", "notes", "complete_objects", "extruder_clearance_radius",
         "extruder_clearance_height", "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "perimeter_extruder",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1337,6 +1337,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_material_xy_spacing");
         optgroup->append_single_option_line("dont_support_bridges");
         optgroup->append_single_option_line("support_material_synchronize_layers");
+        optgroup->append_single_option_line("support_material_inflate_first_layer");
 
     page = add_options_page(L("Speed"), "time");
         optgroup = page->new_optgroup(L("Speed for print moves"));


### PR DESCRIPTION
This is to add an option to disallow the inflated first layer underneath supports. I'm not sure how much stability this adds or when the best use case for it is, but I have been using Cura for a while and have not needed it.

The inflated single layer doesn't always come off very easy, and also comes out in lots of little pieces that end up everywhere.

This change will change the slicing from 
![image](https://user-images.githubusercontent.com/417561/82516771-3d00c080-9ae1-11ea-9f25-539586e5359c.png)

to 
![image](https://user-images.githubusercontent.com/417561/82516804-50139080-9ae1-11ea-91dc-96d3e59de96c.png)

The option was added as an Expert option in the Support Material options section
![image](https://user-images.githubusercontent.com/417561/82516931-8f41e180-9ae1-11ea-8906-4bab5002e9ad.png)

Please consider taking this pull request or implementing some option to allow control over this first layer.