### PR TITLE
Fix for 2nd layer bed temperature choosing wrong extruder/filament.

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -220,6 +220,7 @@ private:
         const LayerTools  				&layer_tools,
 		// Pairs of PrintObject index and its instance index.
 		const std::vector<const PrintInstance*> *ordering,
+        unsigned int                    first_printing_extruder_id,
         // If set to size_t(-1), then print all copies of all objects.
         // Otherwise print a single copy of a single object.
         const size_t                     single_object_idx = size_t(-1));


### PR DESCRIPTION
When the slicer chooses a bed temperature for the first layer, it is understood that it will select the temperature from the filament loaded in the first extruder. I would therefore expect that on the second layer, when the slicer switches to the "Other Layers" temperature it will do so based on the same extruder/filament. This is not the case. The "Other Layers" bed temperature is selected based on which extruder prints first on layer two which is not always the same one. This means the selected temp can vary depending on what objects are on the Plater and can result in First/Other temperatures being chosen based on two distinct filaments. In the case where the two materials are dissimilar in printing temperatures the bed temperature can be changed to an inappropriate temp. 