### PR TITLE
fix png alpha channel support for gtk3

### DIFF
--- a/src/slic3r/GUI/BitmapCache.cpp
+++ b/src/slic3r/GUI/BitmapCache.cpp
@@ -68,7 +68,13 @@ wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_
     wxBitmap *bitmap = nullptr;
     auto      it     = m_map.find(bitmap_key);
     if (it == m_map.end()) {
+#ifdef __WXGTK3__
+        // if we're on GTK3, force the bitmap to be 32bpp
         bitmap = new wxBitmap(width, height, 32);
+#else
+        //everyone else gets the default screen depth
+        bitmap = new wxBitmap(width, height);
+#endif
 #ifdef __APPLE__
         // Contrary to intuition, the `scale` argument isn't "please scale this to such and such"
         // but rather "the wxImage is sized for backing scale such and such".

--- a/src/slic3r/GUI/BitmapCache.cpp
+++ b/src/slic3r/GUI/BitmapCache.cpp
@@ -7,7 +7,7 @@
 
 #include <boost/filesystem.hpp>
 
-#if ! defined(WIN32) && ! defined(__APPLE__)
+#if ! defined(WIN32) && ! defined(__APPLE__) && ! defined(__WXGTK3__)
 #define BROKEN_ALPHA
 #endif
 
@@ -68,7 +68,7 @@ wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_
     wxBitmap *bitmap = nullptr;
     auto      it     = m_map.find(bitmap_key);
     if (it == m_map.end()) {
-        bitmap = new wxBitmap(width, height);
+        bitmap = new wxBitmap(width, height, 32);
 #ifdef __APPLE__
         // Contrary to intuition, the `scale` argument isn't "please scale this to such and such"
         // but rather "the wxImage is sized for backing scale such and such".
@@ -83,7 +83,7 @@ wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_
         if (size_t(bitmap->GetWidth()) != width || size_t(bitmap->GetHeight()) != height)
             bitmap->Create(width, height);
     }
-#ifndef BROKEN_ALPHA
+#if defined(WIN32) || defined(__APPLE__)
     bitmap->UseAlpha();
 #endif
     return bitmap;


### PR DESCRIPTION
# Background
Ubuntu 20.10 no longer installs GTK2 by default. GTK 3 has been out for over 8 years, GTK 4 is due out "any day now"... so probably well past time to start getting the code to support GTK 3.

# Changes
* Forward port [gtk3 supporting change to png alpha channels from Roman Moravčík](https://github.com/prusa3d/PrusaSlicer/issues/1016#issuecomment-419456276) to the current code base.
* Slightly simplified the first one by not nesting `if`s.
* Reduce the risk of breaking other platforms by continuing to supply the default value on them.

# related
fixes #3571, which is a re-open of #1016, which is where the original proposed fix above came from.

# TODO
Quick things to verify before this is merged upstream:
- [ ] verify gtk2 still works on ancient Linux Distros
- [x] verify windows and macos are still good - I redid the code to ensure they were as untouched as possible, after the pre-processor runs the code should be the same as it was.
