### PR TITLE
Fix proposal for crash on rectilinear

### DIFF
--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -1237,7 +1237,7 @@ static void pinch_contours_insert_phony_outer_intersections(std::vector<Segmente
                 for (SegmentIntersection &ip : segs[i_vline - 1].intersections)
                     if (ip.has_right_horizontal())
                         ip.next_on_contour = map[ip.next_on_contour];
-                if (i_vline < segs.size()) {
+                if (i_vline < segs.size() - 1) {
                     // Reindex references on next intersection line.
                     for (SegmentIntersection &ip : segs[i_vline + 1].intersections)
                         if (ip.has_left_horizontal())


### PR DESCRIPTION
`segs[i_vline + 1]` will crash if `i_vline = segs.size() -1`
So you have to test with `if (i_vline < segs.size() - 1)`, right?
I didn't understand the rectilinear code that much, so do the right thing if this is not the right way to fix it.