### PR TITLE
Fix support doesn't ignore overhangs bridge anymore

### DIFF
--- a/src/libslic3r/SupportMaterial.cpp
+++ b/src/libslic3r/SupportMaterial.cpp
@@ -906,13 +906,19 @@ namespace SupportMaterialInternal {
                     polyline.extend_start(fw);
                     polyline.extend_end(fw);
                     // Is the straight perimeter segment supported at both sides?
-					for (size_t i = 0; i < lower_layer.lslices.size(); ++ i)
-						if (lower_layer.lslices_bboxes[i].contains(polyline.first_point()) && lower_layer.lslices_bboxes[i].contains(polyline.last_point()) && 
-							lower_layer.lslices[i].contains(polyline.first_point()) && lower_layer.lslices[i].contains(polyline.last_point())) {
-							// Offset a polyline into a thick line.
-							polygons_append(bridges, offset(polyline, 0.5f * w + 10.f));
-							break;
-						}
+                    bool first_point_supported = false;
+                    for (size_t i = 0; i < lower_layer.lslices.size(); ++ i)
+                        if (lower_layer.lslices_bboxes[i].contains(polyline.first_point()) &&lower_layer.lslices[i].contains(polyline.first_point()) ) {
+                            first_point_supported = true;
+                            break;
+                        }
+                    if(first_point_supported)
+                        for (size_t i = 0; i < lower_layer.lslices.size(); ++i)
+                            if (lower_layer.lslices_bboxes[i].contains(polyline.last_point()) && lower_layer.lslices[i].contains(polyline.last_point())) {
+                                // Offset a polyline into a thick line.
+                                polygons_append(bridges, offset(polyline, 0.5f * w + 10.f));
+                                break;
+                            }
                 }
             bridges = union_(bridges);
         }


### PR DESCRIPTION
commit 564eddd99d6368396dca37bbbf9c5ef7a3d3a958 break the support material overhang bridge detection
simple exemple stl to reproduce (there shouldn't be any bridge, but it can't detect the bridge because each end is on its own island):
[overhangs.zip](https://github.com/prusa3d/PrusaSlicer/files/5542482/overhangs.zip)

here is a patch to come back to the old behavior.