### PR TITLE
Fix missing check that can cause a crash on linux

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -413,7 +413,8 @@ bool GLGizmosManager::gizmo_event(SLAGizmoEventType action, const Vec2d& mouse_p
 
 ClippingPlane GLGizmosManager::get_clipping_plane() const
 {
-    if (! m_common_gizmos_data
+    if (!m_enabled
+     || ! m_common_gizmos_data
      || ! m_common_gizmos_data->object_clipper()
      || m_common_gizmos_data->object_clipper()->get_position() == 0.)
         return ClippingPlane::ClipsNothing();


### PR DESCRIPTION
The missing check for `m_enabled` introduced in commit 535a27de65decbf0b16f85ff8004dc8935d86775 causes a crash on my linux system when slicing. Not for every object, but for most. I've bisected between the first alpha version of 2.3 - which crashes - and the 2.2 version, which does not crash, and found the culprit to be a missing check for the member mentioned above.
Since pretty much any method in that class checks for `m_enabled` and the affected one did so in commits prior to this change too, I'm pretty confident that the check should be there. It definitely fixes the crash for me.

As it does not seem to crash on older linux versions, here are my specs for reference:

Ubuntu 20.04
5.10.6 kernel
Mesa drivers 21.1.0-devel (git-bfe5ac8 2021-01-15 focal-oibaf-ppa)
AMD RX5700XT GPU