### PR TITLE
Imgui visual improvements -- drop shadows and improved text visibility

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -925,22 +925,25 @@ void ImGuiWrapper::init_font(bool compress)
 #endif
 	builder.BuildRanges(&ranges); // Build the final result (ordered ranges with all the unique characters submitted)
 
+    // Brighten font texture to improve visual clarity
+    ImFontConfig font_config;
+    font_config.RasterizerMultiply = 2.0f;
+
     //FIXME replace with io.Fonts->AddFontFromMemoryTTF(buf_decompressed_data, (int)buf_decompressed_size, m_font_size, nullptr, ranges.Data);
     //https://github.com/ocornut/imgui/issues/220
-	ImFont* font = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/" + (m_font_cjk ? "NotoSansCJK-Regular.ttc" : "NotoSans-Regular.ttf")).c_str(), m_font_size, nullptr, ranges.Data);
+	ImFont* font = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/" + (m_font_cjk ? "NotoSansCJK-Regular.ttc" : "NotoSans-Regular.ttf")).c_str(), m_font_size, &font_config, ranges.Data);
     if (font == nullptr) {
         font = io.Fonts->AddFontDefault();
         if (font == nullptr) {
-            throw Slic3r::RuntimeError("ImGui: Could not load deafult font");
+            throw Slic3r::RuntimeError("ImGui: Could not load default font");
         }
     }
 
 #ifdef __APPLE__
-    ImFontConfig config;
-    config.MergeMode = true;
+    font_config.MergeMode = true;
     if (! m_font_cjk) {
 		// Apple keyboard shortcuts are only contained in the CJK fonts.
-		ImFont *font_cjk = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/NotoSansCJK-Regular.ttc").c_str(), m_font_size, &config, ranges_keyboard_shortcuts);
+		ImFont *font_cjk = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/NotoSansCJK-Regular.ttc").c_str(), m_font_size, &font_config, ranges_keyboard_shortcuts);
         assert(font_cjk != nullptr);
     }
 #endif
@@ -950,9 +953,9 @@ void ImGuiWrapper::init_font(bool compress)
 
     int rect_id = io.Fonts->CustomRects.Size;  // id of the rectangle added next
     // add rectangles for the icons to the font atlas
-    for (auto& icon : font_icons)
+    for (const auto& icon : font_icons)
         io.Fonts->AddCustomRectFontGlyph(font, icon.first, icon_sz, icon_sz, 3.0 * font_scale + icon_sz);
-    for (auto& icon : font_icons_large)
+    for (const auto& icon : font_icons_large)
         io.Fonts->AddCustomRectFontGlyph(font, icon.first, icon_sz * 2, icon_sz * 2, 3.0 * font_scale + icon_sz * 2);
 
     // Build texture atlas
@@ -961,7 +964,7 @@ void ImGuiWrapper::init_font(bool compress)
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bits (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
 
     // Fill rectangles from the SVG-icons
-    for (auto icon : font_icons) {
+    for (const auto& icon : font_icons) {
         if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id)) {
             std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz);
             const ImU32* pIn = (ImU32*)raw_data.data();
@@ -975,7 +978,7 @@ void ImGuiWrapper::init_font(bool compress)
     }
     icon_sz = lround(32 * font_scale); // default size of large icon is 32 px
     
-    for (auto icon : font_icons_large) {
+    for (const auto& icon : font_icons_large) {
         if (const ImFontAtlas::CustomRect* rect = io.Fonts->GetCustomRectByIndex(rect_id)) {
             std::vector<unsigned char> raw_data = load_svg(icon.second, icon_sz, icon_sz);
             const ImU32* pIn = (ImU32*)raw_data.data();

--- a/src/slic3r/GUI/ImGuiWrapper.hpp
+++ b/src/slic3r/GUI/ImGuiWrapper.hpp
@@ -31,6 +31,9 @@ class ImGuiWrapper
     unsigned m_mouse_buttons;
     bool m_disabled;
     bool m_new_frame_open;
+    bool m_dropshadows_enabled;
+    int m_dropshadow_size;
+    float m_dropshadow_max_alpha;
     std::string m_clipboard_text;
 
 public:
@@ -58,6 +61,9 @@ public:
     void set_next_window_pos(float x, float y, int flag, float pivot_x = 0.0f, float pivot_y = 0.0f);
     void set_next_window_bg_alpha(float alpha);
 	void set_next_window_size(float x, float y, ImGuiCond cond);
+
+    void set_enable_dropshadows(bool enable);
+    void set_dropshadow_params(int size, float max_alpha) {}
 
     bool begin(const std::string &name, int flags = 0);
     bool begin(const wxString &name, int flags = 0);
@@ -112,6 +118,7 @@ private:
     void render_draw_data(ImDrawData *draw_data);
     bool display_initialized() const;
     void destroy_font();
+    void draw_dropshadow(const ImVec2& tl, const ImVec2& br);
     std::vector<unsigned char> load_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height);
 
     static const char* clipboard_get(void* user_data);


### PR DESCRIPTION
I added drop-shadows to Imgui windows and tool-tips, and improved visibility of the text by increasing rasterizer multiplier.

Drop-shadows are configurable, but I left them not too strong by default.

### Before Drop Shadows
![image](https://user-images.githubusercontent.com/19617165/101236795-edab6780-36a1-11eb-8855-a55001959d45.png)

### After Drop Shadows
![image](https://user-images.githubusercontent.com/19617165/101236798-f69c3900-36a1-11eb-85a9-8b138e52ce57.png)

### Text Visibility Improvement
![image](https://user-images.githubusercontent.com/19617165/101236807-103d8080-36a2-11eb-887d-a7f039351b75.png)
