### PR TITLE
Include <atomic> for std::atomic where needed

### DIFF
--- a/src/libslic3r/Thread.cpp
+++ b/src/libslic3r/Thread.cpp
@@ -6,6 +6,7 @@
 	#include <pthread.h>
 #endif
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <tbb/parallel_for.h>

--- a/src/slic3r/GUI/Mouse3DController.hpp
+++ b/src/slic3r/GUI/Mouse3DController.hpp
@@ -9,6 +9,7 @@
 #include "hidapi.h"
 
 #include <queue>
+#include <atomic>
 #include <thread>
 #include <vector>
 #include <chrono>


### PR DESCRIPTION
Fixes build on linux using clang 11