### PR TITLE
fix build on arch linux

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -589,7 +589,7 @@ int CLI::run(int argc, char **argv)
 #if ENABLE_GCODE_VIEWER
             if (start_as_gcodeviewer) {
                 if (!m_input_files.empty())
-                    gui->plater()->load_gcode(wxString::FromUTF8(m_input_files[0]));
+                    gui->plater()->load_gcode(wxString::FromUTF8(m_input_files[0].c_str()));
             } else {
 #endif // ENABLE_GCODE_VIEWER_AS
 #if 0


### PR DESCRIPTION
This fixes a compilation error that occurs on Arch Linux when compiling the package [prusa-slicer-git from AUR](https://aur.archlinux.org/packages/prusa-slicer-git). Occurs even when compiling directly with `cmake .. -G Ninja -DSLIC3R_WX_STABLE=ON && ninja`.

Compilation Error:
```
../src/PrusaSlicer.cpp:592:82: error: cannot convert ‘__gnu_cxx::__alloc_traits<std::allocator<std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char> >::value_type’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const char*’
  592 |                     gui->plater()->load_gcode(wxString::FromUTF8(m_input_files[0]));
```
All I've done is add the command `.c_str()` to the argument `m_input_files[0]`.

Btw, currently the AUR package builds with -DSLIC3R_PCH=OFF which fails with multiple compilation errors. When setting it to ON the compilation succeeds.