### PR TITLE
Creality Filaments 4

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -568,6 +568,7 @@ filament_colour = #FFE200
 printer_technology = FFF
 before_layer_gcode = ;BEFORE_LAYER_CHANGE\nG92 E0\n;[layer_z]\n\n
 between_objects_gcode = 
+pause_print_gcode = 
 deretract_speed = 0
 extruder_colour = #FFFF00
 extruder_offset = 0x0

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -508,6 +508,17 @@ filament_cost = 19.00
 filament_density = 1.24
 filament_colour = #FF0000
 
+[filament:Devil Design PLA (Galaxy) @CREALITY]
+inherits = *PLA*
+filament_vendor = Devil Design
+temperature = 225
+bed_temperature = 65
+first_layer_temperature = 225
+first_layer_bed_temperature = 65
+filament_cost = 19.00
+filament_density = 1.24
+filament_colour = #FF0000
+
 [filament:Extrudr PLA NX2 @CREALITY]
 inherits = *PLA*
 filament_vendor = Extrudr


### PR DESCRIPTION
Add some glitter filament

With regard to #4980, it seems to make sense to disable pause_print by default, until some specific models have been verified to be capable. If and when capable models have been identified we can add a *pausecapable* virtual printer, and inherit that for the capable models.

However setting pause_print_gcode to "" does not grey out the menu item in the context menu, so that seems to be a bug...