### PR TITLE
Correct translation of "Copy" to the noun "Kopie" instead of the verb…

### DIFF
--- a/resources/localization/nl/PrusaSlicer_nl.po
+++ b/resources/localization/nl/PrusaSlicer_nl.po
@@ -6831,7 +6831,7 @@ msgstr "Voorinstelling opslaan"
 #: src/slic3r/GUI/SavePresetDialog.cpp:215
 msgctxt "PresetName"
 msgid "Copy"
-msgstr "Kopieer"
+msgstr "Kopie"
 
 #: src/slic3r/GUI/SavePresetDialog.cpp:273
 msgid ""


### PR DESCRIPTION
… "Kopieer" in the Save Preset dialog.

Fixes issue https://github.com/prusa3d/PrusaSlicer/issues/5612