### PR TITLE
Use monospaced fonts in gcode sections

### DIFF
--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -1413,6 +1413,8 @@ public:
     bool                                multiline       = false;
     // For text input: If true, the GUI text box spans the complete page width.
     bool                                full_width      = false;
+    // For text input: If true, the GUI formats text as code (fixed-width)
+    bool                                is_code         = false;
     // Not editable. Currently only used for the display of the number of threads.
     bool                                readonly        = false;
     // Height of a multiline GUI text box.

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -373,7 +373,9 @@ void TextCtrl::BUILD() {
 
     const long style = m_opt.multiline ? wxTE_MULTILINE : wxTE_PROCESS_ENTER/*0*/;
 	auto temp = new wxTextCtrl(m_parent, wxID_ANY, text_value, wxDefaultPosition, size, style);
-	temp->SetFont(Slic3r::GUI::wxGetApp().normal_font());
+    temp->SetFont(m_opt.is_code ?
+                  Slic3r::GUI::wxGetApp().code_font():
+                  Slic3r::GUI::wxGetApp().normal_font());
 
     if (! m_opt.multiline && !wxOSX)
 		// Only disable background refresh for single line input fields, as they are completely painted over by the edit control.

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -790,7 +790,7 @@ FirmwareDialog::FirmwareDialog(wxWindow *parent) :
     SetFont(font);
     wxFont status_font = font;//wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
 	status_font.MakeBold();
-	wxFont mono_font(wxFontInfo().Family(wxFONTFAMILY_TELETYPE));
+	wxFont mono_font = GUI::wxGetApp().code_font();
 	mono_font.MakeSmaller();
 
 	// Create GUI components and layout

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -869,6 +869,11 @@ void GUI_App::init_fonts()
     m_small_font.SetPointSize(11);
     m_bold_font.SetPointSize(13);
 #endif /*__WXMAC__*/
+
+    // wxSYS_OEM_FIXED_FONT and wxSYS_ANSI_FIXED_FONT use the same as
+    // DEFAULT in wxGtk. Use the TELETYPE family as a work-around
+    m_code_font = wxFont(wxFontInfo().Family(wxFONTFAMILY_TELETYPE));
+    m_code_font.SetPointSize(m_normal_font.GetPointSize());
 }
 
 void GUI_App::update_fonts(const MainFrame *main_frame)
@@ -884,6 +889,7 @@ void GUI_App::update_fonts(const MainFrame *main_frame)
     m_small_font    = m_normal_font;
     m_bold_font     = main_frame->normal_font().Bold();
     m_em_unit       = main_frame->em_unit();
+    m_code_font.SetPointSize(m_normal_font.GetPointSize());
 }
 
 void GUI_App::set_label_clr_modified(const wxColour& clr) {

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -118,6 +118,7 @@ private:
     wxFont		    m_small_font;
     wxFont		    m_bold_font;
 	wxFont			m_normal_font;
+	wxFont			m_code_font;
 
     int          m_em_unit; // width of a "m"-symbol in pixels for current system font
                                // Note: for 100% Scale m_em_unit = 10 -> it's a good enough coefficient for a size setting of controls
@@ -177,6 +178,7 @@ public:
     const wxFont&   small_font()            { return m_small_font; }
     const wxFont&   bold_font()             { return m_bold_font; }
     const wxFont&   normal_font()           { return m_normal_font; }
+    const wxFont&   code_font()             { return m_code_font; }
     int             em_unit() const         { return m_em_unit; }
     wxSize          get_min_size() const;
     float           toolbar_icon_scale(const bool is_limited = false) const;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1790,12 +1790,14 @@ void TabFilament::build()
         optgroup = page->new_optgroup(L("Start G-code"), 0);
         option = optgroup->get_option("start_filament_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;// 150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("End G-code"), 0);
         option = optgroup->get_option("end_filament_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;// 150;
         optgroup->append_single_option_line(option);
 
@@ -2204,51 +2206,60 @@ void TabPrinter::build_fff()
         optgroup = page->new_optgroup(L("Start G-code"), 0);
         option = optgroup->get_option("start_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("End G-code"), 0);
         option = optgroup->get_option("end_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Before layer change G-code"), 0);
         option = optgroup->get_option("before_layer_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("After layer change G-code"), 0);
         option = optgroup->get_option("layer_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Tool change G-code"), 0);
         option = optgroup->get_option("toolchange_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Between objects G-code (for sequential printing)"), 0);
         option = optgroup->get_option("between_objects_gcode");
         option.opt.full_width = true;
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Color Change G-code"), 0);
         option = optgroup->get_option("color_change_gcode");
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Pause Print G-code"), 0);
         option = optgroup->get_option("pause_print_gcode");
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
         optgroup = page->new_optgroup(L("Template Custom G-code"), 0);
         option = optgroup->get_option("template_custom_gcode");
+        option.opt.is_code = true;
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 


### PR DESCRIPTION
Use the system's default monospaced font for all G-code editors in the settings.

We add a ConfigOptionDef::is_code flag to indicate if the value is intended to display code. This could be later used to highlight it too, so I kept it more generic than "monospaced".

A new method GUI_App::code_font() is added for the purpose of getting a monospaced font. I set the font size to match the normal font, but I cannot test currently if this handles dpi-scaling correctly. I can also only text on linux.

Fixes #4718