### PR TITLE
Error compiling on Linux

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -198,9 +198,9 @@ void ModelNode::UpdateIcons()
 {
     // update icons for the colors, if any exists
     if (!m_old_color.IsEmpty())
-        m_old_color_bmp = get_bitmap(m_toggle ? m_old_color : grey);
+        m_old_color_bmp = get_bitmap(m_toggle ? m_old_color : grey.c_str());
     if (!m_new_color.IsEmpty())
-        m_new_color_bmp = get_bitmap(m_toggle ? m_new_color : grey);
+        m_new_color_bmp = get_bitmap(m_toggle ? m_new_color : grey.c_str());
 
     // update main icon, if any exists
     if (m_icon_name.empty())


### PR DESCRIPTION
### Version
2.3.0 (fcabe8a0f47807bb7efff3fdcecf35c49d02556b)

### Operating system type + version
openSUSE-Leap-15.2

### Behavior
When compiling with "-DSLIC3R_WX_STABLE=1" I get the following error:

```
PrusaSlicer_latest/src/slic3r/GUI/UnsavedChangesDialog.cpp:201:47: error: operands to ?: have different types ‘wxString’ and ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’
         m_old_color_bmp = get_bitmap(m_toggle ? m_old_color : grey);
                                      ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
PrusaSlicer_latest/src/slic3r/GUI/UnsavedChangesDialog.cpp:203:47: error: operands to ?: have different types ‘wxString’ and ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’
         m_new_color_bmp = get_bitmap(m_toggle ? m_new_color : grey);
                                      ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```

This PR solves this for me, it would be nice if you could take a look.