### PR TITLE
Update Translation PrusaSlicer_de.po

### DIFF
--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -910,7 +910,7 @@ msgstr "Druckbett individuelle Textur"
 
 #: src/slic3r/GUI/BedShapeDialog.hpp:59 src/slic3r/GUI/ConfigWizard.cpp:929
 msgid "Bed Shape"
-msgstr "Druckbrettprofil"
+msgstr "Druckbettprofil"
 
 #: src/libslic3r/PrintConfig.cpp:51
 msgid "Bed shape"
@@ -4109,11 +4109,11 @@ msgstr "GESCHLOSSENES SCHLOSS"
 
 #: src/slic3r/GUI/Tab.cpp:3280
 msgid "LOCKED LOCK icon indicates that the settings are the same as the system (or default) values for the current option group"
-msgstr "Das Symbol LOCKED LOCK zeigt an, dass die Einstellungen mit den System- (oder Standard-) Werten für die aktuelle Optionsgruppe übereinstimmen"
+msgstr "Das Symbol GESCHLOSSENES SCHLOSS zeigt an, dass die Einstellungen mit den System- (oder Standard-) Werten für die aktuelle Optionsgruppe übereinstimmen"
 
 #: src/slic3r/GUI/Tab.cpp:3296
 msgid "LOCKED LOCK icon indicates that the value is the same as the system (or default) value."
-msgstr "Das Symbol LOCKED LOCK zeigt an, dass der Wert mit dem System- (oder Standard-) Wert übereinstimmt."
+msgstr "Das Symbol GESCHLOSSENES SCHLOSS zeigt an, dass der Wert mit dem System- (oder Standard-) Wert übereinstimmt."
 
 #: src/libslic3r/PrintConfig.cpp:3508
 msgid "Logging level"
@@ -7461,7 +7461,7 @@ msgstr "Stützstrukturen/Raft/Schürzen Extruder"
 #: src/slic3r/GUI/Plater.cpp:500 src/libslic3r/PrintConfig.cpp:1901
 #: src/libslic3r/PrintConfig.cpp:2674
 msgid "Support on build plate only"
-msgstr "Stützstrukturen nur auf dem Druckbrett"
+msgstr "Stützstrukturen nur auf dem Druckbett"
 
 #: src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp:888
 msgid "Support parameter change"


### PR DESCRIPTION
This fixes a missing "Locked Lock" Tooltip translation in german and matches all translations for "_Bed_" to "_Bett_", not "Brett".(board)