### PR TITLE
Add support for RepetierServer

### DIFF
--- a/src/libslic3r/Format/SL1.cpp
+++ b/src/libslic3r/Format/SL1.cpp
@@ -77,7 +77,6 @@ void fill_slicerconf(ConfMap &m, const SLAPrint &print)
         "print_host"sv,
         "printhost_apikey"sv,
         "printhost_cafile"sv,
-        "repetier_group"sv,
         "repetier_slug"sv
     };
     

--- a/src/libslic3r/Format/SL1.cpp
+++ b/src/libslic3r/Format/SL1.cpp
@@ -77,7 +77,7 @@ void fill_slicerconf(ConfMap &m, const SLAPrint &print)
         "print_host"sv,
         "printhost_apikey"sv,
         "printhost_cafile"sv,
-        "repetier_slug"sv
+        "printhost_slug"sv
     };
     
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));

--- a/src/libslic3r/Format/SL1.cpp
+++ b/src/libslic3r/Format/SL1.cpp
@@ -76,7 +76,9 @@ void fill_slicerconf(ConfMap &m, const SLAPrint &print)
         "compatible_prints"sv,
         "print_host"sv,
         "printhost_apikey"sv,
-        "printhost_cafile"sv
+        "printhost_cafile"sv,
+        "repetier_group"sv,
+        "repetier_slug"sv
     };
     
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2342,7 +2342,6 @@ void GCode::append_full_config(const Print &print, std::string &str)
 		"print_host"sv,
 		"printhost_apikey"sv,
 		"printhost_cafile"sv,
-        "repetier_group"sv,
         "repetier_slug"sv
 	};
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2341,7 +2341,9 @@ void GCode::append_full_config(const Print &print, std::string &str)
 		"compatible_prints"sv,
 		"print_host"sv,
 		"printhost_apikey"sv,
-		"printhost_cafile"sv
+		"printhost_cafile"sv,
+        "repetier_group"sv,
+        "repetier_slug"sv
 	};
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));
 	auto is_banned = [](const std::string &key) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2342,7 +2342,7 @@ void GCode::append_full_config(const Print &print, std::string &str)
 		"print_host"sv,
 		"printhost_apikey"sv,
 		"printhost_cafile"sv,
-        "repetier_slug"sv
+        "printhost_slug"sv
 	};
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));
 	auto is_banned = [](const std::string &key) {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -119,13 +119,6 @@ void PrintConfigDef::init_common_params()
     def->tooltip = L("Name of the Repetier printer");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
-
-    def = this->add("repetier_group", coString);
-    def->label = L("Repetier Group");
-    def->tooltip = L("Name of the Repetier group that the G-code file will be sent to.");
-    def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionString(""));
-
     
     def = this->add("printhost_cafile", coString);
     def->label = L("HTTPS CA File");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -117,6 +117,7 @@ void PrintConfigDef::init_common_params()
     def = this->add("repetier_slug", coString);
     def->label = L("Repetier Printer");
     def->tooltip = L("Name of the Repetier printer");
+    def->gui_type = "select_open";
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
     

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -113,7 +113,20 @@ void PrintConfigDef::init_common_params()
                    "the API Key or the password required for authentication.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
+    
+    def = this->add("repetier_slug", coString);
+    def->label = L("Repetier Printer");
+    def->tooltip = L("Name of the Repetier printer");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionString(""));
 
+    def = this->add("repetier_group", coString);
+    def->label = L("Repetier Group");
+    def->tooltip = L("Name of the Repetier group that the G-code file will be sent to.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionString(""));
+
+    
     def = this->add("printhost_cafile", coString);
     def->label = L("HTTPS CA File");
     def->tooltip = L("Custom CA certificate file can be specified for HTTPS OctoPrint connections, in crt/pem format. "
@@ -1398,10 +1411,12 @@ void PrintConfigDef::init_fff_params()
     def->enum_values.push_back("duet");
     def->enum_values.push_back("flashair");
     def->enum_values.push_back("astrobox");
+    def->enum_values.push_back("repetier");
     def->enum_labels.push_back("OctoPrint");
     def->enum_labels.push_back("Duet");
     def->enum_labels.push_back("FlashAir");
     def->enum_labels.push_back("AstroBox");
+    def->enum_labels.push_back("Repetier");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<PrintHostType>(htOctoPrint));
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -114,9 +114,9 @@ void PrintConfigDef::init_common_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
     
-    def = this->add("repetier_slug", coString);
-    def->label = L("Repetier Printer");
-    def->tooltip = L("Name of the Repetier printer");
+    def = this->add("printhost_slug", coString);
+    def->label = L("Printer");
+    def->tooltip = L("Name of the printer");
     def->gui_type = "select_open";
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -939,7 +939,7 @@ public:
     ConfigOptionString              print_host;
     ConfigOptionString              printhost_apikey;
     ConfigOptionString              printhost_cafile;
-    ConfigOptionString              repetier_slug;
+    ConfigOptionString              printhost_slug;
     ConfigOptionString              serial_port;
     ConfigOptionInt                 serial_speed;
 
@@ -950,7 +950,7 @@ protected:
         OPT_PTR(print_host);
         OPT_PTR(printhost_apikey);
         OPT_PTR(printhost_cafile);
-        OPT_PTR(repetier_slug);
+        OPT_PTR(printhost_slug);
         OPT_PTR(serial_port);
         OPT_PTR(serial_speed);
     }

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -940,7 +940,6 @@ public:
     ConfigOptionString              printhost_apikey;
     ConfigOptionString              printhost_cafile;
     ConfigOptionString              repetier_slug;
-    ConfigOptionString              repetier_group;
     ConfigOptionString              serial_port;
     ConfigOptionInt                 serial_speed;
 
@@ -952,7 +951,6 @@ protected:
         OPT_PTR(printhost_apikey);
         OPT_PTR(printhost_cafile);
         OPT_PTR(repetier_slug);
-        OPT_PTR(repetier_group);
         OPT_PTR(serial_port);
         OPT_PTR(serial_speed);
     }

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -30,7 +30,7 @@ enum GCodeFlavor : unsigned char {
 };
 
 enum PrintHostType {
-    htOctoPrint, htDuet, htFlashAir, htAstroBox
+    htOctoPrint, htDuet, htFlashAir, htAstroBox, htRepetier
 };
 
 enum InfillPattern : int {
@@ -105,6 +105,7 @@ template<> inline const t_config_enum_values& ConfigOptionEnum<PrintHostType>::g
         keys_map["duet"]            = htDuet;
         keys_map["flashair"]        = htFlashAir;
         keys_map["astrobox"]        = htAstroBox;
+        keys_map["repetier"]        = htRepetier;
     }
     return keys_map;
 }
@@ -938,6 +939,8 @@ public:
     ConfigOptionString              print_host;
     ConfigOptionString              printhost_apikey;
     ConfigOptionString              printhost_cafile;
+    ConfigOptionString              repetier_slug;
+    ConfigOptionString              repetier_group;
     ConfigOptionString              serial_port;
     ConfigOptionInt                 serial_speed;
 
@@ -948,6 +951,8 @@ protected:
         OPT_PTR(print_host);
         OPT_PTR(printhost_apikey);
         OPT_PTR(printhost_cafile);
+        OPT_PTR(repetier_slug);
+        OPT_PTR(repetier_group);
         OPT_PTR(serial_port);
         OPT_PTR(serial_speed);
     }

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -175,6 +175,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/FlashAir.hpp
     Utils/AstroBox.cpp
     Utils/AstroBox.hpp
+    Utils/Repetier.cpp
+    Utils/Repetier.hpp
     Utils/PrintHost.cpp
     Utils/PrintHost.hpp
     Utils/Bonjour.cpp

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1868,7 +1868,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     , config(Slic3r::DynamicPrintConfig::new_from_defaults_keys({
         "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "skirts", "skirt_distance",
         "brim_width", "variable_layer_height", "serial_port", "serial_speed", "host_type", "print_host",
-        "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group", "nozzle_diameter", "single_extruder_multi_material",
+        "printhost_apikey", "printhost_cafile", "repetier_slug", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle",
         "extruder_colour", "filament_colour", "max_print_height", "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.
@@ -5062,10 +5062,14 @@ void Plater::send_gcode()
     }
     default_output_file = fs::path(Slic3r::fold_utf8_to_ascii(default_output_file.string()));
 
-    PrintHostSendDialog dlg(default_output_file, upload_job.printhost->can_start_print());
+    wxArrayString groups;
+    upload_job.printhost->get_groups(groups);
+    
+    PrintHostSendDialog dlg(default_output_file, upload_job.printhost->can_start_print(), groups);
     if (dlg.ShowModal() == wxID_OK) {
         upload_job.upload_data.upload_path = dlg.filename();
         upload_job.upload_data.start_print = dlg.start_print();
+        upload_job.upload_data.group       = dlg.group();
 
         p->export_gcode(fs::path(), false, std::move(upload_job));
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1868,7 +1868,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     , config(Slic3r::DynamicPrintConfig::new_from_defaults_keys({
         "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "skirts", "skirt_distance",
         "brim_width", "variable_layer_height", "serial_port", "serial_speed", "host_type", "print_host",
-        "printhost_apikey", "printhost_cafile", "nozzle_diameter", "single_extruder_multi_material",
+        "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle",
         "extruder_colour", "filament_colour", "max_print_height", "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1868,7 +1868,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     , config(Slic3r::DynamicPrintConfig::new_from_defaults_keys({
         "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "skirts", "skirt_distance",
         "brim_width", "variable_layer_height", "serial_port", "serial_speed", "host_type", "print_host",
-        "printhost_apikey", "printhost_cafile", "repetier_slug", "nozzle_diameter", "single_extruder_multi_material",
+        "printhost_apikey", "printhost_cafile", "printhost_slug", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle",
         "extruder_colour", "filament_colour", "max_print_height", "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -459,7 +459,7 @@ const std::vector<std::string>& Preset::printer_options()
             "printer_technology",
             "bed_shape", "bed_custom_texture", "bed_custom_model", "z_offset", "gcode_flavor", "use_relative_e_distances", "serial_port", "serial_speed",
             "use_firmware_retraction", "use_volumetric_e", "variable_layer_height",
-            "host_type", "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group",
+            "host_type", "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug",
             "single_extruder_multi_material", "start_gcode", "end_gcode", "before_layer_gcode", "layer_gcode", "toolchange_gcode",
             "color_change_gcode", "pause_print_gcode", "template_custom_gcode",
             "between_objects_gcode", "printer_vendor", "printer_model", "printer_variant", "printer_notes", "cooling_tube_retraction",
@@ -579,7 +579,7 @@ const std::vector<std::string>& Preset::sla_printer_options()
             "gamma_correction",
             "min_exposure_time", "max_exposure_time",
             "min_initial_exposure_time", "max_initial_exposure_time",
-            "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group",
+            "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug",
             "printer_notes",
             "inherits"
         };
@@ -715,20 +715,17 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 	auto opt_printhost_apikey_old = cfg_old.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_old = cfg_old.option<ConfigOptionString>("printhost_cafile");
     auto opt_repetier_slug_old    = cfg_old.option<ConfigOptionString>("repetier_slug");
-    auto opt_repetier_group_old   = cfg_old.option<ConfigOptionString>("repetier_group");
 
 	auto opt_print_host_new 	  = cfg_new.option<ConfigOptionString>("print_host");
 	auto opt_printhost_apikey_new = cfg_new.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_new = cfg_new.option<ConfigOptionString>("printhost_cafile");
     auto opt_repetier_slug_new    = cfg_new.option<ConfigOptionString>("repetier_slug");
-    auto opt_repetier_group_new   = cfg_new.option<ConfigOptionString>("repetier_group");
 
 	// If the new print host data is undefined, use the old data.
 	bool new_print_host_undefined = (opt_print_host_new 		== nullptr || opt_print_host_new		->empty()) &&
 									(opt_printhost_apikey_new 	== nullptr || opt_printhost_apikey_new	->empty()) &&
 									(opt_printhost_cafile_new 	== nullptr || opt_printhost_cafile_new	->empty()) &&
-                                    (opt_repetier_slug_new      == nullptr || opt_repetier_slug_new     ->empty()) &&
-                                    (opt_repetier_group_new     == nullptr || opt_repetier_group_new    ->empty());
+                                    (opt_repetier_slug_new      == nullptr || opt_repetier_slug_new     ->empty());
 	if (new_print_host_undefined)
 		return ProfileHostParams::Anonymized;
 
@@ -737,8 +734,8 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 			   (l != nullptr && r != nullptr && l->value == r->value);
 	};
 	return (opt_same(opt_print_host_old, opt_print_host_new) && opt_same(opt_printhost_apikey_old, opt_printhost_apikey_new) &&
-            opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new) && opt_same(opt_repetier_slug_old, opt_repetier_slug_new) &&
-		    opt_same(opt_repetier_group_old, opt_repetier_group_new)) ? ProfileHostParams::Same : ProfileHostParams::Different;
+            opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new) && opt_same(opt_repetier_slug_old, opt_repetier_slug_new))
+		    ? ProfileHostParams::Same : ProfileHostParams::Different;
 }
 
 static bool profile_print_params_same(const DynamicPrintConfig &cfg_old, const DynamicPrintConfig &cfg_new)
@@ -750,7 +747,7 @@ static bool profile_print_params_same(const DynamicPrintConfig &cfg_old, const D
                              "compatible_printers", "compatible_printers_condition", "inherits",
                              "print_settings_id", "filament_settings_id", "sla_print_settings_id", "sla_material_settings_id", "printer_settings_id",
                              "printer_model", "printer_variant", "default_print_profile", "default_filament_profile", "default_sla_print_profile", "default_sla_material_profile",
-                             "print_host", "printhost_apikey", "repetier_slug", "repetier_group",  "printhost_cafile" })
+                             "print_host", "printhost_apikey", "repetier_slug", "printhost_cafile" })
         diff.erase(std::remove(diff.begin(), diff.end(), key), diff.end());
     // Preset with the same name as stored inside the config exists.
     return diff.empty() && profile_host_params_same_or_anonymized(cfg_old, cfg_new) != ProfileHostParams::Different;
@@ -801,7 +798,6 @@ Preset& PresetCollection::load_external_preset(
 	    	opt_update("printhost_apikey");
 	    	opt_update("printhost_cafile");
             opt_update("repetier_slug");
-            opt_update("repetier_group");
 	    }
     }
     // Update the "inherits" field.

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -459,7 +459,7 @@ const std::vector<std::string>& Preset::printer_options()
             "printer_technology",
             "bed_shape", "bed_custom_texture", "bed_custom_model", "z_offset", "gcode_flavor", "use_relative_e_distances", "serial_port", "serial_speed",
             "use_firmware_retraction", "use_volumetric_e", "variable_layer_height",
-            "host_type", "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug",
+            "host_type", "print_host", "printhost_apikey", "printhost_cafile", "printhost_slug",
             "single_extruder_multi_material", "start_gcode", "end_gcode", "before_layer_gcode", "layer_gcode", "toolchange_gcode",
             "color_change_gcode", "pause_print_gcode", "template_custom_gcode",
             "between_objects_gcode", "printer_vendor", "printer_model", "printer_variant", "printer_notes", "cooling_tube_retraction",
@@ -579,7 +579,7 @@ const std::vector<std::string>& Preset::sla_printer_options()
             "gamma_correction",
             "min_exposure_time", "max_exposure_time",
             "min_initial_exposure_time", "max_initial_exposure_time",
-            "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug",
+            "print_host", "printhost_apikey", "printhost_cafile", "printhost_slug",
             "printer_notes",
             "inherits"
         };
@@ -714,18 +714,18 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 	auto opt_print_host_old 	  = cfg_old.option<ConfigOptionString>("print_host");
 	auto opt_printhost_apikey_old = cfg_old.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_old = cfg_old.option<ConfigOptionString>("printhost_cafile");
-    auto opt_repetier_slug_old    = cfg_old.option<ConfigOptionString>("repetier_slug");
+    auto opt_printhost_slug_old    = cfg_old.option<ConfigOptionString>("printhost_slug");
 
 	auto opt_print_host_new 	  = cfg_new.option<ConfigOptionString>("print_host");
 	auto opt_printhost_apikey_new = cfg_new.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_new = cfg_new.option<ConfigOptionString>("printhost_cafile");
-    auto opt_repetier_slug_new    = cfg_new.option<ConfigOptionString>("repetier_slug");
+    auto opt_printhost_slug_new    = cfg_new.option<ConfigOptionString>("printhost_slug");
 
 	// If the new print host data is undefined, use the old data.
 	bool new_print_host_undefined = (opt_print_host_new 		== nullptr || opt_print_host_new		->empty()) &&
 									(opt_printhost_apikey_new 	== nullptr || opt_printhost_apikey_new	->empty()) &&
 									(opt_printhost_cafile_new 	== nullptr || opt_printhost_cafile_new	->empty()) &&
-                                    (opt_repetier_slug_new      == nullptr || opt_repetier_slug_new     ->empty());
+                                    (opt_printhost_slug_new     == nullptr || opt_printhost_slug_new    ->empty());
 	if (new_print_host_undefined)
 		return ProfileHostParams::Anonymized;
 
@@ -734,7 +734,7 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 			   (l != nullptr && r != nullptr && l->value == r->value);
 	};
 	return (opt_same(opt_print_host_old, opt_print_host_new) && opt_same(opt_printhost_apikey_old, opt_printhost_apikey_new) &&
-            opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new) && opt_same(opt_repetier_slug_old, opt_repetier_slug_new))
+            opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new) && opt_same(opt_printhost_slug_old, opt_printhost_slug_new))
 		    ? ProfileHostParams::Same : ProfileHostParams::Different;
 }
 
@@ -747,7 +747,7 @@ static bool profile_print_params_same(const DynamicPrintConfig &cfg_old, const D
                              "compatible_printers", "compatible_printers_condition", "inherits",
                              "print_settings_id", "filament_settings_id", "sla_print_settings_id", "sla_material_settings_id", "printer_settings_id",
                              "printer_model", "printer_variant", "default_print_profile", "default_filament_profile", "default_sla_print_profile", "default_sla_material_profile",
-                             "print_host", "printhost_apikey", "repetier_slug", "printhost_cafile" })
+                             "print_host", "printhost_apikey", "printhost_slug", "printhost_cafile" })
         diff.erase(std::remove(diff.begin(), diff.end(), key), diff.end());
     // Preset with the same name as stored inside the config exists.
     return diff.empty() && profile_host_params_same_or_anonymized(cfg_old, cfg_new) != ProfileHostParams::Different;
@@ -797,7 +797,7 @@ Preset& PresetCollection::load_external_preset(
 	    	opt_update("print_host");
 	    	opt_update("printhost_apikey");
 	    	opt_update("printhost_cafile");
-            opt_update("repetier_slug");
+            opt_update("printhost_slug");
 	    }
     }
     // Update the "inherits" field.

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -459,7 +459,7 @@ const std::vector<std::string>& Preset::printer_options()
             "printer_technology",
             "bed_shape", "bed_custom_texture", "bed_custom_model", "z_offset", "gcode_flavor", "use_relative_e_distances", "serial_port", "serial_speed",
             "use_firmware_retraction", "use_volumetric_e", "variable_layer_height",
-            "host_type", "print_host", "printhost_apikey", "printhost_cafile",
+            "host_type", "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group",
             "single_extruder_multi_material", "start_gcode", "end_gcode", "before_layer_gcode", "layer_gcode", "toolchange_gcode",
             "color_change_gcode", "pause_print_gcode", "template_custom_gcode",
             "between_objects_gcode", "printer_vendor", "printer_model", "printer_variant", "printer_notes", "cooling_tube_retraction",
@@ -579,7 +579,7 @@ const std::vector<std::string>& Preset::sla_printer_options()
             "gamma_correction",
             "min_exposure_time", "max_exposure_time",
             "min_initial_exposure_time", "max_initial_exposure_time",
-            "print_host", "printhost_apikey", "printhost_cafile",
+            "print_host", "printhost_apikey", "printhost_cafile", "repetier_slug", "repetier_group",
             "printer_notes",
             "inherits"
         };
@@ -714,15 +714,21 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 	auto opt_print_host_old 	  = cfg_old.option<ConfigOptionString>("print_host");
 	auto opt_printhost_apikey_old = cfg_old.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_old = cfg_old.option<ConfigOptionString>("printhost_cafile");
+    auto opt_repetier_slug_old    = cfg_old.option<ConfigOptionString>("repetier_slug");
+    auto opt_repetier_group_old   = cfg_old.option<ConfigOptionString>("repetier_group");
 
 	auto opt_print_host_new 	  = cfg_new.option<ConfigOptionString>("print_host");
 	auto opt_printhost_apikey_new = cfg_new.option<ConfigOptionString>("printhost_apikey");
 	auto opt_printhost_cafile_new = cfg_new.option<ConfigOptionString>("printhost_cafile");
+    auto opt_repetier_slug_new    = cfg_new.option<ConfigOptionString>("repetier_slug");
+    auto opt_repetier_group_new   = cfg_new.option<ConfigOptionString>("repetier_group");
 
 	// If the new print host data is undefined, use the old data.
 	bool new_print_host_undefined = (opt_print_host_new 		== nullptr || opt_print_host_new		->empty()) &&
 									(opt_printhost_apikey_new 	== nullptr || opt_printhost_apikey_new	->empty()) &&
-									(opt_printhost_cafile_new 	== nullptr || opt_printhost_cafile_new	->empty());
+									(opt_printhost_cafile_new 	== nullptr || opt_printhost_cafile_new	->empty()) &&
+                                    (opt_repetier_slug_new      == nullptr || opt_repetier_slug_new     ->empty()) &&
+                                    (opt_repetier_group_new     == nullptr || opt_repetier_group_new    ->empty());
 	if (new_print_host_undefined)
 		return ProfileHostParams::Anonymized;
 
@@ -730,8 +736,9 @@ static ProfileHostParams profile_host_params_same_or_anonymized(const DynamicPri
 		return ((l == nullptr || l->empty()) && (r == nullptr || r->empty())) ||
 			   (l != nullptr && r != nullptr && l->value == r->value);
 	};
-	return (opt_same(opt_print_host_old, opt_print_host_new) && opt_same(opt_printhost_apikey_old, opt_printhost_apikey_new) && 
-		    opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new)) ? ProfileHostParams::Same : ProfileHostParams::Different;
+	return (opt_same(opt_print_host_old, opt_print_host_new) && opt_same(opt_printhost_apikey_old, opt_printhost_apikey_new) &&
+            opt_same(opt_printhost_cafile_old, opt_printhost_cafile_new) && opt_same(opt_repetier_slug_old, opt_repetier_slug_new) &&
+		    opt_same(opt_repetier_group_old, opt_repetier_group_new)) ? ProfileHostParams::Same : ProfileHostParams::Different;
 }
 
 static bool profile_print_params_same(const DynamicPrintConfig &cfg_old, const DynamicPrintConfig &cfg_new)
@@ -743,7 +750,7 @@ static bool profile_print_params_same(const DynamicPrintConfig &cfg_old, const D
                              "compatible_printers", "compatible_printers_condition", "inherits",
                              "print_settings_id", "filament_settings_id", "sla_print_settings_id", "sla_material_settings_id", "printer_settings_id",
                              "printer_model", "printer_variant", "default_print_profile", "default_filament_profile", "default_sla_print_profile", "default_sla_material_profile",
-                             "print_host", "printhost_apikey", "printhost_cafile" })
+                             "print_host", "printhost_apikey", "repetier_slug", "repetier_group",  "printhost_cafile" })
         diff.erase(std::remove(diff.begin(), diff.end(), key), diff.end());
     // Preset with the same name as stored inside the config exists.
     return diff.empty() && profile_host_params_same_or_anonymized(cfg_old, cfg_new) != ProfileHostParams::Different;
@@ -793,6 +800,8 @@ Preset& PresetCollection::load_external_preset(
 	    	opt_update("print_host");
 	    	opt_update("printhost_apikey");
 	    	opt_update("printhost_cafile");
+            opt_update("repetier_slug");
+            opt_update("repetier_group");
 	    }
     }
     // Update the "inherits" field.

--- a/src/slic3r/GUI/PresetBundle.cpp
+++ b/src/slic3r/GUI/PresetBundle.cpp
@@ -528,6 +528,8 @@ DynamicPrintConfig PresetBundle::full_config_secure() const
     DynamicPrintConfig config = this->full_config();
     config.erase("print_host");
     config.erase("printhost_apikey");
+    config.erase("repetier_slug");
+    config.erase("repetier_group");
     config.erase("printhost_cafile");
     return config;
 }

--- a/src/slic3r/GUI/PresetBundle.cpp
+++ b/src/slic3r/GUI/PresetBundle.cpp
@@ -529,7 +529,6 @@ DynamicPrintConfig PresetBundle::full_config_secure() const
     config.erase("print_host");
     config.erase("printhost_apikey");
     config.erase("repetier_slug");
-    config.erase("repetier_group");
     config.erase("printhost_cafile");
     return config;
 }

--- a/src/slic3r/GUI/PresetBundle.cpp
+++ b/src/slic3r/GUI/PresetBundle.cpp
@@ -528,7 +528,7 @@ DynamicPrintConfig PresetBundle::full_config_secure() const
     DynamicPrintConfig config = this->full_config();
     config.erase("print_host");
     config.erase("printhost_apikey");
-    config.erase("repetier_slug");
+    config.erase("printhost_slug");
     config.erase("printhost_cafile");
     return config;
 }

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -28,7 +28,7 @@ namespace GUI {
 
 static const char *CONFIG_KEY_PATH  = "printhost_path";
 static const char *CONFIG_KEY_PRINT = "printhost_print";
-static const char *CONFIG_KEY_GROUP = "repetier_group";
+static const char *CONFIG_KEY_GROUP = "printhost_group";
 
 PrintHostSendDialog::PrintHostSendDialog(const fs::path &path, bool can_start_print, wxArrayString& groups)
     : MsgDialog(nullptr, _(L("Send G-Code to printer host")), _(L("Upload to Printer Host with the following filename:")), wxID_NONE)

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -29,14 +29,16 @@ namespace GUI {
 class PrintHostSendDialog : public GUI::MsgDialog
 {
 public:
-    PrintHostSendDialog(const boost::filesystem::path &path, bool can_start_print);
+    PrintHostSendDialog(const boost::filesystem::path &path, bool can_start_print, wxArrayString& groups);
     boost::filesystem::path filename() const;
     bool start_print() const;
+    std::string group() const;
 
     virtual void EndModal(int ret) override;
 private:
     wxTextCtrl *txt_filename;
     wxCheckBox *box_print;
+    wxComboBox *combo_groups;
 };
 
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1933,8 +1933,8 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
     };
 
     auto print_host_printers = [this](wxWindow* parent) {
-        add_scaled_button(parent, &m_repetier_slug_browse_btn, "browse", _(L("Refresh Printers")), wxBU_LEFT | wxBU_EXACTFIT);
-        ScalableButton* btn = m_repetier_slug_browse_btn;
+        add_scaled_button(parent, &m_printhost_slug_browse_btn, "browse", _(L("Refresh Printers")), wxBU_LEFT | wxBU_EXACTFIT);
+        ScalableButton* btn = m_printhost_slug_browse_btn;
         btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
 
         auto sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1955,7 +1955,7 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
     option.opt.width = Field::def_width_wider();
     optgroup->append_single_option_line(option);
     
-    option = optgroup->get_option("repetier_slug");
+    option = optgroup->get_option("printhost_slug");
     option.opt.width = Field::def_width_wider();
     Line slug_line = optgroup->create_single_option_line(option);
     slug_line.append_widget(print_host_printers);
@@ -2358,7 +2358,7 @@ void TabPrinter::update_printers()
     std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
     
     wxArrayString printers;
-    Field *rs = get_field("repetier_slug");
+    Field *rs = get_field("printhost_slug");
     if (!host->get_printers(printers)) {
         std::vector<std::string> slugs;
         
@@ -2747,9 +2747,9 @@ void TabPrinter::update_fff()
         std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
         m_print_host_test_btn->Enable(!m_config->opt_string("print_host").empty() && host->can_test());
         m_printhost_browse_btn->Enable(host->has_auto_discovery());
-        m_repetier_slug_browse_btn->Enable(host->can_support_multiple_printers());
+        m_printhost_slug_browse_btn->Enable(host->can_support_multiple_printers());
     
-        Field *rs = get_field("repetier_slug");
+        Field *rs = get_field("printhost_slug");
         if (host->can_support_multiple_printers()) {
             update_printers();
             rs->enable();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1931,27 +1931,19 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
 
         return sizer;
     };
-    
-    auto repetier_slug_browse = [=](wxWindow* parent) {
-        add_scaled_button(parent, &m_repetier_slug_browse_btn, "printers", _(L("Printers")) + " "+ dots, wxBU_LEFT | wxBU_EXACTFIT);
+
+    auto print_host_printers = [this](wxWindow* parent) {
+        add_scaled_button(parent, &m_repetier_slug_browse_btn, "browse", _(L("Refresh Printers")), wxBU_LEFT | wxBU_EXACTFIT);
         ScalableButton* btn = m_repetier_slug_browse_btn;
         btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
 
         auto sizer = new wxBoxSizer(wxHORIZONTAL);
         sizer->Add(btn);
-
-        btn->Bind(wxEVT_BUTTON, [=](wxCommandEvent &e) {
-            BonjourDialog dialog(parent, tech);
-            if (dialog.show_and_lookup()) {
-                optgroup->set_value("repetier_slug", std::move(dialog.get_selected()), true);
-                optgroup->get_field("repetier_slug")->field_changed();
-            }
-        });
-
+        
+        btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent e) { update_printers(); });
         return sizer;
     };
-
-
+    
     // Set a wider width for a better alignment
     Option option = optgroup->get_option("print_host");
     option.opt.width = Field::def_width_wider();
@@ -1965,7 +1957,9 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
     
     option = optgroup->get_option("repetier_slug");
     option.opt.width = Field::def_width_wider();
-    optgroup->append_single_option_line(option);
+    Line slug_line = optgroup->create_single_option_line(option);
+    slug_line.append_widget(print_host_printers);
+    optgroup->append_line(slug_line);
     
     const auto ca_file_hint = _utf8(L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate."));
 
@@ -2359,6 +2353,32 @@ void TabPrinter::update_serial_ports()
     choice->set_values(Utils::scan_serial_ports());
 }
 
+void TabPrinter::update_printers()
+{
+    std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
+    
+    wxArrayString printers;
+    Field *rs = get_field("repetier_slug");
+    if (!host->get_printers(printers)) {
+        std::vector<std::string> slugs;
+        
+        Choice *choice = dynamic_cast<Choice *>(rs);
+        choice->set_values(slugs);
+
+        rs->disable();
+    } else {
+        std::vector<std::string> slugs;
+        for (int i = 0; i < printers.size(); i++) {
+            slugs.push_back(printers[i].ToStdString());
+        }
+                
+        Choice *choice = dynamic_cast<Choice *>(rs);
+        choice->set_values(slugs);
+        
+        rs->enable();
+    }
+}
+
 void TabPrinter::extruders_count_changed(size_t extruders_count)
 {
     bool is_count_changed = false;
@@ -2727,6 +2747,15 @@ void TabPrinter::update_fff()
         std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
         m_print_host_test_btn->Enable(!m_config->opt_string("print_host").empty() && host->can_test());
         m_printhost_browse_btn->Enable(host->has_auto_discovery());
+        m_repetier_slug_browse_btn->Enable(host->can_support_multiple_printers());
+    
+        Field *rs = get_field("repetier_slug");
+        if (host->can_support_multiple_printers()) {
+            update_printers();
+            rs->enable();
+        } else {
+            rs->disable();
+        }
     }
 
     bool have_multiple_extruders = m_extruders_count > 1;
@@ -2807,16 +2836,6 @@ void TabPrinter::update_fff()
         bool toolchange_retraction = m_config->opt_float("retract_length_toolchange", i) > 0;
         get_field("retract_restart_extra_toolchange", i)->toggle
             (have_multiple_extruders && toolchange_retraction);
-    }
-    
-    bool is_repetier = m_config->option<ConfigOptionEnum<PrintHostType>>("host_type")->value == htRepetier;
-    {
-        Field *rs = get_field("repetier_slug");
-        if (is_repetier) {
-            rs->enable();
-        } else {
-            rs->disable();
-        }
     }
 
 //	Thaw();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1931,6 +1931,26 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
 
         return sizer;
     };
+    
+    auto repetier_slug_browse = [=](wxWindow* parent) {
+        add_scaled_button(parent, &m_repetier_slug_browse_btn, "printers", _(L("Printers")) + " "+ dots, wxBU_LEFT | wxBU_EXACTFIT);
+        ScalableButton* btn = m_repetier_slug_browse_btn;
+        btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
+
+        auto sizer = new wxBoxSizer(wxHORIZONTAL);
+        sizer->Add(btn);
+
+        btn->Bind(wxEVT_BUTTON, [=](wxCommandEvent &e) {
+            BonjourDialog dialog(parent, tech);
+            if (dialog.show_and_lookup()) {
+                optgroup->set_value("repetier_slug", std::move(dialog.get_selected()), true);
+                optgroup->get_field("repetier_slug")->field_changed();
+            }
+        });
+
+        return sizer;
+    };
+
 
     // Set a wider width for a better alignment
     Option option = optgroup->get_option("print_host");
@@ -1942,13 +1962,11 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
     option = optgroup->get_option("printhost_apikey");
     option.opt.width = Field::def_width_wider();
     optgroup->append_single_option_line(option);
+    
     option = optgroup->get_option("repetier_slug");
     option.opt.width = Field::def_width_wider();
     optgroup->append_single_option_line(option);
-    option = optgroup->get_option("repetier_group");
-    option.opt.width = Field::def_width_wider();
-    optgroup->append_single_option_line(option);
-
+    
     const auto ca_file_hint = _utf8(L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate."));
 
     if (Http::ca_file_supported()) {
@@ -2794,13 +2812,10 @@ void TabPrinter::update_fff()
     bool is_repetier = m_config->option<ConfigOptionEnum<PrintHostType>>("host_type")->value == htRepetier;
     {
         Field *rs = get_field("repetier_slug");
-        Field *rg = get_field("repetier_group");
         if (is_repetier) {
             rs->enable();
-            rg->enable();
         } else {
             rs->disable();
-            rg->disable();
         }
     }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1942,6 +1942,12 @@ void TabPrinter::build_printhost(ConfigOptionsGroup *optgroup)
     option = optgroup->get_option("printhost_apikey");
     option.opt.width = Field::def_width_wider();
     optgroup->append_single_option_line(option);
+    option = optgroup->get_option("repetier_slug");
+    option.opt.width = Field::def_width_wider();
+    optgroup->append_single_option_line(option);
+    option = optgroup->get_option("repetier_group");
+    option.opt.width = Field::def_width_wider();
+    optgroup->append_single_option_line(option);
 
     const auto ca_file_hint = _utf8(L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate."));
 
@@ -2783,6 +2789,19 @@ void TabPrinter::update_fff()
         bool toolchange_retraction = m_config->opt_float("retract_length_toolchange", i) > 0;
         get_field("retract_restart_extra_toolchange", i)->toggle
             (have_multiple_extruders && toolchange_retraction);
+    }
+    
+    bool is_repetier = m_config->option<ConfigOptionEnum<PrintHostType>>("host_type")->value == htRepetier;
+    {
+        Field *rs = get_field("repetier_slug");
+        Field *rg = get_field("repetier_group");
+        if (is_repetier) {
+            rs->enable();
+            rg->enable();
+        } else {
+            rs->disable();
+            rg->disable();
+        }
     }
 
 //	Thaw();

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -403,7 +403,7 @@ public:
 	ScalableButton*	m_print_host_test_btn = nullptr;
 	ScalableButton*	m_printhost_browse_btn = nullptr;
     ScalableButton* m_printhost_browse_printer_btn = nullptr;
-    ScalableButton* m_repetier_slug_browse_btn = nullptr;
+    ScalableButton* m_printhost_slug_browse_btn = nullptr;
 	ScalableButton*	m_reset_to_filament_color = nullptr;
 
 	size_t		m_extruders_count;

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -402,6 +402,7 @@ public:
 	wxButton*	m_serial_test_btn = nullptr;
 	ScalableButton*	m_print_host_test_btn = nullptr;
 	ScalableButton*	m_printhost_browse_btn = nullptr;
+    ScalableButton* m_repetier_slug_browse_btn = nullptr;
 	ScalableButton*	m_reset_to_filament_color = nullptr;
 
 	size_t		m_extruders_count;

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -402,6 +402,7 @@ public:
 	wxButton*	m_serial_test_btn = nullptr;
 	ScalableButton*	m_print_host_test_btn = nullptr;
 	ScalableButton*	m_printhost_browse_btn = nullptr;
+    ScalableButton* m_printhost_browse_printer_btn = nullptr;
     ScalableButton* m_repetier_slug_browse_btn = nullptr;
 	ScalableButton*	m_reset_to_filament_color = nullptr;
 
@@ -425,6 +426,7 @@ public:
     void		update_sla();
     void        update_pages(); // update m_pages according to printer technology
 	void		update_serial_ports();
+    void        update_printers();
 	void		extruders_count_changed(size_t extruders_count);
 	PageShp		build_kinematics_page();
 	void		build_unregular_pages();

--- a/src/slic3r/Utils/AstroBox.hpp
+++ b/src/slic3r/Utils/AstroBox.hpp
@@ -28,7 +28,8 @@ public:
     bool can_test() const override { return true; }
     bool can_start_print() const override { return true; }
     std::string get_host() const override { return host; }
-
+    bool get_groups(wxArrayString& groups) const override { return false; }
+    
 protected:
     bool validate_version_text(const boost::optional<std::string> &version_text) const;
 

--- a/src/slic3r/Utils/AstroBox.hpp
+++ b/src/slic3r/Utils/AstroBox.hpp
@@ -27,8 +27,11 @@ public:
     bool has_auto_discovery() const override { return true; }
     bool can_test() const override { return true; }
     bool can_start_print() const override { return true; }
+    bool can_support_multiple_printers() const override { return false; }
     std::string get_host() const override { return host; }
-    bool get_groups(wxArrayString& groups) const override { return false; }
+    
+    bool get_groups(wxArrayString &groups) const override { return false; }
+    bool get_printers(wxArrayString &printers) const override { return false; }
     
 protected:
     bool validate_version_text(const boost::optional<std::string> &version_text) const;

--- a/src/slic3r/Utils/Duet.hpp
+++ b/src/slic3r/Utils/Duet.hpp
@@ -27,7 +27,8 @@ public:
 	bool can_test() const override { return true; }
 	bool can_start_print() const override { return true; }
 	std::string get_host() const override { return host; }
-
+    bool get_groups(wxArrayString& groups) const override { return false; }
+    
 private:
 	std::string host;
 	std::string password;

--- a/src/slic3r/Utils/Duet.hpp
+++ b/src/slic3r/Utils/Duet.hpp
@@ -26,8 +26,11 @@ public:
 	bool has_auto_discovery() const override { return false; }
 	bool can_test() const override { return true; }
 	bool can_start_print() const override { return true; }
+    bool can_support_multiple_printers() const override { return false; }
 	std::string get_host() const override { return host; }
-    bool get_groups(wxArrayString& groups) const override { return false; }
+   
+    bool get_groups(wxArrayString &groups) const override { return false; }
+    bool get_printers(wxArrayString &printers) const override { return false; }
     
 private:
 	std::string host;

--- a/src/slic3r/Utils/FlashAir.hpp
+++ b/src/slic3r/Utils/FlashAir.hpp
@@ -27,8 +27,11 @@ public:
 	bool has_auto_discovery() const override { return false; }
 	bool can_test() const override { return true; }
 	bool can_start_print() const override { return false; }
+    bool can_support_multiple_printers() const override { return false; }
 	std::string get_host() const override { return host; }
-    bool get_groups(wxArrayString& groups) const override { return false; }
+    
+    bool get_groups(wxArrayString &groups) const override { return false; }
+    bool get_printers(wxArrayString &printers) const override { return false; }
     
 private:
 	std::string host;

--- a/src/slic3r/Utils/FlashAir.hpp
+++ b/src/slic3r/Utils/FlashAir.hpp
@@ -28,7 +28,8 @@ public:
 	bool can_test() const override { return true; }
 	bool can_start_print() const override { return false; }
 	std::string get_host() const override { return host; }
-
+    bool get_groups(wxArrayString& groups) const override { return false; }
+    
 private:
 	std::string host;
 

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -28,8 +28,10 @@ public:
     bool has_auto_discovery() const override { return true; }
     bool can_test() const override { return true; }
     bool can_start_print() const override { return true; }
+    bool can_support_multiple_printers() const override { return false; }
     std::string get_host() const override { return host; }
-    bool get_groups(wxArrayString& groups) const override { return false; }
+    bool get_groups(wxArrayString &groups) const override { return false; }
+    bool get_printers(wxArrayString &printers) const override { return false; }
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -29,6 +29,7 @@ public:
     bool can_test() const override { return true; }
     bool can_start_print() const override { return true; }
     std::string get_host() const override { return host; }
+    bool get_groups(wxArrayString& groups) const override { return false; }
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -16,6 +16,7 @@
 #include "Duet.hpp"
 #include "FlashAir.hpp"
 #include "AstroBox.hpp"
+#include "Repetier.hpp"
 #include "../GUI/PrintHostDialogs.hpp"
 
 namespace fs = boost::filesystem;
@@ -47,6 +48,7 @@ PrintHost* PrintHost::get_print_host(DynamicPrintConfig *config)
             case htDuet:      return new Duet(config);
             case htFlashAir:  return new FlashAir(config);
             case htAstroBox:  return new AstroBox(config);
+            case htRepetier:  return new Repetier(config);
             default:          return nullptr;
         }
     } else {

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -20,6 +20,9 @@ struct PrintHostUpload
 {
     boost::filesystem::path source_path;
     boost::filesystem::path upload_path;
+    
+    std::string group;
+    
     bool start_print = false;
 };
 
@@ -42,6 +45,7 @@ public:
     virtual bool can_test() const = 0;
     virtual bool can_start_print() const = 0;
     virtual std::string get_host() const = 0;
+    virtual bool get_groups(wxArrayString& groups) const = 0;
 
     static PrintHost* get_print_host(DynamicPrintConfig *config);
 

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -44,8 +44,10 @@ public:
     virtual bool has_auto_discovery() const = 0;
     virtual bool can_test() const = 0;
     virtual bool can_start_print() const = 0;
+    virtual bool can_support_multiple_printers() const = 0;
     virtual std::string get_host() const = 0;
     virtual bool get_groups(wxArrayString& groups) const = 0;
+    virtual bool get_printers(wxArrayString &printers) const = 0;
 
     static PrintHost* get_print_host(DynamicPrintConfig *config);
 

--- a/src/slic3r/Utils/Repetier.cpp
+++ b/src/slic3r/Utils/Repetier.cpp
@@ -28,7 +28,7 @@ Repetier::Repetier(DynamicPrintConfig *config) :
     host(config->opt_string("print_host")),
     apikey(config->opt_string("printhost_apikey")),
     cafile(config->opt_string("printhost_cafile")),
-    slug(config->opt_string("repetier_slug"))
+    slug(config->opt_string("printhost_slug"))
 {}
 
 const char* Repetier::get_name() const { return "Repetier"; }
@@ -41,7 +41,7 @@ bool Repetier::test(wxString &msg) const
     const char *name = get_name();
 
     bool res = true;
-    auto url = make_url("printer/version");
+    auto url = make_url("printer/info");
 
     BOOST_LOG_TRIVIAL(info) << boost::format("%1%: List version at: %2%") % name % url;
 
@@ -61,20 +61,11 @@ bool Repetier::test(wxString &msg) const
                 pt::ptree ptree;
                 pt::read_json(ss, ptree);
                 
-                /*
-                const auto error = ptree.get_optional<std::string>("error");
-                if (error) {
-                    msg = GUI::from_u8((boost::format(_utf8(L("%s"))) % error).str());
-                    res = false;
-                } else {
-                    BOOST_FOREACH(boost::property_tree::ptree::value_type &v, ptree.get_child("data.")) {
-                        const auto slug = v.second.get<std::string>("slug");
-                        slugs.push_back(slug);
-                    }
-                    
-                    //res = !printers.empty();
+                const auto text = ptree.get_optional<std::string>("name");
+                res = validate_version_text(text);
+                if (! res) {
+                    msg = GUI::from_u8((boost::format(_utf8(L("Mismatched type of print host: %s"))) % (text ? *text : "Repetier")).str());
                 }
-                 */
             }
             catch (const std::exception &) {
                 res = false;

--- a/src/slic3r/Utils/Repetier.cpp
+++ b/src/slic3r/Utils/Repetier.cpp
@@ -1,0 +1,174 @@
+#include "Repetier.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <exception>
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <wx/progdlg.h>
+
+#include "libslic3r/PrintConfig.hpp"
+#include "slic3r/GUI/I18N.hpp"
+#include "slic3r/GUI/GUI.hpp"
+#include "Http.hpp"
+
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+
+namespace Slic3r {
+
+Repetier::Repetier(DynamicPrintConfig *config) :
+    host(config->opt_string("print_host")),
+    apikey(config->opt_string("printhost_apikey")),
+    cafile(config->opt_string("printhost_cafile")),
+    slug(config->opt_string("repetier_slug")),
+    group(config->opt_string("repetier_group"))
+{}
+
+const char* Repetier::get_name() const { return "Repetier"; }
+
+bool Repetier::test(wxString &msg) const
+{
+    // Since the request is performed synchronously here,
+    // it is ok to refer to `msg` from within the closure
+
+    const char *name = get_name();
+
+    bool res = true;
+    auto url = make_url("printer/info");
+
+    BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Get version at: %2%") % name % url;
+
+    auto http = Http::get(std::move(url));
+    set_auth(http);
+    http.on_error([&](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error getting version: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
+            res = false;
+            msg = format_error(body, error, status);
+        })
+        .on_complete([&, this](std::string body, unsigned) {
+            BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got version: %2%") % name % body;
+
+            try {
+                std::stringstream ss(body);
+                pt::ptree ptree;
+                pt::read_json(ss, ptree);
+
+                const auto text = ptree.get_optional<std::string>("name");
+                res = validate_version_text(text);
+                if (! res) {
+                    msg = GUI::from_u8((boost::format(_utf8(L("Mismatched type of print host: %s"))) % (text ? *text : "Repetier")).str());
+                }
+            }
+            catch (const std::exception &) {
+                res = false;
+                msg = "Could not parse server response";
+            }
+        })
+        .perform_sync();
+
+    return res;
+}
+
+wxString Repetier::get_test_ok_msg () const
+{
+    return _(L("Connection to Repetier works correctly."));
+}
+
+wxString Repetier::get_test_failed_msg (wxString &msg) const
+{
+    return GUI::from_u8((boost::format("%s: %s\n\n%s")
+        % _utf8(L("Could not connect to Repetier"))
+        % std::string(msg.ToUTF8())
+        % _utf8(L("Note: Repetier version at least 0.90.0 is required."))).str());
+}
+
+bool Repetier::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const
+{
+    const char *name = get_name();
+
+    const auto upload_filename = upload_data.upload_path.filename();
+    const auto upload_parent_path = upload_data.upload_path.parent_path();
+
+    wxString test_msg;
+    if (! test(test_msg)) {
+        error_fn(std::move(test_msg));
+        return false;
+    }
+
+    bool res = true;
+
+    auto url = make_url((boost::format("printer/model/%1%") % slug).str());
+
+    BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Uploading file %2% at %3%, filename: %4%, path: %5%, print: %6%")
+        % name
+        % upload_data.source_path
+        % url
+        % upload_filename.string()
+        % upload_parent_path.string()
+        % upload_data.start_print;
+
+    auto http = Http::post(std::move(url));
+    set_auth(http);
+    
+    if (! group.empty()) {
+        http.form_add("group", group);
+    }
+    
+    http.form_add("a", "upload")
+        .form_add_file("filename", upload_data.source_path.string(), upload_filename.string())
+        .on_complete([&](std::string body, unsigned status) {
+            BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: File uploaded: HTTP %2%: %3%") % name % status % body;
+        })
+        .on_error([&](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error uploading file: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
+            error_fn(format_error(body, error, status));
+            res = false;
+        })
+        .on_progress([&](Http::Progress progress, bool &cancel) {
+            prorgess_fn(std::move(progress), cancel);
+            if (cancel) {
+                // Upload was canceled
+                BOOST_LOG_TRIVIAL(info) << "Repetier: Upload canceled";
+                res = false;
+            }
+        })
+        .perform_sync();
+
+    return res;
+}
+
+bool Repetier::validate_version_text(const boost::optional<std::string> &version_text) const
+{
+    return version_text ? boost::starts_with(*version_text, "Repetier") : true;
+}
+
+void Repetier::set_auth(Http &http) const
+{
+    http.header("X-Api-Key", apikey);
+
+    if (! cafile.empty()) {
+        http.ca_file(cafile);
+    }
+}
+
+std::string Repetier::make_url(const std::string &path) const
+{
+    if (host.find("http://") == 0 || host.find("https://") == 0) {
+        if (host.back() == '/') {
+            return (boost::format("%1%%2%") % host % path).str();
+        } else {
+            return (boost::format("%1%/%2%") % host % path).str();
+        }
+    } else {
+        return (boost::format("http://%1%/%2%") % host % path).str();
+    }
+}
+
+}

--- a/src/slic3r/Utils/Repetier.hpp
+++ b/src/slic3r/Utils/Repetier.hpp
@@ -1,0 +1,49 @@
+#ifndef slic3r_Repetier_hpp_
+#define slic3r_Repetier_hpp_
+
+#include <string>
+#include <wx/string.h>
+#include <boost/optional.hpp>
+
+#include "PrintHost.hpp"
+
+
+namespace Slic3r {
+
+class DynamicPrintConfig;
+class Http;
+
+class Repetier : public PrintHost
+{
+public:
+    Repetier(DynamicPrintConfig *config);
+    ~Repetier() override = default;
+
+    const char* get_name() const;
+
+    bool test(wxString &curl_msg) const override;
+    wxString get_test_ok_msg () const override;
+    wxString get_test_failed_msg (wxString &msg) const override;
+    bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
+    bool has_auto_discovery() const override { return false; }
+    bool can_test() const override { return true; }
+    bool can_start_print() const override { return false; }
+    std::string get_host() const override { return host; }
+
+protected:
+    virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;
+
+private:
+    std::string host;
+    std::string apikey;
+    std::string cafile;
+    std::string slug;
+    std::string group;
+
+    void set_auth(Http &http) const;
+    std::string make_url(const std::string &path) const;
+};
+
+}
+
+#endif

--- a/src/slic3r/Utils/Repetier.hpp
+++ b/src/slic3r/Utils/Repetier.hpp
@@ -29,6 +29,7 @@ public:
     bool can_test() const override { return true; }
     bool can_start_print() const override { return false; }
     std::string get_host() const override { return host; }
+    bool get_groups(wxArrayString& groups) const override;
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;
@@ -38,7 +39,6 @@ private:
     std::string apikey;
     std::string cafile;
     std::string slug;
-    std::string group;
 
     void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;

--- a/src/slic3r/Utils/Repetier.hpp
+++ b/src/slic3r/Utils/Repetier.hpp
@@ -28,8 +28,11 @@ public:
     bool has_auto_discovery() const override { return false; }
     bool can_test() const override { return true; }
     bool can_start_print() const override { return false; }
+    bool can_support_multiple_printers() const override { return true; }
     std::string get_host() const override { return host; }
-    bool get_groups(wxArrayString& groups) const override;
+    
+    bool get_groups(wxArrayString &groups) const override;
+    bool get_printers(wxArrayString &printers) const override;
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;


### PR DESCRIPTION
First attempt at adding support for Repetier Server (see #1605). Right now, both printer name as well as (optionally) a group need to be specified manually. In an ideal world, this would be done via some selection UI that pulls the information from the server.