### PR TITLE
Add extrudr filament profiles

### DIFF
--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2825,6 +2825,138 @@ min_fan_speed = 100
 start_filament_gcode = "M900 K0 ; Filament gcode"
 temperature = 220
 
+[filament:extrudr DuraPro ASA]
+inherits = Fillamentum ASA
+filament_vendor = Extrudr
+filament_cost = 38.7
+bed_temperature = 90
+first_layer_bed_temperature = 90
+first_layer_temperature = 220
+temperature = 220
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=120"
+
+[filament:extrudr PETG]
+inherits = Prusa PETG
+filament_vendor = Extrudr
+filament_cost = 35.45
+bed_temperature = 70
+filament_density = 1.29
+first_layer_bed_temperature = 70
+first_layer_temperature = 220
+temperature = 220
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=94"
+
+[filament:extrudr BioFusion]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 31.23
+disable_fan_first_layers = 3
+filament_density = 1.25
+first_layer_temperature = 220
+max_fan_speed = 45
+min_fan_speed = 20
+temperature = 220
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=121"
+
+[filament:extrudr Flax]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 56.23
+filament_density = 1.35
+first_layer_temperature = 190
+max_fan_speed = 80
+min_fan_speed = 30
+temperature = 190
+filament_notes = "High Performance Filament for decorative parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=131"
+
+[filament:extrudr GreenTEC]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 23.63
+first_layer_temperature = 208
+temperature = 208
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=106"
+
+[filament:extrudr GreenTEC Pro]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 56.23
+filament_density = 1.35
+max_fan_speed = 80
+min_fan_speed = 30
+filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=134"
+
+[filament:extrudr GreenTEC Pro Carbon]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 56.23
+filament_density = 1.35
+first_layer_temperature = 225
+max_fan_speed = 80
+min_fan_speed = 30
+temperature = 225
+filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher stregnth and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=138"
+
+[filament:extrudr PLA NX1]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 22.76
+first_layer_temperature = 205
+max_fan_speed = 90
+min_fan_speed = 30
+temperature = 205
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=97"
+
+[filament:extrudr PLA NX2]
+inherits = Prusament PLA
+filament_vendor = Extrudr
+filament_cost = 23.63
+filament_density = 1.3
+first_layer_temperature = 205
+max_fan_speed = 90
+min_fan_speed = 30
+temperature = 205
+filament_notes = "High Quality filament from Extrudr.\nPrints with a strong layer adhesion and nice mat finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=128\n"
+
+[filament:extrudr Flex Hard]
+inherits = SemiFlex or Flexfill 98A
+filament_vendor = Extrudr
+filament_cost = 39.98
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.2
+filament_density = 1.2
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3
+filament_retract_length = 0.4
+filament_wipe = nil
+filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+
+[filament:extrudr Flex Medium]
+inherits = SemiFlex or Flexfill 98A
+filament_vendor = Extrudr
+filament_cost = 39.98
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.2
+filament_density = 1.19
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3
+filament_retract_length = 0.4
+filament_wipe = nil
+filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+
+[filament:extrudr Flex SemiSoft]
+inherits = SemiFlex or Flexfill 98A
+filament_vendor = Extrudr
+filament_cost = 39.98
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.2
+filament_density = 1.18
+filament_deretract_speed = nil
+filament_max_volumetric_speed = 3
+filament_retract_length = 0.4
+filament_wipe = nil
+filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+
 ## Filaments MMU1
 
 [filament:ColorFabb HT @MMU1]

--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2841,6 +2841,8 @@ bed_temperature = 70
 filament_cost = 35.45
 filament_density = 1.29
 filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=94"
+filament_retract_length = nil
+filament_retract_lift = nil
 filament_vendor = Extrudr
 first_layer_bed_temperature = 70
 first_layer_temperature = 220

--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -2827,135 +2827,135 @@ temperature = 220
 
 [filament:extrudr DuraPro ASA]
 inherits = Fillamentum ASA
-filament_vendor = Extrudr
-filament_cost = 38.7
 bed_temperature = 90
+filament_cost = 38.7
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=120"
+filament_vendor = Extrudr
 first_layer_bed_temperature = 90
 first_layer_temperature = 220
 temperature = 220
-filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=120"
 
 [filament:extrudr PETG]
 inherits = Prusa PETG
-filament_vendor = Extrudr
-filament_cost = 35.45
 bed_temperature = 70
+filament_cost = 35.45
 filament_density = 1.29
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=94"
+filament_vendor = Extrudr
 first_layer_bed_temperature = 70
 first_layer_temperature = 220
 temperature = 220
-filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=94"
 
 [filament:extrudr BioFusion]
 inherits = Prusament PLA
-filament_vendor = Extrudr
-filament_cost = 31.23
 disable_fan_first_layers = 3
+filament_cost = 31.23
 filament_density = 1.25
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=121"
+filament_vendor = Extrudr
 first_layer_temperature = 220
 max_fan_speed = 45
 min_fan_speed = 20
 temperature = 220
-filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=121"
 
 [filament:extrudr Flax]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 56.23
 filament_density = 1.35
+filament_notes = "High Performance Filament for decorative parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=131"
+filament_vendor = Extrudr
 first_layer_temperature = 190
 max_fan_speed = 80
 min_fan_speed = 30
 temperature = 190
-filament_notes = "High Performance Filament for decorative parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=131"
 
 [filament:extrudr GreenTEC]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 23.63
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=106"
+filament_vendor = Extrudr
 first_layer_temperature = 208
 temperature = 208
-filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=106"
 
 [filament:extrudr GreenTEC Pro]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 56.23
 filament_density = 1.35
+filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=134"
+filament_vendor = Extrudr
 max_fan_speed = 80
 min_fan_speed = 30
-filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher strength and temperature resistance.\nFully biodegradable with a nice matt finish.\nHigh Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=134"
 
 [filament:extrudr GreenTEC Pro Carbon]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 56.23
 filament_density = 1.35
+filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher stregnth and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=138"
+filament_vendor = Extrudr
 first_layer_temperature = 225
 max_fan_speed = 80
 min_fan_speed = 30
 temperature = 225
-filament_notes = "High Performance Filament for technical parts.\nPrints as easely as PLA with much higher stregnth and temperature resistance.\nFully biodegradable with a nice matt finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=138"
 
 [filament:extrudr PLA NX1]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 22.76
+filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=97"
+filament_vendor = Extrudr
 first_layer_temperature = 205
 max_fan_speed = 90
 min_fan_speed = 30
 temperature = 205
-filament_notes = "High Quality filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=97"
 
 [filament:extrudr PLA NX2]
 inherits = Prusament PLA
-filament_vendor = Extrudr
 filament_cost = 23.63
 filament_density = 1.3
+filament_notes = "High Quality filament from Extrudr.\nPrints with a strong layer adhesion and nice mat finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=128\n"
+filament_vendor = Extrudr
 first_layer_temperature = 205
 max_fan_speed = 90
 min_fan_speed = 30
 temperature = 205
-filament_notes = "High Quality filament from Extrudr.\nPrints with a strong layer adhesion and nice mat finish.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=128\n"
 
 [filament:extrudr Flex Hard]
 inherits = SemiFlex or Flexfill 98A
-filament_vendor = Extrudr
-filament_cost = 39.98
 disable_fan_first_layers = 1
 extrusion_multiplier = 1.2
+filament_cost = 39.98
 filament_density = 1.2
 filament_deretract_speed = nil
 filament_max_volumetric_speed = 3
-filament_retract_length = 0.4
-filament_wipe = nil
 filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+filament_retract_length = 0.4
+filament_vendor = Extrudr
+filament_wipe = nil
 
 [filament:extrudr Flex Medium]
 inherits = SemiFlex or Flexfill 98A
-filament_vendor = Extrudr
-filament_cost = 39.98
 disable_fan_first_layers = 1
 extrusion_multiplier = 1.2
+filament_cost = 39.98
 filament_density = 1.19
 filament_deretract_speed = nil
 filament_max_volumetric_speed = 3
-filament_retract_length = 0.4
-filament_wipe = nil
 filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+filament_retract_length = 0.4
+filament_vendor = Extrudr
+filament_wipe = nil
 
 [filament:extrudr Flex SemiSoft]
 inherits = SemiFlex or Flexfill 98A
-filament_vendor = Extrudr
-filament_cost = 39.98
 disable_fan_first_layers = 1
 extrusion_multiplier = 1.2
+filament_cost = 39.98
 filament_density = 1.18
 filament_deretract_speed = nil
 filament_max_volumetric_speed = 3
-filament_retract_length = 0.4
-filament_wipe = nil
 filament_notes = "High Quality TPU filament from Extrudr.\n\nCheck our website for more information:\nhttps://www.extrudr.com/en/products/catalogue/?material=115"
+filament_retract_length = 0.4
+filament_vendor = Extrudr
+filament_wipe = nil
 
 ## Filaments MMU1
 


### PR DESCRIPTION
I ordered some filaments from extrudr and they kindly sent me their [filament settings](https://github.com/prusa3d/PrusaSlicer/files/5603872/Extrudr.zip). I tried my best to find out the differences and this PR is the result of this process.

I would really like to see this PR merged, so all comments/critics/help are/is welcome :)


I also have a question about my diffs. If you look at the 'extrudr Flex ...' filaments the diff resulted in:

```diff
-filament_wipe = 0
+filament_wipe = nil
+filament_deretract_speed = nil
```
Does this make any difference or can I discard the `nil` value lines?


[Extrudr.zip](https://github.com/prusa3d/PrusaSlicer/files/5603872/Extrudr.zip)