### PR TITLE
Add linking of ICU

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,7 +116,7 @@ if (APPLE)
 #    add_compile_options(-stdlib=libc++)
 #    add_definitions(-DBOOST_THREAD_DONT_USE_CHRONO -DBOOST_NO_CXX11_RVALUE_REFERENCES -DBOOST_THREAD_USES_MOVE)
     # -liconv: boost links to libiconv by default
-    target_link_libraries(PrusaSlicer "-liconv -framework IOKit" "-framework CoreFoundation" -lc++)
+    target_link_libraries(PrusaSlicer "-licuuc -licui18n -liconv -framework IOKit" "-framework CoreFoundation" -lc++)
 elseif (MSVC)
     # Manifest is provided through PrusaSlicer.rc, don't generate your own.
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")


### PR DESCRIPTION
When building on Apple Silicon, without this it tries to link to the system provided dylib and fails. Since PrusaSlicer relies on boost (and boost when installed through brew also installs ICU) I thought think linking would work.

Could be totally wrong though, and if I am please close!

#5179