### PR TITLE
Fix #1806 - add gap_fill_minimum_area option

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -217,6 +217,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.));
 
+    def = this->add("gap_fill_minimum_area", coFloat);
+    def->label = L("Gap fill minimum area");
+    def->category = L("Infill");
+    def->tooltip = L("The minimum area of a section of gap fill. Areas below this threshold will not be gap-filled.");
+    def->sidetext = L("mm²");
+    def->min = 0;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("bridge_fan_speed", coInts);
     def->label = L("Bridges fan speed");
     def->tooltip = L("This fan speed is enforced during all bridges and overhangs.");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -501,6 +501,7 @@ public:
     ConfigOptionPercent             fill_density;
     ConfigOptionEnum<InfillPattern> fill_pattern;
     ConfigOptionFloat               gap_fill_speed;
+    ConfigOptionFloat               gap_fill_minimum_area;
     ConfigOptionInt                 infill_extruder;
     ConfigOptionFloatOrPercent      infill_extrusion_width;
     ConfigOptionInt                 infill_every_layers;
@@ -552,6 +553,7 @@ protected:
         OPT_PTR(fill_density);
         OPT_PTR(fill_pattern);
         OPT_PTR(gap_fill_speed);
+        OPT_PTR(gap_fill_minimum_area);
         OPT_PTR(infill_extruder);
         OPT_PTR(infill_extrusion_width);
         OPT_PTR(infill_every_layers);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -472,6 +472,7 @@ bool PrintObject::invalidate_state_by_config_options(const std::vector<t_config_
         if (   opt_key == "perimeters"
             || opt_key == "extra_perimeters"
             || opt_key == "gap_fill_speed"
+            || opt_key == "gap_fill_minimum_area"
             || opt_key == "overhangs"
             || opt_key == "first_layer_extrusion_width"
             || opt_key == "perimeter_extrusion_width"

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -405,7 +405,7 @@ const std::vector<std::string>& Preset::print_options()
         "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs",
         "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
         "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
-        "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", 
+        "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first", "gap_fill_minimum_area",
     	"ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
         "max_print_speed", "max_volumetric_speed",
 #ifdef HAS_PRESSURE_EQUALIZER

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1347,6 +1347,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("bridge_angle");
         optgroup->append_single_option_line("only_retract_when_crossing_perimeters");
         optgroup->append_single_option_line("infill_first");
+        optgroup->append_single_option_line("gap_fill_minimum_area");        
 
     page = add_options_page(L("Skirt and brim"), "skirt+brim");
         optgroup = page->new_optgroup(L("Skirt"));


### PR DESCRIPTION
- Add `gap_fill_minimum_area` print config option. Default is 0, which leaves the existing gap fill behaviour unchanged.
- Skip gap fills below `gap_fill_minimum_area` in `PerimeterGenerator.cpp`.
- Add `gap_fill_minimum_area` to `Infill` section of GUI: even though this is technically a perimeter feature, arguably a user would see it as an infill feature.

Disclaimer: This is my first PrusaSlicer pull request, please treat gently! It has been many years since I last coded in C++. I have not tried to deeply understand all the relevant code, instead I've adapted existing similar code. This fix "works for me", but it absolutely needs review by someone who knows what they're doing. 