### PR TITLE
Use Ctrl+Shift+I to open a new instance instead of Ctrl+I

### DIFF
--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -136,6 +136,7 @@ void KBShortcutsDialog::fill_shortcuts()
             { ctrl + "5", L("Switch to 3D") },
             { ctrl + "6", L("Switch to Preview") },
             { ctrl + "J", L("Print host upload queue") },
+            { ctrl + "Shift+" + "I", L("Open new instance") },
             // View
             { "0-6", L("Camera view") },
             { "E", L("Show/Hide object/instance labels") },

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1256,9 +1256,8 @@ void MainFrame::init_menubar()
             [this](wxCommandEvent&) { m_printhost_queue_dlg->Show(); }, "upload_queue", nullptr, []() {return true; }, this);
         
         windowMenu->AppendSeparator();
-        append_menu_item(windowMenu, wxID_ANY, _L("Open new instance") + "\tCtrl+I", _L("Open a new PrusaSlicer instance"),
+        append_menu_item(windowMenu, wxID_ANY, _L("Open new instance") + "\tCtrl+Shift+I", _L("Open a new PrusaSlicer instance"),
 			[this](wxCommandEvent&) { start_new_slicer(); }, "", nullptr, [this]() {return m_plater != nullptr && wxGetApp().app_config->get("single_instance") != "1"; }, this);
-
     }
 
     // View menu


### PR DESCRIPTION
"Open new instance" overrides the "import" shortcut.

Use Ctrl+Shift+I for new instance, which is definitely less important
than importing new models.

Also document the shortcut in the Keyboard shortcuts dialog.

Fixes #4711