### PR TITLE
changes needed to build dependencies on Apple Silicon

### DIFF
--- a/deps/PNG/PNG.cmake
+++ b/deps/PNG/PNG.cmake
@@ -8,6 +8,7 @@ prusaslicer_add_cmake_project(PNG
         -DPNG_STATIC=ON
         -DPNG_PREFIX=prusaslicer_
         -DPNG_TESTS=OFF
+        -DDISABLE_DEPENDENCY_TRACKING
 )
 
 if (MSVC)


### PR DESCRIPTION

- fixes "PNG_ARM_NEON_FILE undefined" error