### PR TITLE
Set data directory using an environment variable.

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -643,7 +643,13 @@ bool CLI::setup(int argc, char **argv)
             m_config.option(optdef.first, true);
 
     set_data_dir(m_config.opt_string("datadir"));
-    
+
+    if (data_dir().empty()) {
+        const char *env_data_dir = boost::nowide::getenv("PRUSASLICER_DATA");
+        if (env_data_dir != nullptr)
+            set_data_dir(env_data_dir);
+    }
+
     if (!validity.empty()) {
         boost::nowide::cerr << "error: " << validity << std::endl;
         return false;


### PR DESCRIPTION
Allows the data directory to be set using the environment variable "PRUSASLICER_DATA"  Double-clicking on an STL file currently causes PS to use the default data location.

Priority of setting:
command line > environment > default

This fixes / implements #4579 and is also another solution for #3947 
