### PR TITLE
Fix linux build

### DIFF
--- a/src/libslic3r/Fill/FillAdaptive.hpp
+++ b/src/libslic3r/Fill/FillAdaptive.hpp
@@ -8,6 +8,7 @@
 namespace Slic3r {
 
 class PrintObject;
+class TriangleMesh;
 
 namespace FillAdaptive_Internal
 {

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -11,7 +11,6 @@
 
 #include <wx/progdlg.h>
 
-#include "libslic3r/PrintConfig.hpp"
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/GUI/GUI.hpp"
 #include "Http.hpp"

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include "PrintHost.hpp"
+#include "libslic3r/PrintConfig.hpp"
 
 
 namespace Slic3r {

--- a/src/slic3r/Utils/Process.hpp
+++ b/src/slic3r/Utils/Process.hpp
@@ -2,6 +2,7 @@
 #define GUI_PROCESS_HPP
 
 class wxWindow;
+class wxString;
 
 namespace Slic3r {
 namespace GUI {


### PR DESCRIPTION
Current master fails to build on my system.

- Add two missing forward declarations
- The ``AuthorizationType`` enum requires definition, so move the include from OctoPrint.cpp to the class declaration