### PR TITLE
Field.cpp: wider def_width_wider

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -115,7 +115,7 @@ void Field::PostInitialize()
 
 // Values of width to alignments of fields
 int Field::def_width()			{ return wxOSX ? 8 : 7; }
-int Field::def_width_wider()	{ return 14; }
+int Field::def_width_wider()	{ return 16; }
 int Field::def_width_thinner()	{ return 4; }
 
 void Field::on_kill_focus()


### PR DESCRIPTION
This fixes truncated ComboBox present on some systems

![prusaslicer_width_wider_14](https://user-images.githubusercontent.com/929583/86618639-8cc81800-bfb9-11ea-95de-d95e2dc60f50.png)
