### PR TITLE
Add setting to control when bridge infill is used

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -74,6 +74,7 @@ bool Print::invalidate_state_by_config_options(const std::vector<t_config_option
         "before_layer_gcode",
         "between_objects_gcode",
         "bridge_acceleration",
+        "bridge_infill_threshold",
         "bridge_fan_speed",
         "colorprint_heights",
         "cooling",

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -61,6 +61,8 @@ public:
     coordf_t                    nozzle_dmr_avg(const PrintConfig &print_config) const;
     // Average diameter of nozzles participating on extruding this region.
     coordf_t                    bridging_height_avg(const PrintConfig &print_config) const;
+    // True if infill voids (computed from infill_density) are larger than bridge_infill_threshold.
+    bool                        needs_bridge_over_infill() const;
 
     // Collect 0-based extruder indices used to print this region's object.
 	void                        collect_object_printing_extruders(std::vector<unsigned int> &object_extruders) const;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -236,6 +236,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("bridge_infill_threshold", coFloat);
+    def->label = L("Bridge infill threshold");
+    def->tooltip = L("Forces bridge settings for the layer above infill where voids are larger than the specified area. "
+                    "The infill void area is computed from the infill density and infill extrusion width. "
+                    "Set to zero to force bridge settings for any layer above non-solid infill.");
+    def->sidetext = L("mm²");
+    def->min = 0;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloat(25.));
+
     def = this->add("bridge_speed", coFloat);
     def->label = L("Bridges");
     def->category = L("Speed");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -490,6 +490,7 @@ public:
     ConfigOptionFloat               bottom_solid_min_thickness;
     ConfigOptionFloat               bridge_flow_ratio;
     ConfigOptionFloat               bridge_speed;
+    ConfigOptionFloat               bridge_infill_threshold;
     ConfigOptionBool                ensure_vertical_shell_thickness;
     ConfigOptionEnum<InfillPattern> top_fill_pattern;
     ConfigOptionEnum<InfillPattern> bottom_fill_pattern;
@@ -540,6 +541,7 @@ protected:
         OPT_PTR(bottom_solid_layers);
         OPT_PTR(bottom_solid_min_thickness);
         OPT_PTR(bridge_flow_ratio);
+        OPT_PTR(bridge_infill_threshold);
         OPT_PTR(bridge_speed);
         OPT_PTR(ensure_vertical_shell_thickness);
         OPT_PTR(top_fill_pattern);

--- a/src/libslic3r/PrintRegion.cpp
+++ b/src/libslic3r/PrintRegion.cpp
@@ -65,6 +65,17 @@ coordf_t PrintRegion::bridging_height_avg(const PrintConfig &print_config) const
     return this->nozzle_dmr_avg(print_config) * sqrt(m_config.bridge_flow_ratio.value);
 }
 
+bool PrintRegion::needs_bridge_over_infill() const
+{
+    if (config().fill_density <= 0)
+        return false;
+    const double infill_extrusion_width = Flow::new_from_config_width(frInfill, m_config.infill_extrusion_width,
+        m_print->config().nozzle_diameter.get_at(extruder(frInfill) - 1), 0.2f, 0.f).width;
+    // Compute the unsupported area assuming a grid, which is pragmatically good enough for all infill types.
+    const double bridging_area = pow<double>(2.0 * 100.0 * infill_extrusion_width / config().fill_density - infill_extrusion_width, 2);
+    return bridging_area > config().bridge_infill_threshold;
+}
+
 void PrintRegion::collect_object_printing_extruders(const PrintConfig &print_config, const PrintRegionConfig &region_config, std::vector<unsigned int> &object_extruders)
 {
     // These checks reflect the same logic used in the GUI for enabling/disabling extruder selection fields.

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -407,7 +407,7 @@ const std::vector<std::string>& Preset::print_options()
         "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
         "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", 
     	"ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
-        "max_print_speed", "max_volumetric_speed",
+        "max_print_speed", "max_volumetric_speed", "bridge_infill_threshold",
 #ifdef HAS_PRESSURE_EQUALIZER
         "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative",
 #endif /* HAS_PRESSURE_EQUALIZER */

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1299,6 +1299,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("fill_angle");
         optgroup->append_single_option_line("solid_infill_below_area");
         optgroup->append_single_option_line("bridge_angle");
+        optgroup->append_single_option_line("bridge_infill_threshold");
         optgroup->append_single_option_line("only_retract_when_crossing_perimeters");
         optgroup->append_single_option_line("infill_first");
 


### PR DESCRIPTION
This fixes issue #3814 by adding a bridge_infill_threshold setting to control when bridge infill is applied. The change works by computing the average void area for the infill below the solid layer, and flagging the solid layer as stInternalBridge only if it's larger than the threshold value. Assuming a reasonable threshold is chosen, **this results in both reduced print times and stronger parts with no apparent reduction in print quality.**

The default bridge_infill_threshold value is 25mm², which has been reliable in all my testing with PLA and PETG, and means that on .4mm infill extrusion width you will get bridge infill at 15% infill density but not at 20% infill density.

I've been carrying this change in my local build and printing with it for the better part of a year with good results. It pairs very well with my perimeter fan speed controls in PR #2921, which I rely on when printing any structural parts.