### PR TITLE
Fixed build regression in commit a5882a1a1c3f561233a22cc7663514b97e5f…

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -257,10 +257,10 @@ if (SLIC3R_PCH AND NOT SLIC3R_SYNTAXONLY)
 endif ()
 
 # We need to implement some hacks for wxWidgets and touch the underlying GTK
-# layer and sub-libraries. This forces us to use the include locations of these
-# libraries. No need to link to them, wxWidgets does that already.
-# See PresetComboBox.cpp for the includes and subsequent workarounds.
+# layer and sub-libraries. This forces us to use the include locations and
+# link these libraries.
 if (UNIX AND NOT APPLE)
     find_package(GTK${SLIC3R_GTK} REQUIRED)
     target_include_directories(libslic3r_gui PRIVATE ${GTK${SLIC3R_GTK}_INCLUDE_DIRS})
+    target_link_libraries(libslic3r_gui ${GTK${SLIC3R_GTK}_LIBRARIES})
 endif ()


### PR DESCRIPTION
…b3ba on some Linux platforms. We need to link with GTK libs after all.

Without this change I get link error:
/usr/bin/ld: src/slic3r/liblibslic3r_gui.a(PresetComboBoxes.cpp.o): undefined reference to symbol 'gtk_cell_layout_get_type'

gcc-10.2.1, binutils 2.35, cmake 3.18.4, GTK 3.24.24, wxwidgets 3.0.5.1