### PR TITLE
Fix OG_CustomCtrl hpos computation for CoPoint

### DIFF
--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -180,8 +180,16 @@ wxPoint OG_CustomCtrl::get_pos(const Line& line, Field* field_in/* = nullptr*/)
                 h_pos += 3 * blinking_button_width;
                 
                 if (field == field_in)
-                    break;    
-                h_pos += field->getWindow()->GetSize().x;
+                    break;
+                if (field->getSizer()) {
+                    for (auto child : field->getSizer()->GetChildren()) {
+                        if (child->IsWindow() && child->IsShown()) {
+                            wxSize  sz = child->GetWindow()->GetSize();
+                            h_pos += sz.x + m_h_gap;
+                        }
+                    }
+                } else
+                    h_pos += field->getWindow()->GetSize().x;
 
                 if (option_set.size() == 1 && option_set.front().opt.full_width)
                     break;


### PR DESCRIPTION
Problem : 
* coPoint contain 2 windows in a sizer, and window() return only the first 
* OG_CustomCtrl::get_pos check only the window() and so miss the second one

solution:
* OG_CustomCtrl::get_pos now check if the field has a sizer, and if so get all sizes from inside, like the correct_widgets_position method