### PR TITLE
Replace include to simplify

### DIFF
--- a/src/libslic3r/SLA/SupportPoint.hpp
+++ b/src/libslic3r/SLA/SupportPoint.hpp
@@ -2,7 +2,7 @@
 #define SLA_SUPPORTPOINT_HPP
 
 #include <vector>
-#include <libslic3r/ExPolygon.hpp>
+#include <Eigen/Geometry>
 
 namespace Slic3r { namespace sla {
 


### PR DESCRIPTION
In `src/libslic3r/SLA/SupportPoint.hpp` file, it might not be needed to include the whole `<libslic3r/ExPolygon.hpp>` file, since only `<Eigen/Geometry>` is needed. 