### PR TITLE
Use correct M204 command for acceleration

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -204,6 +204,9 @@ std::string GCodeWriter::set_acceleration(unsigned int acceleration)
         gcode << "\n";
         // M202: Set max travel acceleration
         gcode << "M202 X" << acceleration << " Y" << acceleration;
+    } else if (FLAVOR_IS(gcfRepRapFirmware)) {
+	// M204: Set default acceleration
+	gcode << "M204 P" << acceleration;    
     } else {
         // M204: Set default acceleration
         gcode << "M204 S" << acceleration;


### PR DESCRIPTION
M204 S is not supported for RepRapFrimware (https://duet3d.dozuki.com/Wiki/Gcode#Section_M204_Set_printing_and_travel_accelerations).