### PR TITLE
creality.ini: introduce slow abl variant start_gcode

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -635,14 +635,17 @@ default_filament_profile = Creality PLA @CREALITY
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 ; home all\nG1 Z2 F240\nG1 X2 Y10 F3000\nG1 Z0.28 F240\nG92 E0.0\nG1 Y190 E15.0 F1500.0 ; intro line\nG1 X2.3 F5000\nG1 Y10 E15.0 F1200.0 ; intro line\nG92 E0.0
 end_gcode = M104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\n{if layer_z < max_print_height}G1 Z{z_offset+min(layer_z+5, max_print_height)} F600{endif} ; Move print head up\nG1 X5 Y170 F3000 ; present print\n{if layer_z < max_print_height-10}G1 Z{z_offset+min(layer_z+70, max_print_height-10)} F600{endif} ; Move print head up\nM84 X Y E ; disable motors
 
-[printer:*abl*]
+[printer:*fastabl*]
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S150 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0.0\nG1 Y190 E15.0 F1500.0 ; intro line\nG1 X2.3 F5000\nG1 Y10 E15.0 F1200.0 ; intro line\nG92 E0.0
+
+[printer:*slowabl*]
+start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S150 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0.0\nG1 Y190 E15.0 F1500.0 ; intro line\nG1 X2.3 F5000\nG1 Y10 E15.0 F1200.0 ; intro line\nG92 E0.0
 
 [printer:*invertedz*]
 end_gcode = M104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\n{if layer_z < max_print_height}G1 Z{z_offset+min(layer_z+5, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F3000 ; present print\n{if layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed down\nM84 X Y E ; disable motors
 
 [printer:Creality Ender-3 BLTouch]
-inherits = Creality Ender-3; *abl*
+inherits = Creality Ender-3; *fastabl*
 renamed_from = "Creality ENDER-3 BLTouch"
 printer_model = ENDER3BLTOUCH
 
@@ -655,7 +658,7 @@ printer_notes = Don't remove the following keywords! These keywords are used in 
 max_print_height = 300
 
 [printer:Creality Ender-5 Plus]
-inherits = Creality Ender-3; *abl*; *invertedz*
+inherits = Creality Ender-3; *slowabl*; *invertedz*
 retract_length = 6
 bed_shape = 5x5,355x5,355x355,5x355
 printer_model = ENDER5PLUS
@@ -713,7 +716,7 @@ printer_notes = Don't remove the following keywords! These keywords are used in 
 max_print_height = 400
 
 [printer:Creality CR-10 S Pro]
-inherits = Creality Ender-3; *abl*
+inherits = Creality Ender-3; *slowabl*
 retract_length = 6
 bed_shape = 0x0,300x0,300x300,0x300
 printer_model = CR10SPRO
@@ -721,7 +724,7 @@ printer_notes = Don't remove the following keywords! These keywords are used in 
 max_print_height = 400
 
 [printer:Creality CR-10 S Pro V2]
-inherits = Creality Ender-3; *abl*
+inherits = Creality Ender-3; *slowabl*
 retract_length = 6
 bed_shape = 5x5,305x5,305x305,5x305
 printer_model = CR10SPROV2
@@ -750,7 +753,7 @@ printer_model = CR20
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR20\nPRINTER_HAS_BOWDEN
 
 [printer:Creality CR-20 Pro]
-inherits = Creality Ender-3; *abl*
+inherits = Creality Ender-3; *fastabl*
 retract_length = 4
 printer_model = CR20PRO
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR20PRO\nPRINTER_HAS_BOWDEN


### PR DESCRIPTION
printers with a large bed are probably more prone to heat induced
bed warping, there we'll split up our abl start_gcode in fast
and slow variants, where printers with a smaller bed like
the Ender-3 will still use the fast variant, printers with
a large bed like the CR-10 will use the slow variant which
heats up the bed before starting the abl procedure.