### PR TITLE
Add profiles for Anycubic Predator

### DIFF
--- a/resources/profiles/Anycubic.ini
+++ b/resources/profiles/Anycubic.ini
@@ -1102,3 +1102,690 @@ printer_notes = Do not remove the following keywords! These keywords are used in
 machine_max_feedrate_z = 8
 
 
+## Anycubic PREDATOR
+## Author: https://github.com/tillverka3d
+## Initial PR: TBD
+
+#########################################
+###### begin common print presets #######
+#########################################
+
+# Common print preset
+[print:*common predator*]
+spiral_vase = 0
+top_solid_min_thickness = 0.8
+bottom_solid_min_thickness = 0.6
+extra_perimeters = 0
+ensure_vertical_shell_thickness = 1
+avoid_crossing_perimeters = 0
+thin_walls = 0
+overhangs = 1
+seam_position = nearest
+external_perimeters_first = 0
+fill_density = 20%
+external_fill_pattern = rectilinear
+infill_every_layers = 1
+infill_only_where_needed = 0
+solid_infill_every_layers = 0
+fill_angle = 45
+solid_infill_below_area = 20
+bridge_angle = 0
+only_retract_when_crossing_perimeters = 0
+infill_first = 0
+skirts = 1
+skirt_distance = 4
+skirt_height = 1
+min_skirt_length = 8
+brim_width = 0
+support_material = 0
+support_material_auto = 1
+support_material_threshold = 50
+support_material_enforce_layers = 0
+raft_layers = 0
+support_material_contact_distance = 0.1
+support_material_pattern = rectilinear
+support_material_with_sheath = 0
+support_material_spacing = 2
+support_material_angle = 0
+support_material_interface_layers = 2
+support_material_interface_spacing = 0.2
+support_material_interface_contact_loops = 0
+support_material_buildplate_only = 0
+support_material_xy_spacing = 60%
+dont_support_bridges = 1
+support_material_synchronize_layers = 0
+travel_speed = 94
+first_layer_speed = 15
+perimeter_acceleration = 300
+infill_acceleration = 200
+bridge_acceleration = 300
+first_layer_acceleration = 300
+default_acceleration = 300
+max_volumetric_speed = 15
+perimeter_extruder = 1
+infill_extruder = 1
+solid_infill_extruder = 1
+support_material_extruder = 0
+support_material_interface_extruder = 0
+ooze_prevention = 0
+standby_temperature_delta = -5
+wipe_tower = 0
+wipe_tower_x = 170
+wipe_tower_y = 140
+wipe_tower_width = 60
+wipe_tower_rotation_angle = 0
+wipe_tower_bridging = 10
+interface_shells = 0
+infill_overlap = 20%
+bridge_flow_ratio = 0.8
+resolution = 0
+xy_size_compensation = 0
+elefant_foot_compensation = 0.2
+clip_multipart_objects = 1
+complete_objects = 0
+extruder_clearance_radius = 45
+extruder_clearance_height = 25
+gcode_comments = 0
+output_filename_format = {input_filename_base}_{print_preset}_{filament_type[0]}_{printer_model}_{print_time}.gcode
+post_process =
+notes =
+max_volumetric_extrusion_rate_slope_negative = 0
+max_volumetric_extrusion_rate_slope_positive = 0
+print_settings_id =
+
+# Common print preset
+[print:*common predator 0.4 nozzle*]
+inherits = *common predator*
+printer_variant = 0.4
+nozzle_diameter = 0.4
+first_layer_height = 0.16
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANYCUBIC.*/ and printer_notes=~/.*PRINTER_MODEL_PREDATOR.*/ and printer_notes=~/.*PRINTER_HAS_BOWDEN.*/ and nozzle_diameter[0]==0.4
+
+# Common print preset
+[print:*common predator 0.6 nozzle*]
+inherits = *common predator*
+printer_variant = 0.6
+nozzle_diameter = 0.6
+first_layer_height = 0.24
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANYCUBIC.*/ and printer_notes=~/.*PRINTER_MODEL_PREDATOR.*/ and printer_notes=~/.*PRINTER_HAS_BOWDEN.*/ and nozzle_diameter[0]==0.6
+
+# Common print preset
+[print:*common predator 0.8 nozzle*]
+inherits = *common predator*
+printer_variant = 0.8
+nozzle_diameter = 0.8
+first_layer_height = 0.32
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANYCUBIC.*/ and printer_notes=~/.*PRINTER_MODEL_PREDATOR.*/ and printer_notes=~/.*PRINTER_HAS_BOWDEN.*/ and nozzle_diameter[0]==0.8
+
+# Common print preset
+[print:*common predator quality*]
+perimeter_speed = 50
+small_perimeter_speed = 15
+external_perimeter_speed = 70%
+infill_speed = 65
+solid_infill_speed = 85%
+top_solid_infill_speed = 85%
+support_material_speed = 30
+support_material_interface_speed = 85%
+bridge_speed = 30
+gap_fill_speed = 40
+ironing_speed = 15
+
+# Common print preset
+[print:*common predator speed*]
+perimeter_speed = 70
+small_perimeter_speed = 15
+external_perimeter_speed = 70%
+infill_speed = 85
+solid_infill_speed = 85%
+top_solid_infill_speed = 85%
+support_material_speed = 30
+support_material_interface_speed = 85%
+bridge_speed = 30
+gap_fill_speed = 40
+ironing_speed = 15
+
+# Common print preset
+[print:*common predator 0.4 nozzle detailed*]
+inherits = *common predator 0.4 nozzle*
+extrusion_width = 0.42
+first_layer_extrusion_width = 0.41
+perimeter_extrusion_width = 0.42
+external_perimeter_extrusion_width = 0.42
+infill_extrusion_width = 0.4
+solid_infill_extrusion_width = 0.4
+top_infill_extrusion_width = 0.4
+support_material_extrusion_width = 0.38
+
+# Common print preset
+[print:*common predator 0.4 nozzle coarse*]
+inherits = *common predator 0.4 nozzle*
+extrusion_width = 0.44
+first_layer_extrusion_width = 0.42
+perimeter_extrusion_width = 0.5
+external_perimeter_extrusion_width = 0.5
+infill_extrusion_width = 0.5
+solid_infill_extrusion_width = 0.5
+top_infill_extrusion_width = 0.4
+support_material_extrusion_width = 0.38
+
+# Common print preset
+[print:*common predator 0.6 nozzle detailed*]
+inherits = *common predator 0.6 nozzle*
+extrusion_width = 0.64
+first_layer_extrusion_width = 0.62
+perimeter_extrusion_width = 0.64
+external_perimeter_extrusion_width = 0.64
+infill_extrusion_width = 0.6
+solid_infill_extrusion_width = 0.6
+top_infill_extrusion_width = 0.6
+support_material_extrusion_width = 0.56
+
+# Common print preset
+[print:*common predator 0.6 nozzle coarse*]
+inherits = *common predator 0.6 nozzle*
+extrusion_width = 0.67
+first_layer_extrusion_width = 0.64
+perimeter_extrusion_width = 0.7
+external_perimeter_extrusion_width = 0.7
+infill_extrusion_width = 0.7
+solid_infill_extrusion_width = 0.7
+top_infill_extrusion_width = 0.6
+support_material_extrusion_width = 0.56
+
+# Common print preset
+[print:*common predator 0.8 nozzle detailed*]
+inherits = *common predator 0.8 nozzle*
+extrusion_width = 0.84
+first_layer_extrusion_width = 0.82
+perimeter_extrusion_width = 0.84
+external_perimeter_extrusion_width = 0.84
+infill_extrusion_width = 0.8
+solid_infill_extrusion_width = 0.8
+top_infill_extrusion_width = 0.8
+support_material_extrusion_width = 0.72
+
+# Common print preset
+[print:*common predator 0.8 nozzle coarse*]
+inherits = *common predator 0.8 nozzle*
+extrusion_width = 0.87
+first_layer_extrusion_width = 0.84
+perimeter_extrusion_width = 0.9
+external_perimeter_extrusion_width = 0.9
+infill_extrusion_width = 0.9
+solid_infill_extrusion_width = 0.9
+top_infill_extrusion_width = 0.8
+support_material_extrusion_width = 0.72
+
+#########################################
+####### end common print presets ########
+#########################################
+
+#########################################
+########## begin print presets ##########
+#########################################
+
+[print:*0.08mm 0.4 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.4 nozzle detailed*; *common predator quality*
+layer_height = 0.08
+max_print_speed = 50
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.16mm 0.4 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.4 nozzle detailed*; *common predator quality*
+layer_height = 0.16
+max_print_speed = 60
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.16mm 0.4 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.4 nozzle coarse*; *common predator quality*
+layer_height = 0.16
+max_print_speed = 60
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.24mm 0.4 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.4 nozzle detailed*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 70
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.24mm 0.4 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.4 nozzle coarse*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 70
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.32mm 0.4 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.4 nozzle detailed*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 70
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.32mm 0.4 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.4 nozzle coarse*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 70
+perimeters = 3
+fill_pattern = grid
+
+[print:*0.16mm 0.6 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator quality*
+layer_height = 0.16
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.16mm 0.6 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator speed*
+layer_height = 0.16
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.16mm 0.6 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator quality*
+layer_height = 0.16
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.16mm 0.6 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator speed*
+layer_height = 0.16
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.6 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.6 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator speed*
+layer_height = 0.24
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.6 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.6 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator speed*
+layer_height = 0.24
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.6 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.6 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator speed*
+layer_height = 0.32
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.6 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.6 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator speed*
+layer_height = 0.32
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.6 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator quality*
+layer_height = 0.4
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.6 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.6 nozzle detailed*; *common predator speed*
+layer_height = 0.4
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.6 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator quality*
+layer_height = 0.4
+max_print_speed = 70
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.6 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.6 nozzle coarse*; *common predator speed*
+layer_height = 0.4
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.8 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.8 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator speed*
+layer_height = 0.24
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.8 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator quality*
+layer_height = 0.24
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.24mm 0.8 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator speed*
+layer_height = 0.24
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.8 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.8 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator speed*
+layer_height = 0.32
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.8 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator quality*
+layer_height = 0.32
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.32mm 0.8 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator speed*
+layer_height = 0.32
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.8 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator quality*
+layer_height = 0.4
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.8 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator speed*
+layer_height = 0.4
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.8 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator quality*
+layer_height = 0.4
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.4mm 0.8 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator speed*
+layer_height = 0.4
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.48mm 0.8 nozzle DETAILED QUALITY predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator quality*
+layer_height = 0.48
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.48mm 0.8 nozzle DETAILED SPEED predator*]
+inherits = *common predator 0.8 nozzle detailed*; *common predator speed*
+layer_height = 0.48
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.48mm 0.8 nozzle COARSE QUALITY predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator quality*
+layer_height = 0.48
+max_print_speed = 80
+perimeters = 2
+fill_pattern = gyroid
+
+[print:*0.48mm 0.8 nozzle COARSE SPEED predator*]
+inherits = *common predator 0.8 nozzle coarse*; *common predator speed*
+layer_height = 0.48
+max_print_speed = 90
+perimeters = 2
+fill_pattern = gyroid
+
+#########################################
+########### end print presets ###########
+#########################################
+
+#########################################
+######## begin filament presets #########
+#########################################
+
+# Common filament preset
+[filament:*common predator*]
+cooling = 0
+compatible_printers =
+extrusion_multiplier = 1
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = ""
+filament_soluble = 0
+min_print_speed = 15
+slowdown_below_layer_time = 20
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANYCUBIC.*/ and printer_notes=~/.*PRINTER_MODEL_PREDATOR.*/
+
+[filament:*PLA predator*]
+inherits = *common predator*
+bed_temperature = 60
+fan_below_layer_time = 100
+filament_colour = #FF3232
+filament_max_volumetric_speed = 10
+filament_type = PLA
+filament_density = 1.24
+filament_cost = 20
+first_layer_bed_temperature = 60
+first_layer_temperature = 200
+fan_always_on = 1
+cooling = 1
+max_fan_speed = 100
+min_fan_speed = 100
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+temperature = 200
+
+[filament:*PET predator*]
+inherits = *common predator*
+bed_temperature = 70
+cooling = 1
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_colour = #FF8000
+filament_max_volumetric_speed = 8
+filament_type = PETG
+filament_density = 1.27
+filament_cost = 30
+first_layer_bed_temperature =70
+first_layer_temperature = 240
+fan_always_on = 1
+max_fan_speed = 50
+min_fan_speed = 20
+bridge_fan_speed = 100
+temperature = 240
+
+[filament:*ABS predator*]
+inherits = *common predator*
+bed_temperature = 100
+cooling = 0
+disable_fan_first_layers = 3
+fan_below_layer_time = 20
+filament_colour = #3A80CA
+filament_max_volumetric_speed = 10
+filament_type = ABS
+filament_density = 1.04
+filament_cost = 20
+first_layer_bed_temperature = 100
+first_layer_temperature = 245
+fan_always_on = 0
+max_fan_speed = 0
+min_fan_speed = 0
+bridge_fan_speed = 30
+top_fan_speed = 0
+temperature = 245
+
+[filament:Generic PLA @predator]
+inherits = *PLA predator*
+filament_vendor = Generic
+
+[filament:Generic PETG @predator]
+inherits = *PET predator*
+filament_vendor = Generic
+
+[filament:Generic ABS @predator]
+inherits = *ABS predator*
+filament_vendor = Generic
+
+#########################################
+######### end filament presets ##########
+#########################################
+
+#########################################
+######### begin printer presets #########
+#########################################
+
+# Anycubic predator common printer preset
+[printer:*common predator*]
+printer_vendor = Anycubic
+printer_model = Predator
+printer_technology = FFF
+printer_variant = 0.4
+thumbnails = 16x16,220x124
+bed_shape = 188.779x16.516,186.621x32.9063,183.043x49.0462,178.072x64.8128,171.745x80.0862,164.112x94.75,155.229x108.693,145.165x121.808,133.997x133.997,121.808x145.165,108.693x155.229,94.75x164.112,80.0862x171.745,64.8128x178.072,49.0462x183.043,32.9063x186.621,16.516x188.779,1.16035e-14x189.5,-16.516x188.779,-32.9063x186.621,-49.0462x183.043,-64.8128x178.072,-80.0862x171.745,-94.75x164.112,-108.693x155.229,-121.808x145.165,-133.997x133.997,-145.165x121.808,-155.229x108.693,-164.112x94.75,-171.745x80.0862,-178.072x64.8128,-183.043x49.0462,-186.621x32.9063,-188.779x16.516,-189.5x2.32071e-14,-188.779x-16.516,-186.621x-32.9063,-183.043x-49.0462,-178.072x-64.8128,-171.745x-80.0862,-164.112x-94.75,-155.229x-108.693,-145.165x-121.808,-133.997x-133.997,-121.808x-145.165,-108.693x-155.229,-94.75x-164.112,-80.0862x-171.745,-64.8128x-178.072,-49.0462x-183.043,-32.9063x-186.621,-16.516x-188.779,-3.48106e-14x-189.5,16.516x-188.779,32.9063x-186.621,49.0462x-183.043,64.8128x-178.072,80.0862x-171.745,94.75x-164.112,108.693x-155.229,121.808x-145.165,133.997x-133.997,145.165x-121.808,155.229x-108.693,164.112x-94.75,171.745x-80.0862,178.072x-64.8128,183.043x-49.0462,186.621x-32.9063,188.779x-16.516,189.5x-4.64141e-14
+max_print_height = 450
+z_offset = 0
+single_extruder_multi_material = 0
+gcode_flavor = reprap
+silent_mode = 0
+remaining_times = 0
+use_relative_e_distances = 0
+use_firmware_retraction = 0
+use_volumetric_e = 0
+variable_layer_height = 1
+start_gcode = "; start_gcode | start\n\n; v11 2020-09-02_14-27 tillverka\n\n; set metric values\n\nG21\n\n; use absolute positioning\n\nG90\n\n; set extruder to absolute mode\n\nM82\n\n; start with fan off\n\nM107\n\n; set e-steps for bondtech bmg and force store in eeprom\n; mm/step for chitu\n; 1/415 for bondtech bmg\n\nM8011 S0.0024096394\nM8500\n\n; set temps\n\nM104 S[first_layer_temperature]\nM140 S[first_layer_bed_temperature]\n\n; home xy\n\nG28 X0 Y0\n\n; home z\n\nG28 Z0\n\n; move the head down to Z 94mm\n\nG1 Z94.0 F2394\n\n; set and wait for temps\n\nM109 S[first_layer_temperature]\nM190 S[first_layer_bed_temperature]\n\n; zero the extruded length\n\nG92 E0\n\n; extrude 3mm of feed stock\n\nG1 F200 E3\n\n; zero the extruded length again\n\nG92 E0\n\n; set speed\n\nG1 F{travel_speed}\n\n; print preskirt\n\nG92 E0\nG1 E3.94000 F2520.00000\n\nG1 X125.464 Y-139.310\nG1 Z0.329 F3994.000\n\nG1 F994.000\n\nG1 X125.464 Y-139.310 E4.19679\nG1 X130.218 Y-134.876 E4.70359\nG1 X132.569 Y-132.567 E4.96053\nG1 X137.099 Y-127.877 E5.46890\nG1 X139.325 Y-125.447 E5.72585\nG1 X141.507 Y-122.981 E5.98254\nG1 X145.685 Y-118.002 E6.48934\nG1 X149.741 Y-112.810 E7.00296\nG1 X153.561 Y-107.552 E7.50975\nG1 X155.440 Y-104.819 E7.76827\nG1 X158.980 Y-99.367 E8.27506\nG1 X160.702 Y-96.558 E8.53201\nG1 X163.962 Y-90.911 E9.04038\nG1 X165.535 Y-88.015 E9.29732\nG1 X168.496 Y-82.205 E9.80570\nG1 X169.915 Y-79.231 E10.06264\nG1 X171.280 Y-76.235 E10.31934\nG1 X173.819 Y-70.251 E10.82613\nG1 X176.180 Y-64.101 E11.33975\nG1 X178.297 Y-57.955 E11.84654\nG1 X179.294 Y-54.793 E12.10507\nG1 X181.085 Y-48.544 E12.61186\nG1 X181.911 Y-45.354 E12.86880\nG1 X183.378 Y-39.001 E13.37718\nG1 X184.035 Y-35.771 E13.63412\nG1 X185.168 Y-29.350 E14.14250\nG1 X185.655 Y-26.091 E14.39944\nG1 X186.084 Y-22.826 E14.65614\nG1 X186.764 Y-16.362 E15.16293\nG1 X187.223 Y-9.790 E15.67655\nG1 X187.450 Y-3.294 E16.18334\nG1 X187.479 Y0.002 E16.44028\nG1 X187.450 Y3.294 E16.69698\nG1 X187.223 Y9.810 E17.20529\nG1 X187.021 Y13.100 E17.46229\nG1 X186.454 Y19.575 E17.96909\nG1 X186.079 Y22.870 E18.22761\nG1 X185.174 Y29.307 E18.73440\nG1 X184.031 Y35.794 E19.24802\nG1 X182.679 Y42.152 E19.75481\nG1 X181.910 Y45.357 E20.01176\nG1 X180.223 Y51.655 E20.52013\nG1 X179.287 Y54.815 E20.77708\nG1 X177.272 Y61.017 E21.28545\nG1 X176.172 Y64.123 E21.54239\nG1 X175.019 Y67.207 E21.79909\nG1 X172.584 Y73.234 E22.30588\nG1 X169.905 Y79.252 E22.81950\nG1 X167.055 Y85.094 E23.32629\nG1 X165.524 Y88.035 E23.58482\nG1 X162.373 Y93.721 E24.09161\nG1 X160.700 Y96.560 E24.34855\nG1 X157.245 Y102.090 E24.85693\nG1 X155.427 Y104.838 E25.11387\nG1 X151.687 Y110.180 E25.62225\nG1 X149.727 Y112.829 E25.87919\nG1 X147.722 Y115.441 E26.13588\nG1 X143.631 Y120.493 E26.64268\nG1 X139.310 Y125.464 E27.15629\nG1 X134.876 Y130.218 E27.66309\nG1 X132.567 Y132.569 E27.92003\nG1 X127.877 Y137.099 E28.42840\nG1 X125.447 Y139.325 E28.68535\nG1 X122.981 Y141.507 E28.94204\nG1 X118.002 Y145.685 E29.44883\nG1 X112.810 Y149.741 E29.96245\nG1 X107.552 Y153.561 E30.46924\nG1 X104.819 Y155.440 E30.72777\nG1 X99.367 Y158.980 E31.23456\nG1 X96.558 Y160.702 E31.49151\nG1 X90.911 Y163.962 E31.99988\nG1 X88.015 Y165.535 E32.25682\nG1 X82.205 Y168.496 E32.76520\nG1 X79.231 Y169.915 E33.02214\nG1 X76.235 Y171.280 E33.27884\nG1 X70.251 Y173.819 E33.78563\nG1 X64.101 Y176.180 E34.29925\nG1 X57.955 Y178.297 E34.80604\nG1 X54.793 Y179.294 E35.06457\nG1 X48.544 Y181.085 E35.57136\nG1 X45.354 Y181.911 E35.82830\nG1 X39.001 Y183.378 E36.33668\nG1 X35.771 Y184.035 E36.59362\nG1 X29.350 Y185.168 E37.10200\nG1 X26.091 Y185.655 E37.35894\nG1 X22.826 Y186.084 E37.61563\nG1 X16.362 Y186.764 E38.12242\nG1 X9.790 Y187.223 E38.63605\nG1 X3.294 Y187.450 E39.14283\nG1 X-0.002 Y187.479 E39.39978\nG1 X-3.294 Y187.450 E39.65648\nG1 X-9.810 Y187.223 E40.16479\nG1 X-13.100 Y187.021 E40.42179\nG1 X-19.575 Y186.454 E40.92858\nG1 X-22.870 Y186.079 E41.18711\nG1 X-29.307 Y185.174 E41.69390\nG1 X-35.794 Y184.031 E42.20752\nG1 X-42.152 Y182.679 E42.71431\nG1 X-45.357 Y181.910 E42.97126\nG1 X-51.655 Y180.223 E43.47963\nG1 X-54.815 Y179.287 E43.73657\nG1 X-61.017 Y177.272 E44.24495\nG1 X-64.123 Y176.172 E44.50189\nG1 X-67.207 Y175.019 E44.75859\nG1 X-73.234 Y172.584 E45.26538\nG1 X-79.252 Y169.905 E45.77900\nG1 X-85.094 Y167.055 E46.28579\nG1 X-88.035 Y165.524 E46.54432\nG1 X-93.721 Y162.373 E47.05111\nG1 X-96.560 Y160.700 E47.30805\nG1 X-102.090 Y157.245 E47.81643\nG1 X-104.838 Y155.427 E48.07337\nG1 X-110.180 Y151.687 E48.58174\nG1 X-112.829 Y149.727 E48.83869\nG1 X-115.441 Y147.722 E49.09538\nG1 X-120.493 Y143.631 E49.60218\nG1 X-125.464 Y139.310 E50.11579\nG1 X-130.218 Y134.876 E50.62259\nG1 X-132.569 Y132.567 E50.87953\nG1 X-137.099 Y127.877 E51.38790\nG1 X-139.325 Y125.447 E51.64485\nG1 X-141.507 Y122.981 E51.90154\nG1 X-145.685 Y118.002 E52.40833\nG1 X-149.741 Y112.810 E52.92195\nG1 X-153.561 Y107.552 E53.42874\nG1 X-155.440 Y104.819 E53.68727\nG1 X-158.980 Y99.367 E54.19406\nG1 X-160.702 Y96.558 E54.45101\nG1 X-163.962 Y90.911 E54.95938\nG1 X-165.535 Y88.015 E55.21632\nG1 X-168.496 Y82.205 E55.72470\nG1 X-169.915 Y79.231 E55.98164\nG1 X-171.280 Y76.235 E56.23834\nG1 X-173.819 Y70.251 E56.74513\nG1 X-176.180 Y64.101 E57.25875\nG1 X-178.297 Y57.955 E57.76554\nG1 X-179.294 Y54.793 E58.02407\nG1 X-181.085 Y48.544 E58.53086\nG1 X-181.911 Y45.354 E58.78780\nG1 X-183.378 Y39.001 E59.29618\nG1 X-184.035 Y35.771 E59.55312\nG1 X-185.168 Y29.350 E60.06149\nG1 X-185.655 Y26.091 E60.31844\nG1 X-186.084 Y22.826 E60.57513\nG1 X-186.764 Y16.362 E61.08192\nG1 X-187.223 Y9.790 E61.59554\nG1 X-187.450 Y3.294 E62.10233\nG1 X-187.479 Y-0.002 E62.35928\nG1 X-187.450 Y-3.294 E62.61598\nG1 X-187.223 Y-9.810 E63.12429\nG1 X-187.021 Y-13.100 E63.38129\nG1 X-186.454 Y-19.575 E63.88808\nG1 X-186.079 Y-22.870 E64.14661\nG1 X-185.174 Y-29.307 E64.65340\nG1 X-184.031 Y-35.794 E65.16702\nG1 X-182.679 Y-42.152 E65.67381\nG1 X-181.910 Y-45.357 E65.93076\nG1 X-180.223 Y-51.655 E66.43913\nG1 X-179.287 Y-54.815 E66.69607\nG1 X-177.272 Y-61.017 E67.20445\nG1 X-176.172 Y-64.123 E67.46139\nG1 X-175.019 Y-67.207 E67.71809\nG1 X-172.584 Y-73.234 E68.22488\nG1 X-169.905 Y-79.252 E68.73850\nG1 X-167.055 Y-85.094 E69.24529\nG1 X-165.524 Y-88.035 E69.50382\nG1 X-162.373 Y-93.721 E70.01061\nG1 X-160.700 Y-96.560 E70.26755\nG1 X-157.245 Y-102.090 E70.77593\nG1 X-155.427 Y-104.838 E71.03287\nG1 X-151.687 Y-110.180 E71.54124\nG1 X-149.727 Y-112.829 E71.79819\nG1 X-147.722 Y-115.441 E72.05488\nG1 X-143.631 Y-120.493 E72.56167\nG1 X-139.310 Y-125.464 E73.07529\nG1 X-134.876 Y-130.218 E73.58209\nG1 X-132.567 Y-132.569 E73.83903\nG1 X-127.877 Y-137.099 E74.34740\nG1 X-125.447 Y-139.325 E74.60435\nG1 X-122.981 Y-141.507 E74.86104\nG1 X-118.002 Y-145.685 E75.36783\nG1 X-112.810 Y-149.741 E75.88145\nG1 X-107.552 Y-153.561 E76.38824\nG1 X-104.819 Y-155.440 E76.64677\nG1 X-99.367 Y-158.980 E77.15356\nG1 X-96.558 Y-160.702 E77.41051\nG1 X-90.911 Y-163.962 E77.91888\nG1 X-88.015 Y-165.535 E78.17582\nG1 X-82.205 Y-168.496 E78.68420\nG1 X-79.231 Y-169.915 E78.94114\nG1 X-76.235 Y-171.280 E79.19784\nG1 X-70.251 Y-173.819 E79.70463\nG1 X-64.101 Y-176.180 E80.21825\nG1 X-57.955 Y-178.297 E80.72504\nG1 X-54.793 Y-179.294 E80.98356\nG1 X-48.544 Y-181.085 E81.49036\nG1 X-45.354 Y-181.911 E81.74730\nG1 X-39.001 Y-183.378 E82.25568\nG1 X-35.771 Y-184.035 E82.51262\nG1 X-29.350 Y-185.168 E83.02099\nG1 X-26.091 Y-185.655 E83.27794\nG1 X-22.826 Y-186.084 E83.53463\nG1 X-16.362 Y-186.764 E84.04142\nG1 X-9.790 Y-187.223 E84.55504\nG1 X-3.294 Y-187.450 E85.06183\nG1 X0.006 Y-187.479 E85.31908\nG1 X6.521 Y-187.366 E85.82715\nG1 X9.810 Y-187.223 E86.08379\nG1 X13.100 Y-187.021 E86.34079\nG1 X19.575 Y-186.454 E86.84758\nG1 X22.870 Y-186.079 E87.10611\nG1 X29.307 Y-185.174 E87.61290\nG1 X35.794 Y-184.031 E88.12652\nG1 X42.152 Y-182.679 E88.63331\nG1 X45.357 Y-181.910 E88.89025\nG1 X51.655 Y-180.223 E89.39863\nG1 X54.815 Y-179.287 E89.65557\nG1 X61.017 Y-177.272 E90.16395\nG1 X64.123 Y-176.172 E90.42089\nG1 X67.207 Y-175.019 E90.67759\nG1 X73.234 Y-172.584 E91.18438\nG1 X79.252 Y-169.905 E91.69800\nG1 X85.094 Y-167.055 E92.20479\nG1 X88.035 Y-165.524 E92.46332\nG1 X93.721 Y-162.373 E92.97011\nG1 X96.560 Y-160.700 E93.22705\nG1 X102.090 Y-157.245 E93.73543\nG1 X104.838 Y-155.427 E93.99237\nG1 X110.180 Y-151.687 E94.50074\nG1 X112.829 Y-149.727 E94.75768\nG1 X115.441 Y-147.722 E95.01438\nG1 X120.493 Y-143.631 E95.52117\nG1 X122.911 Y-141.529 E95.77098\n\n; end preskirt\n; start_gcode | end"
+end_gcode = "; end_gcode | start\n\n; v11 2020-09-02_14-27 tillverka\n\n; use relative positioning\n\nG91\n\n; retract the filament a bit before lifting the nozzle to release some of the pressure\n\nG1 E-1 F300\n\n; home\n\nG28\n\n; use absolute positioning\n\nG90\n\n; cooldown\n\nM104 S0\nM140 S0\n\n; end_gcode | end\n"
+before_layer_gcode =
+layer_gcode =
+toolchange_gcode =
+between_objects_gcode =
+retract_length = 4
+retract_lift = 0.3
+retract_lift_above = 0
+retract_lift_below = 449
+retract_speed = 30
+deretract_speed = 0
+retract_restart_extra = 0
+retract_before_travel = 2
+retract_layer_change = 1
+wipe = 1
+retract_before_wipe = 70%
+retract_length_toolchange = 10
+retract_restart_extra_toolchange = 0
+extruder_colour = #1193FF
+machine_max_acceleration_e = 3000
+machine_max_acceleration_extruding = 1000
+machine_max_acceleration_retracting = 1000
+machine_max_acceleration_x = 1500
+machine_max_acceleration_y = 1500
+machine_max_acceleration_z = 1500
+machine_max_feedrate_e = 60
+machine_max_feedrate_x = 200
+machine_max_feedrate_y = 200
+machine_max_feedrate_z = 200
+machine_max_jerk_e = 5
+machine_max_jerk_x = 5
+machine_max_jerk_y = 5
+machine_max_jerk_z = 5
+machine_min_extruding_rate = 0
+machine_min_travel_rate = 0
+octoprint_apikey =
+octoprint_host =
+printer_notes =
+printer_settings_id =
+serial_port =
+serial_speed = 125000
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_ANYCUBIC\nPRINTER_MODEL_PREDATOR\nPRINTER_HAS_BOWDEN\n
+default_filament_profile = Generic PLA @predator
+
+[printer:Anycubic Predator 0.4 nozzle]
+inherits = *common predator*
+printer_model = Anycubic Predator 0.4 nozzle
+nozzle_diameter = 0.4
+min_layer_height = 0.08
+max_layer_height = 0.32
+default_print_profile = 0.16mm 0.4 nozzle DETAILED QUALITY predator
+
+[printer:Anycubic Predator 0.6 nozzle]
+inherits = *common predator*
+printer_model = Anycubic Predator 0.6 nozzle
+nozzle_diameter = 0.6
+min_layer_height = 0.12
+max_layer_height = 0.4
+default_print_profile = 0.24mm 0.8 nozzle DETAILED QUALITY predator
+
+[printer:Anycubic Predator 0.8 nozzle]
+inherits = *common predator*
+printer_model = Anycubic Predator 0.8 nozzle
+nozzle_diameter = 0.8
+min_layer_height = 0.16
+max_layer_height = 0.48
+default_print_profile = 0.24mm 0.8 nozzle DETAILED QUALITY predator
+
+#########################################
+########## end printer presets ##########
+#########################################

--- a/resources/profiles/Anycubic.ini
+++ b/resources/profiles/Anycubic.ini
@@ -53,6 +53,12 @@ variants = 0.4
 technology = FFF
 family = MEGA
 
+[printer_model:PREDATOR]
+name = Anycubic Predator
+variants = 0.4; 0.6; 0.8
+technology = FFF
+default_materials = Generic PLA @PREDATOR; Generic PETG @PREDATOR; Anycubic PLA @PREDATOR; Prusament PLA @PREDATOR; Prusament PETG @PREDATOR
+
 # All presets starting with asterisk, for example *common*, are intermediate and they will
 # not make it into the user interface.
 


### PR DESCRIPTION
Our shop has been using 5 anycubic predators with prusaslicer every day for about one year now. The profiles have been refined over and over to ensure maximum performance and reliability from these printers - which are *extremely* finnicky [as they say, a butterfly's wings in Brasil can cause a Predator to layershift on Mars]. We've upgraded all of them to bondtech BMGs + original E3D volcanos but I made sure to keep these profiles at a definitive stage before we upgraded, to publish them here in the future, so here I am.

The profiles are for 0.4, 0.6, and 0.8mm nozzles.

The logic of these profiles is to be able to choose between:

- [coarse / detailed] meaning the extrusion width
- [speed / quality] meaning the speed of the print

These two concepts are basically blended together in the MK3S profiles except slightly for the 0.15/0.2 profiles where quality and speed can be chosen. Our profiles allow for all combinations except where unreasonable [low end of the nozzle size spectrum].

The bed size has been updated to 379mm which is correct given that the glass is 380mm in diameter and of course needs no clips as it is mounted to the printer directly. Very important detail: the start gcode integrates an initial nozzle purge line [aka preskirt] that goes all around the plate at the very edge of it, in order to purge the nozzle from 360degrees, something absolutely necessary especially when printing remotely via octoprint.

I have not touched the filament settings but rather inherited them from the Kossel profile as I still am not 100% clear on the new filament naming scheme and recursiveness implemented in 2.2.0 [I think].

The profiles are extremely rational and avoid any kind of "finger to the wind" optimizations on a per-profile level. Everything is neatly abstracted in its own common profile and the final layer profiles only change the 4 things they absolutely have to.

Thanks in advance for your time and feedback.