### PR TITLE
Collapse sidebar with Shift+Tab

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3274,6 +3274,10 @@ void GLCanvas3D::on_key(wxKeyEvent& evt)
                     // m_canvas->HandleAsNavigationKey(evt);   // XXX: Doesn't work in some cases / on Linux
                     post_event(SimpleEvent(EVT_GLCANVAS_TAB));
                 }
+                else if (keyCode == WXK_TAB && evt.ShiftDown()) {
+                    // Collapse side-panel with Shift+Tab
+                    post_event(SimpleEvent(EVT_GLCANVAS_COLLAPSE_SIDEBAR));
+                }
                 else if (keyCode == WXK_SHIFT)
                 {
                     translationProcessor.process(evt);

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -143,6 +143,7 @@ void KBShortcutsDialog::fill_shortcuts()
 #if ENABLE_SLOPE_RENDERING
             { "D", L("Turn On/Off facets' slope rendering") },
 #endif // ENABLE_SLOPE_RENDERING
+            { "Tab", L("Switch between Editor/Preview") },
             // Configuration
             { ctrl + "P", L("Preferences") },
             // Help

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -144,6 +144,7 @@ void KBShortcutsDialog::fill_shortcuts()
             { "D", L("Turn On/Off facets' slope rendering") },
 #endif // ENABLE_SLOPE_RENDERING
             { "Tab", L("Switch between Editor/Preview") },
+            { "Shift+Tab", L("Collapse/Expand the sidebar") },
             // Configuration
             { ctrl + "P", L("Preferences") },
             // Help

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1256,7 +1256,7 @@ void MainFrame::init_menubar()
             [this](wxCommandEvent&) { m_plater->show_view3D_labels(!m_plater->are_view3D_labels_shown()); }, this,
             [this]() { return m_plater->is_view3D_shown(); }, [this]() { return m_plater->are_view3D_labels_shown(); }, this);
 #endif // ENABLE_SLOPE_RENDERING
-        append_menu_check_item(viewMenu, wxID_ANY, _L("&Collapse sidebar"), _L("Collapse sidebar"),
+        append_menu_check_item(viewMenu, wxID_ANY, _L("&Collapse sidebar") + sep + "Shift+Tab", _L("Collapse sidebar"),
             [this](wxCommandEvent&) { m_plater->collapse_sidebar(!m_plater->is_sidebar_collapsed()); }, this,
             [this]() { return true; }, [this]() { return m_plater->is_sidebar_collapsed(); }, this);
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1929,6 +1929,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_QUESTION_MARK, [this](SimpleEvent&) { wxGetApp().keyboard_shortcuts(); });
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_UPDATE_BED_SHAPE, [q](SimpleEvent&) { q->set_bed_shape(); });
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_TAB, [this](SimpleEvent&) { select_next_view_3D(); });
+    preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_COLLAPSE_SIDEBAR, [this](SimpleEvent&) { this->q->collapse_sidebar(!this->q->is_sidebar_collapsed());  });
 #if ENABLE_GCODE_VIEWER
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_MOVE_LAYERS_SLIDER, [this](wxKeyEvent& evt) { preview->move_layers_slider(evt); });
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_EDIT_COLOR_CHANGE, [this](wxKeyEvent& evt) { preview->edit_layers_slider(evt); });

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4036,23 +4036,26 @@ bool Plater::priv::init_collapse_toolbar()
 
     GLToolbarItem::Data item;
 
-    item.name = "collapse_sidebar";
-    item.icon_filename = "collapse.svg";
-    item.tooltip = wxGetApp().plater()->is_sidebar_collapsed() ? _utf8(L("Expand right panel")) : _utf8(L("Collapse right panel"));
-    item.sprite_id = 0;
-    item.left.action_callback = [this, item]() {
-        std::string new_tooltip = wxGetApp().plater()->is_sidebar_collapsed() ?
-            _utf8(L("Collapse right panel")) : _utf8(L("Expand right panel"));
-
+    auto item_tooltip_update = [this, item](bool flip) {
+        std::string new_tooltip = wxGetApp().plater()->is_sidebar_collapsed() ^ flip?
+            _utf8(L("Expand sidebar")) : _utf8(L("Collapse sidebar"));
+        new_tooltip += " [Shift+Tab]";
         int id = collapse_toolbar.get_item_id("collapse_sidebar");
         collapse_toolbar.set_tooltip(id, new_tooltip);
+    };
 
+    item.name = "collapse_sidebar";
+    item.icon_filename = "collapse.svg";
+    item.sprite_id = 0;
+    item.left.action_callback = [this, item_tooltip_update]() {
+        item_tooltip_update(true);
         wxGetApp().plater()->collapse_sidebar(!wxGetApp().plater()->is_sidebar_collapsed());
     };
 
     if (!collapse_toolbar.add_item(item))
         return false;
 
+    item_tooltip_update(false);
     return true;
 }
 


### PR DESCRIPTION
Handle Shift+Tab in both normal/preview mode to collapse the sidebar. Since Tab switches mode, Shift+Tab felt a natural extension, and is easy to use.

The special handling for shift (select rectangle, fine movement) still works as expected.

Tab and Shift-Tab are documented in the keyboard shortcut dialogs, as well as the tooltips and menus.

The tooltip of the collapse button has been changed from "Right panel" to "sidebar" for consistency, which is used everywhere else.

Fixes #4712 