### PR TITLE
Add the ability to invert the scroll wheel when zooming

### DIFF
--- a/src/slic3r/GUI/AppConfig.cpp
+++ b/src/slic3r/GUI/AppConfig.cpp
@@ -93,6 +93,9 @@ void AppConfig::set_defaults()
     if (get("use_free_camera").empty())
         set("use_free_camera", "0");
 
+    if (get("invert_scroll_zoom").empty())
+        set("invert_scroll_zoom", "0");
+
 #if ENABLE_ENVIRONMENT_MAP
     if (get("use_environment_map").empty())
         set("use_environment_map", "0");

--- a/src/slic3r/GUI/Camera.cpp
+++ b/src/slic3r/GUI/Camera.cpp
@@ -35,6 +35,7 @@ Camera::Camera()
     , m_target(Vec3d::Zero())
     , m_zenit(45.0f)
     , m_zoom(1.0)
+    , m_invert_scroll_zoom(false)
     , m_distance(DefaultDistance)
     , m_gui_scale(1.0)
     , m_view_matrix(Transform3d::Identity())
@@ -79,6 +80,21 @@ void Camera::select_next_type()
     set_type((EType)next);
 }
 
+void Camera::set_invert_scroll_zoom(bool invert_scroll_zoom)
+{
+    if (m_invert_scroll_zoom != invert_scroll_zoom)
+    {
+        m_invert_scroll_zoom = invert_scroll_zoom;
+        wxGetApp().app_config->set("invert_scroll_zoom", m_invert_scroll_zoom ? "1" : "0");
+        wxGetApp().app_config->save();
+    }
+}
+
+void Camera::set_invert_scroll_zoom(const std::string& invert_scroll_zoom)
+{
+    set_invert_scroll_zoom((invert_scroll_zoom == "1") ? true : false);
+}
+
 void Camera::set_target(const Vec3d& target)
 {
     Vec3d new_target = validate_target(target);
@@ -90,8 +106,12 @@ void Camera::set_target(const Vec3d& target)
     }
 }
 
-void Camera::update_zoom(double delta_zoom)
+void Camera::update_zoom(double delta_zoom, bool is_from_scroll)
 {
+    if (is_from_scroll && m_invert_scroll_zoom)
+    {
+      delta_zoom = -delta_zoom;
+    }
     set_zoom(m_zoom / (1.0 - std::max(std::min(delta_zoom, 4.0), -4.0) * 0.1));
 }
 

--- a/src/slic3r/GUI/Camera.hpp
+++ b/src/slic3r/GUI/Camera.hpp
@@ -33,6 +33,7 @@ private:
     Vec3d m_target;
     float m_zenit;
     double m_zoom;
+    bool   m_invert_scroll_zoom;
     // Distance between camera position and camera target measured along the camera Z axis
     mutable double m_distance;
     mutable double m_gui_scale;
@@ -56,6 +57,10 @@ public:
     void set_type(const std::string& type);
     void select_next_type();
 
+    bool get_invert_scroll_zoom() const { return m_invert_scroll_zoom; }
+    void set_invert_scroll_zoom(bool invert_scroll_zoom);
+    void set_invert_scroll_zoom(const std::string& invert_scroll_zoom);
+
     const Vec3d& get_target() const { return m_target; }
     void set_target(const Vec3d& target);
 
@@ -64,7 +69,7 @@ public:
 
     double get_zoom() const { return m_zoom; }
     double get_inv_zoom() const { assert(m_zoom != 0.0); return 1.0 / m_zoom; }
-    void update_zoom(double delta_zoom);
+    void update_zoom(double delta_zoom, bool is_from_scroll = false);
     void set_zoom(double zoom);
 
     const BoundingBoxf3& get_scene_box() const { return m_scene_box; }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3346,7 +3346,7 @@ void GLCanvas3D::on_mouse_wheel(wxMouseEvent& evt)
         return;
 
     // Calculate the zoom delta and apply it to the current zoom factor
-    _update_camera_zoom((double)evt.GetWheelRotation() / (double)evt.GetWheelDelta());
+    _update_camera_zoom((double)evt.GetWheelRotation() / (double)evt.GetWheelDelta(), true);
 }
 
 void GLCanvas3D::on_timer(wxTimerEvent& evt)
@@ -5099,9 +5099,9 @@ void GLCanvas3D::_zoom_to_box(const BoundingBoxf3& box, double margin_factor)
     m_dirty = true;
 }
 
-void GLCanvas3D::_update_camera_zoom(double zoom)
+void GLCanvas3D::_update_camera_zoom(double zoom, bool is_from_scroll)
 {
-    wxGetApp().plater()->get_camera().update_zoom(zoom);
+    wxGetApp().plater()->get_camera().update_zoom(zoom, is_from_scroll);
     m_dirty = true;
 }
 

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -735,7 +735,7 @@ private:
     BoundingBoxf3 _max_bounding_box(bool include_gizmos, bool include_bed_model) const;
 
     void _zoom_to_box(const BoundingBoxf3& box, double margin_factor = DefaultCameraZoomToBoxMarginFactor);
-    void _update_camera_zoom(double zoom);
+    void _update_camera_zoom(double zoom, bool is_from_scroll = false);
 
     void _refresh_if_shown_on_screen();
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2024,6 +2024,9 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     // updates camera type from .ini file
     camera.set_type(get_config("use_perspective_camera"));
 
+    // updates camera scroll zoom invert from .ini file
+    camera.set_invert_scroll_zoom(get_config("invert_scroll_zoom"));
+
     // Load the 3DConnexion device database.
     mouse3d_controller.load_config(*wxGetApp().app_config);
 	// Start the background thread to detect and connect to a HID device (Windows and Linux).
@@ -2156,6 +2159,8 @@ void Plater::priv::update_ui_from_settings()
     camera.set_type(wxGetApp().app_config->get("use_perspective_camera"));
     if (wxGetApp().app_config->get("use_free_camera") != "1")
         camera.recover_from_free_camera();
+
+    camera.set_invert_scroll_zoom(wxGetApp().app_config->get("invert_scroll_zoom"));
 
     view3D->get_canvas3d()->update_ui_from_settings();
     preview->get_canvas3d()->update_ui_from_settings();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -151,6 +151,13 @@ void PreferencesDialog::build()
 	option = Option(def, "use_free_camera");
 	m_optgroup_camera->append_single_option_line(option);
 
+	def.label = L("Invert Scroll Wheel For Zoom");
+	def.type = coBool;
+	def.tooltip = L("Inverts the direction of the scroll wheel or touch pad for zooming");
+	def.set_default_value(new ConfigOptionBool(app_config->get("invert_scroll_zoom") == "1"));
+	option = Option(def, "invert_scroll_zoom");
+	m_optgroup_camera->append_single_option_line(option);
+
 	m_optgroup_gui = std::make_shared<ConfigOptionsGroup>(this, _(L("GUI")));
 	m_optgroup_gui->label_width = 40;
 	m_optgroup_gui->m_on_change = [this](t_config_option_key opt_key, boost::any value) {


### PR DESCRIPTION
I normally have "natural" scrolling on my Mac for both my trackpad and my mouse. I've become so used to it, that I set up my PC(s) to work the same way. This means that I'm used to zooming in when scrolling forward, and zooming out when scrolling backward.

In PrusaSlicer, you can hold down shift while scrolling to get this effect, but I don't want to have to hold shift whenever I'm scrolling. I added an option under camera to invert the default scroll sense. Shift still reverses the scroll, and everything else works as it used to. Include the keystrokes i and o.