### PR TITLE
UnsavedChangesDialog : improvements

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -122,6 +122,12 @@ void AppConfig::set_defaults()
     if (get("show_splash_screen").empty())
         set("show_splash_screen", "1");
 
+    if (get("default_action_on_close_application").empty())
+        set("default_action_on_close_application", "none"); // , "discard" or "save" 
+
+    if (get("default_action_on_select_preset").empty())
+        set("default_action_on_select_preset", "none");     // , "transfer", "discard" or "save" 
+
     // Remove legacy window positions/sizes
     erase("", "main_frame_maximized");
     erase("", "main_frame_pos");

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4429,10 +4429,14 @@ bool GLCanvas3D::_render_search_list(float pos_x) const
 
     if (selected >= 0) {
         // selected == 9999 means that Esc kye was pressed
+        /*// revert commit https://github.com/prusa3d/PrusaSlicer/commit/91897589928789b261ca0dc735ffd46f2b0b99f2
         if (selected == 9999)
             action_taken = true;
         else
+            sidebar.jump_to_option(selected);*/
+        if (selected != 9999)
             sidebar.jump_to_option(selected);
+        action_taken = true;
     }
 
     imgui->end();

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1654,7 +1654,7 @@ bool GUI_App::check_unsaved_changes(const wxString &header)
     if (has_unsaved_changes)
     {
         UnsavedChangesDialog dlg(header);
-        if (dlg.ShowModal() == wxID_CANCEL)
+        if (wxGetApp().app_config->get("default_action_on_close_application") == "none" && dlg.ShowModal() == wxID_CANCEL)
             return false;
 
         if (dlg.save_preset())  // save selected changes

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -170,6 +170,7 @@ public:
     void        update_ui_from_settings();
     bool        is_loaded() const { return m_loaded; }
     bool        is_last_input_file() const  { return !m_qs_last_input_file.IsEmpty(); }
+    bool        is_dlg_layout() const { return m_layout == ESettingsLayout::Dlg; }
 
     void        quick_slice(const int qs = qsUndef);
     void        reslice_now();

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -236,6 +236,8 @@ PhysicalPrinterDialog::PhysicalPrinterDialog(wxString printer_name) :
         m_printer_name->SetFocus();
         m_printer_name->SelectAll();
     }
+
+    this->CenterOnScreen();
 }
 
 PhysicalPrinterDialog::~PhysicalPrinterDialog()

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1221,6 +1221,8 @@ void SavePresetDialog::build(std::vector<Preset::Type> types, std::string suffix
 
     SetSizer(topSizer);
     topSizer->SetSizeHints(this);
+
+    this->CenterOnScreen();
 }
 
 void SavePresetDialog::AddItem(Preset::Type type, const std::string& suffix)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3099,7 +3099,7 @@ bool Tab::may_discard_current_dirty_preset(PresetCollection* presets /*= nullptr
     if (presets == nullptr) presets = m_presets;
 
     UnsavedChangesDialog dlg(m_type, presets, new_printer_name);
-    if (dlg.ShowModal() == wxID_CANCEL)
+    if (wxGetApp().app_config->get("default_action_on_select_preset") == "none" && dlg.ShowModal() == wxID_CANCEL)
         return false;
 
     if (dlg.save_preset())  // save selected changes
@@ -3124,7 +3124,7 @@ bool Tab::may_discard_current_dirty_preset(PresetCollection* presets /*= nullptr
                 wxGetApp().plater()->force_filament_colors_update();
         }
     }
-    else if (dlg.move_preset()) // move selected changes
+    else if (dlg.transfer_changes()) // move selected changes
     {
         std::vector<std::string> selected_options = dlg.get_selected_options();
         if (m_type == presets->type()) // move changes for the current preset from this tab

--- a/src/slic3r/GUI/UnsavedChangesDialog.hpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.hpp
@@ -192,10 +192,11 @@ class UnsavedChangesDialog : public DPIDialog
     UnsavedChangesModel*    m_tree_model    { nullptr };
 
     ScalableButton*         m_save_btn      { nullptr };
-    ScalableButton*         m_move_btn      { nullptr };
-    ScalableButton*         m_continue_btn  { nullptr };
+    ScalableButton*         m_transfer_btn  { nullptr };
+    ScalableButton*         m_discard_btn   { nullptr };
     wxStaticText*           m_action_line   { nullptr };
     wxStaticText*           m_info_line     { nullptr };
+    wxCheckBox*             m_remember_choice   { nullptr };
 
     bool                    m_empty_selection   { false };
     bool                    m_has_long_strings  { false };
@@ -203,12 +204,18 @@ class UnsavedChangesDialog : public DPIDialog
     int                     m_move_btn_id       { wxID_ANY };
     int                     m_continue_btn_id   { wxID_ANY };
 
+    std::string             m_app_config_key;
+
     enum class Action {
         Undef,
-        Save,
-        Move,
-        Continue
+        Transfer,
+        Discard,
+        Save
     };
+
+    static constexpr char ActTransfer[] = "transfer";
+    static constexpr char ActDiscard[]  = "discard";
+    static constexpr char ActSave[]     = "save";
 
     // selected action after Dialog closing
     Action m_exit_action {Action::Undef};
@@ -244,12 +251,13 @@ public:
     void item_value_changed(wxDataViewEvent &event);
     void context_menu(wxDataViewEvent &event);
     void show_info_line(Action action, std::string preset_name = "");
+    void update_config(Action action);
     void close(Action action);
-    void save_and_close(PresetCollection* dependent_presets);
+    void save(PresetCollection* dependent_presets);
 
-    bool save_preset() const    { return m_exit_action == Action::Save;      }
-    bool move_preset() const    { return m_exit_action == Action::Move;      }
-    bool just_continue() const  { return m_exit_action == Action::Continue;  }
+    bool save_preset() const        { return m_exit_action == Action::Save;     }
+    bool transfer_changes() const   { return m_exit_action == Action::Transfer; }
+    bool discard() const            { return m_exit_action == Action::Discard;  }
 
     // get full bundle of preset names and types for saving
     const std::vector<std::pair<std::string, Preset::Type>>& get_names_and_types() { return names_and_types; }

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -787,10 +787,12 @@ ScalableButton::ScalableButton( wxWindow *          parent,
                                 const wxSize&       size /* = wxDefaultSize*/,
                                 const wxPoint&      pos /* = wxDefaultPosition*/,
                                 long                style /*= wxBU_EXACTFIT | wxNO_BORDER*/,
-                                bool                use_default_disabled_bitmap/* = false*/) :
+                                bool                use_default_disabled_bitmap/* = false*/,
+                                int                 bmp_px_cnt/* = 16*/) :
     m_parent(parent),
     m_current_icon_name(icon_name),
-    m_use_default_disabled_bitmap (use_default_disabled_bitmap)
+    m_use_default_disabled_bitmap (use_default_disabled_bitmap),
+    m_px_cnt(bmp_px_cnt)
 {
     Create(parent, id, label, pos, size, style);
 #ifdef __WXMSW__
@@ -798,7 +800,7 @@ ScalableButton::ScalableButton( wxWindow *          parent,
         SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
 #endif // __WXMSW__
 
-    SetBitmap(create_scaled_bitmap(icon_name, parent));
+    SetBitmap(create_scaled_bitmap(icon_name, parent, m_px_cnt));
     if (m_use_default_disabled_bitmap)
         SetBitmapDisabled(create_scaled_bitmap(m_current_icon_name, m_parent, m_px_cnt, true));
 

--- a/src/slic3r/GUI/wxExtensions.hpp
+++ b/src/slic3r/GUI/wxExtensions.hpp
@@ -210,7 +210,8 @@ public:
         const wxSize&       size = wxDefaultSize,
         const wxPoint&      pos = wxDefaultPosition,
         long                style = wxBU_EXACTFIT | wxNO_BORDER,
-        bool                use_default_disabled_bitmap = false);
+        bool                use_default_disabled_bitmap = false,
+        int                 bmp_px_cnt = 16);
 
     ScalableButton(
         wxWindow *          parent,


### PR DESCRIPTION
* Added "Remember my choice" checkbox
* Center on the screen and set position in respect to the position of mainframe or settings dialog

Preferences : Added checkboxes for enable/suppress showing of the UnsavedChangeDialog

SearchImGui : close after parameter selection_is_changed_according_to_physical_printers

PhysicalPrinterDialog, SavePresetDialog : Center on the screen