### PR TITLE
fix some msvc compile error under Chinese Windows system.

### DIFF
--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -87,7 +87,7 @@ enum ConfigMenuIDs {
 class Tab;
 class ConfigWizard;
 
-static wxString dots("…", wxConvUTF8);
+static wxString dots("...", wxConvUTF8);
 
 // Does our wxWidgets version support markup?
 // https://github.com/prusa3d/PrusaSlicer/issues/4282#issuecomment-634676371

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1361,7 +1361,7 @@ void MainFrame::quick_slice(const int qs)
 //     auto sprint = new Slic3r::Print::Simple(
 //         print_center = > print_center,
 //         status_cb = > [](int percent, const wxString& msg) {
-//         m_progress_dialog->Update(percent, msg+"…");
+//         m_progress_dialog->Update(percent, msg+"...");
 //     });
 
     // keep model around

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3569,7 +3569,7 @@ void Plater::priv::on_slicing_update(SlicingStatusEvent &evt)
         }
 
         this->statusbar()->set_progress(evt.status.percent);
-        this->statusbar()->set_status_text(_(evt.status.text) + wxString::FromUTF8("…"));
+        this->statusbar()->set_status_text(_(evt.status.text) + wxString::FromUTF8("..."));
         //notification_manager->set_progress_bar_percentage("Slicing progress", (float)evt.status.percent / 100.0f);
     }
     if (evt.status.flags & (PrintBase::SlicingStatus::RELOAD_SCENE | PrintBase::SlicingStatus::RELOAD_SLA_SUPPORT_POINTS)) {

--- a/src/slic3r/GUI/PresetComboBoxes.hpp
+++ b/src/slic3r/GUI/PresetComboBoxes.hpp
@@ -107,8 +107,8 @@ protected:
     static const char* separator_head() { return "------- "; }
     static const char* separator_tail() { return " -------"; }
 #else // __linux__ 
-    static const char* separator_head() { return "————— "; }
-    static const char* separator_tail() { return " —————"; }
+    static const char* separator_head() { return "------- "; }
+    static const char* separator_tail() { return " -------"; }
 #endif // __linux__
     static wxString    separator(const std::string& label);
 


### PR DESCRIPTION
    Due to the Chinese system compiler default GBK coding, so several string values in the code will cause compiler coding errors, which will stop the compilation.

