### PR TITLE
Start Simulation for Duet

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6124,11 +6124,12 @@ void Plater::send_gcode()
         upload_job.printhost->get_groups(groups);
     }
     
-    PrintHostSendDialog dlg(default_output_file, upload_job.printhost->can_start_print(), groups);
+    PrintHostSendDialog dlg(default_output_file, upload_job.printhost->get_post_upload_actions(), groups);
     if (dlg.ShowModal() == wxID_OK) {
         upload_job.upload_data.upload_path = dlg.filename();
-        upload_job.upload_data.start_print = dlg.start_print();
+        upload_job.upload_data.post_action = dlg.post_action();
         upload_job.upload_data.group       = dlg.group();
+
         p->export_gcode(fs::path(), false, std::move(upload_job));
     }
 }

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -1,6 +1,7 @@
 #ifndef slic3r_PrintHostSendDialog_hpp_
 #define slic3r_PrintHostSendDialog_hpp_
 
+#include <set>
 #include <string>
 #include <boost/filesystem/path.hpp>
 
@@ -13,14 +14,15 @@
 
 class wxButton;
 class wxTextCtrl;
+class wxChoice;
 class wxComboBox;
-class wxCheckBox;
 class wxDataViewListCtrl;
 
 
 namespace Slic3r {
 
 struct PrintHostJob;
+enum class PrintHostPostUploadAction;
 
 namespace GUI {
 
@@ -28,16 +30,16 @@ namespace GUI {
 class PrintHostSendDialog : public GUI::MsgDialog
 {
 public:
-    PrintHostSendDialog(const boost::filesystem::path &path, bool can_start_print, const wxArrayString& groups);
+    PrintHostSendDialog(const boost::filesystem::path &path, std::set<PrintHostPostUploadAction> post_actions, const wxArrayString& groups);
     boost::filesystem::path filename() const;
-    bool start_print() const;
+    PrintHostPostUploadAction post_action() const;
     std::string group() const;
 
     virtual void EndModal(int ret) override;
 private:
     wxTextCtrl *txt_filename;
     wxComboBox *combo_groups;
-    bool start_print_selected { false };
+    PrintHostPostUploadAction post_upload_action;
 };
 
 

--- a/src/slic3r/Utils/AstroBox.cpp
+++ b/src/slic3r/Utils/AstroBox.cpp
@@ -115,11 +115,11 @@ bool AstroBox::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
         % url
         % upload_filename.string()
         % upload_parent_path.string()
-        % upload_data.start_print;
+        % (upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false");
 
     auto http = Http::post(std::move(url));
     set_auth(http);
-    http.form_add("print", upload_data.start_print ? "true" : "false")
+    http.form_add("print", upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false")
         .form_add("path", upload_parent_path.string())      // XXX: slashes on windows ???
         .form_add_file("file", upload_data.source_path.string(), upload_filename.string())
         .on_complete([&](std::string body, unsigned status) {

--- a/src/slic3r/Utils/AstroBox.hpp
+++ b/src/slic3r/Utils/AstroBox.hpp
@@ -26,7 +26,7 @@ public:
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
     bool has_auto_discovery() const override { return true; }
     bool can_test() const override { return true; }
-    bool can_start_print() const override { return true; }
+    std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set({PrintHostPostUploadAction::StartPrint});}
     std::string get_host() const override { return host; }
     
 protected:

--- a/src/slic3r/Utils/Duet.hpp
+++ b/src/slic3r/Utils/Duet.hpp
@@ -25,7 +25,7 @@ public:
 	bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
 	bool has_auto_discovery() const override { return false; }
 	bool can_test() const override { return true; }
-	bool can_start_print() const override { return true; }
+	std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set({PrintHostPostUploadAction::StartPrint, PrintHostPostUploadAction::StartSimulation});}
 	std::string get_host() const override { return host; }
    
 private:
@@ -39,7 +39,7 @@ private:
 	std::string timestamp_str() const;
 	ConnectionType connect(wxString &msg) const;
 	void disconnect(ConnectionType connectionType) const;
-	bool start_print(wxString &msg, const std::string &filename, ConnectionType connectionType) const;
+	bool start_print(wxString &msg, const std::string &filename, ConnectionType connectionType, bool simulationMode) const;
 	int get_err_code_from_body(const std::string &body) const;
 };
 

--- a/src/slic3r/Utils/FlashAir.hpp
+++ b/src/slic3r/Utils/FlashAir.hpp
@@ -26,7 +26,7 @@ public:
 	bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
 	bool has_auto_discovery() const override { return false; }
 	bool can_test() const override { return true; }
-	bool can_start_print() const override { return false; }
+	std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set<PrintHostPostUploadAction>();}
 	std::string get_host() const override { return host; }
     
 private:

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -137,11 +137,11 @@ bool OctoPrint::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Erro
         % url
         % upload_filename.string()
         % upload_parent_path.string()
-        % upload_data.start_print;
+        % (upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false");
 
     auto http = Http::post(std::move(url));
     set_auth(http);
-    http.form_add("print", upload_data.start_print ? "true" : "false")
+    http.form_add("print", upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false")
         .form_add("path", upload_parent_path.string())      // XXX: slashes on windows ???
         .form_add_file("file", upload_data.source_path.string(), upload_filename.string())
         .on_complete([&](std::string body, unsigned status) {

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -28,7 +28,7 @@ public:
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
     bool has_auto_discovery() const override { return true; }
     bool can_test() const override { return true; }
-    bool can_start_print() const override { return true; }
+    std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set({PrintHostPostUploadAction::StartPrint});}
     std::string get_host() const override { return m_host; }
     const std::string& get_apikey() const { return m_apikey; }
     const std::string& get_cafile() const { return m_cafile; }
@@ -57,7 +57,7 @@ public:
 
     wxString get_test_ok_msg() const override;
     wxString get_test_failed_msg(wxString &msg) const override;
-    bool can_start_print() const override { return false; }
+    std::set<PrintHostPostUploadAction> get_post_upload_actions() const override {return std::set<PrintHostPostUploadAction>();}
 
 protected:
     bool validate_version_text(const boost::optional<std::string> &version_text) const override;
@@ -82,7 +82,7 @@ public:
 
     wxString get_test_ok_msg() const override;
     wxString get_test_failed_msg(wxString& msg) const override;
-    bool can_start_print() const override { return true; }
+    std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set({PrintHostPostUploadAction::StartPrint});}
 
 protected:
     bool validate_version_text(const boost::optional<std::string>& version_text) const override;

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -2,6 +2,7 @@
 #define slic3r_PrintHost_hpp_
 
 #include <memory>
+#include <set>
 #include <string>
 #include <functional>
 #include <boost/filesystem/path.hpp>
@@ -16,6 +17,11 @@ namespace Slic3r {
 
 class DynamicPrintConfig;
 
+enum class PrintHostPostUploadAction {
+    None,
+    StartPrint,
+    StartSimulation
+};
 
 struct PrintHostUpload
 {
@@ -24,7 +30,7 @@ struct PrintHostUpload
     
     std::string group;
     
-    bool start_print = false;
+    PrintHostPostUploadAction post_action = PrintHostPostUploadAction::None;
 };
 
 
@@ -44,7 +50,7 @@ public:
     virtual bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const = 0;
     virtual bool has_auto_discovery() const = 0;
     virtual bool can_test() const = 0;
-    virtual bool can_start_print() const = 0;
+    virtual std::set<PrintHostPostUploadAction> get_post_upload_actions() const = 0;
     // A print host usually does not support multiple printers, with the exception of Repetier server.
     virtual bool supports_multiple_printers() const { return false; }
     virtual std::string get_host() const = 0;

--- a/src/slic3r/Utils/Repetier.cpp
+++ b/src/slic3r/Utils/Repetier.cpp
@@ -107,7 +107,9 @@ bool Repetier::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
 
     bool res = true;
 
-    auto url = upload_data.start_print?make_url((boost::format("printer/job/%1%") % port).str()):make_url((boost::format("printer/model/%1%") % port).str());
+    auto url = upload_data.post_action == PrintHostPostUploadAction::StartPrint
+        ? make_url((boost::format("printer/job/%1%") % port).str())
+        : make_url((boost::format("printer/model/%1%") % port).str());
 
     BOOST_LOG_TRIVIAL(info) << boost::format("%1%: Uploading file %2% at %3%, filename: %4%, path: %5%, print: %6%, group: %7%")
         % name
@@ -115,17 +117,17 @@ bool Repetier::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
         % url
         % upload_filename.string()
         % upload_parent_path.string()
-        % upload_data.start_print
+        % (upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false")
         % upload_data.group;
 
     auto http = Http::post(std::move(url));
     set_auth(http);
-    
+
     if (! upload_data.group.empty() && upload_data.group != _utf8(L("Default"))) {
         http.form_add("group", upload_data.group);
     }
-    
-    if(upload_data.start_print) {
+
+    if(upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
         http.form_add("name", upload_filename.string());
     }
 

--- a/src/slic3r/Utils/Repetier.hpp
+++ b/src/slic3r/Utils/Repetier.hpp
@@ -27,7 +27,7 @@ public:
     bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const override;
     bool has_auto_discovery() const override { return false; }
     bool can_test() const override { return true; }
-    bool can_start_print() const override { return true; }
+    std::set<PrintHostPostUploadAction> get_post_upload_actions() const {return std::set({PrintHostPostUploadAction::StartPrint});}
     bool supports_multiple_printers() const override { return true; }
     std::string get_host() const override { return host; }
     


### PR DESCRIPTION
With this pull request the following changes were made:

* PrintHost can now return a set of possible actions to be done after a upload is finished
* PrintHostSendDialog now contains a dropdown with available actions instead of a "start print" action
* Duet Hosts are now able to start a simulation after upload instead of starting a print

@wilriker I had to touch your recent DSF changes too. Unfortunately i do not have a Duet with attached SBC, so i cannot verify my changes for DSF. I would be glad if you'll find some time and test this PR with an attached SBC

this will close #1241 when merged.

Here are some screens:
Duet Host
![duet_upload](https://user-images.githubusercontent.com/6674396/99153267-b7348b00-26a7-11eb-9e07-77249ea7ec66.png)
Duet Host
![duet_upload2](https://user-images.githubusercontent.com/6674396/99153272-bb60a880-26a7-11eb-94f9-df60e166d67f.png)
Octoprint Host (Without Simulation option)
![octoprint_upload](https://user-images.githubusercontent.com/6674396/99153276-be5b9900-26a7-11eb-9d3d-81ffe9d70c3a.png)
Flash Air Host (Without any option)
![flash_air_upload](https://user-images.githubusercontent.com/6674396/99153279-c1568980-26a7-11eb-9741-3eb409cc8fff.png)
