### PR TITLE
Allow full_width fields to take the full width

### DIFF
--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -509,7 +509,13 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord v_pos)
         option_set.front().side_widget == nullptr && og_line.get_extra_widgets().size() == 0)
     {
         if (field && field->undo_to_sys_bitmap())
-            draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->bmp(), field->undo_bitmap()->bmp(), field->blink());
+            h_pos = draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->bmp(), field->undo_bitmap()->bmp(), field->blink());
+        h_pos += ctrl->m_h_gap;
+        // update width for full_width fields
+        if (option_set.front().opt.full_width) {
+            if (field->getWindow())
+                field->getWindow()->SetSize(this->ctrl->GetSize().x - h_pos, -1);
+        }
         return;
     }
 


### PR DESCRIPTION
instead of `3 * Field::def_width_wider() * wxGetApp().em_unit()`

![image](https://user-images.githubusercontent.com/6536403/98866249-f0cd8200-246c-11eb-8ee4-ca8d29d3633b.png)


also useful for the output filename format