### PR TITLE
Preview DoubleSlider keyboard fixes

### DIFF
--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -1468,8 +1468,11 @@ void Control::OnKeyDown(wxKeyEvent &event)
 #endif // ENABLE_GCODE_VIEWER
     else if (is_horizontal())
     {
-        if (key == WXK_LEFT || key == WXK_RIGHT)
+        if (key == WXK_LEFT || key == WXK_RIGHT) {
+            if (m_selection == ssUndef)
+                m_selection = key == WXK_LEFT ? ssLower : ssHigher;
             move_current_thumb(key == WXK_LEFT);
+        }
         else if (key == WXK_UP || key == WXK_DOWN) {
             m_selection = key == WXK_UP ? ssHigher : ssLower;
             Refresh();
@@ -1480,8 +1483,11 @@ void Control::OnKeyDown(wxKeyEvent &event)
             m_selection = key == WXK_LEFT ? ssHigher : ssLower;
             Refresh();
         }
-        else if (key == WXK_UP || key == WXK_DOWN)
-            move_current_thumb(key == WXK_UP);
+        else if (key == WXK_UP || key == WXK_DOWN) {
+           if (m_selection == ssUndef)
+               m_selection = key == WXK_UP ? ssLower : ssHigher;
+           move_current_thumb(key == WXK_UP);
+        }
     }
 
     event.Skip(); // !Needed to have EVT_CHAR generated as well

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -1468,34 +1468,20 @@ void Control::OnKeyDown(wxKeyEvent &event)
 #endif // ENABLE_GCODE_VIEWER
     else if (is_horizontal())
     {
-#if ENABLE_GCODE_VIEWER
-        if (m_is_focused)
-        {
-#endif // ENABLE_GCODE_VIEWER
-            if (key == WXK_LEFT || key == WXK_RIGHT)
-                move_current_thumb(key == WXK_LEFT);
-            else if (key == WXK_UP || key == WXK_DOWN) {
-                m_selection = key == WXK_UP ? ssHigher : ssLower;
-                Refresh();
-            }
-#if ENABLE_GCODE_VIEWER
+        if (key == WXK_LEFT || key == WXK_RIGHT)
+            move_current_thumb(key == WXK_LEFT);
+        else if (key == WXK_UP || key == WXK_DOWN) {
+            m_selection = key == WXK_UP ? ssHigher : ssLower;
+            Refresh();
         }
-#endif // ENABLE_GCODE_VIEWER
-        }
+    }
     else {
-#if ENABLE_GCODE_VIEWER
-        if (m_is_focused)
-        {
-#endif // ENABLE_GCODE_VIEWER
-            if (key == WXK_LEFT || key == WXK_RIGHT) {
-                m_selection = key == WXK_LEFT ? ssHigher : ssLower;
-                Refresh();
-            }
-            else if (key == WXK_UP || key == WXK_DOWN)
-                move_current_thumb(key == WXK_UP);
-#if ENABLE_GCODE_VIEWER
+        if (key == WXK_LEFT || key == WXK_RIGHT) {
+            m_selection = key == WXK_LEFT ? ssHigher : ssLower;
+            Refresh();
         }
-#endif // ENABLE_GCODE_VIEWER
+        else if (key == WXK_UP || key == WXK_DOWN)
+            move_current_thumb(key == WXK_UP);
     }
 
     event.Skip(); // !Needed to have EVT_CHAR generated as well


### PR DESCRIPTION
Pressing UP/DOWN in the preview currently does nothing with the new Preview mode.

There's a check to see if the control has focus before handling them, but GUI_Preview actually relays these events to the control, so it seems bogus (@enricoturri1966 any reason why this is explicitly done only in GCODE_PREVIEW? OnKeyDown is only normally triggered if the control has focus already).

Also, when pressing DOWN right after switching to preview, the intention is to look into the model. As such, if there's no tick selection yet, auto-select the best tick so that we start scrolling immediately