### PR TITLE
creality.ini: raise remaining PLA bed temperatures to 60

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -435,9 +435,9 @@ inherits = *PLA*
 renamed_from = "Creality PLA @ENDER3"
 filament_vendor = Creality
 temperature = 200
-bed_temperature = 50
+bed_temperature = 60
 first_layer_temperature = 205
-first_layer_bed_temperature = 50
+first_layer_bed_temperature = 60
 filament_colour = #42BDD8
 
 [filament:Creality PETG @CREALITY]
@@ -467,9 +467,9 @@ inherits = *PLA*
 renamed_from = "Prusament PLA @ENDER3"
 filament_vendor = Prusa Polymers
 temperature = 210
-bed_temperature = 50
+bed_temperature = 60
 first_layer_temperature = 215
-first_layer_bed_temperature = 50
+first_layer_bed_temperature = 60
 filament_cost = 24.99
 filament_density = 1.24
 filament_colour = #F94D0C


### PR DESCRIPTION
While doing a bunch of bed adhesion tests, both on Creality's
FakeTak as well as on smooth PEI, while 50 degrees seems to work
with most lower temp PLAs at least, but less so with the higher
temp PLAs, it universally requires the first layer height to be
dialed in much better to not get any warping.

With the bed temperature set to 60 degrees, there is much more
leeway in the first layer height while still getting unwarped
prints.

Particularly given that most Creality printers don't have ABL as
standard, I think it might sense from a robustness perspective
to have all PLAs default to at least 60 degrees, as to increase
chances prints will come out just fine.

https://www.prusaprinters.org/prints/4634-bed-adhesion-warp-test