### PR TITLE
Move Label Objects to Printer Settings tab

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1480,7 +1480,6 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Output file"));
         optgroup->append_single_option_line("gcode_comments");
-        optgroup->append_single_option_line("gcode_label_objects");
         Option option = optgroup->get_option("output_filename_format");
         option.opt.full_width = true;
         optgroup->append_single_option_line(option);
@@ -2152,6 +2151,7 @@ void TabPrinter::build_fff()
 
         optgroup = page->new_optgroup(L("Print Host upload"));
         build_printhost(optgroup.get());
+        optgroup->append_single_option_line("gcode_label_objects");
 
         optgroup = page->new_optgroup(L("Firmware"));
         optgroup->append_single_option_line("gcode_flavor");


### PR DESCRIPTION
Moved gcode_label_objects to Print Host Upload tab since it's only ever going to be used with Octoprint and the CancelObject plugin. Issue #4314

I don't ever see a circumstance where you'd want this option on a single printing profile since this feature is printer/octoprint dependant.

Honestly, where's the harm in making this option default true anyway? It would improve gcode readability for a marginal filesize increase.