### PR TITLE
#4062 Conversion of empty layer error to warning.

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -33,6 +33,7 @@
 #include <tbb/parallel_for.h>
 
 #include <Shiny/Shiny.h>
+#include <wx/msgdlg.h>
 
 #include "miniz_extension.hpp"
 
@@ -636,12 +637,14 @@ std::vector<GCode::LayerToPrint> GCode::collect_layers_to_print(const PrintObjec
             bool has_extrusions = (layer_to_print.object_layer && layer_to_print.object_layer->has_extrusions())
                                || (layer_to_print.support_layer && layer_to_print.support_layer->has_extrusions());
 
-            if (has_extrusions && layer_to_print.print_z() > maximal_print_z + 2. * EPSILON)
-                throw std::runtime_error(_(L("Empty layers detected, the output would not be printable.")) + "\n\n" +
+            if (has_extrusions && layer_to_print.print_z() > maximal_print_z + 2. * EPSILON){
+                wxString msg_text = _(L("Empty layers detected, the output would not be printable.")) + "\n\n" +
                     _(L("Object name")) + ": " + object.model_object()->name + "\n" + _(L("Print z")) + ": " +
                     std::to_string(layers_to_print.back().print_z()) + "\n\n" + _(L("This is "
                     "usually caused by negligibly small extrusions or by a faulty model. Try to repair "
-                    "the model or change its orientation on the bed.")));
+                    "the model or change its orientation on the bed."));
+                wxMessageDialog dialog (nullptr, msg_text, _(L("Warning")), wxICON_WARNING | wxOK);
+            }
             // Remember last layer with extrusions.
             last_extrusion_layer = &layers_to_print.back();
         }


### PR DESCRIPTION
This is a proposal only to solve #4062.
This enables printing with empty layers. Sometimes they are intentional. No text was altered but should be changed, probably (+translations). 