### PR TITLE
feat: add option for minimum filament use on a single-extruder print

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.hpp
+++ b/src/libslic3r/GCode/ToolOrdering.hpp
@@ -35,6 +35,10 @@ public:
     // This is called from GCode::process_layer - see implementation for further comments:
     const ExtruderPerCopy* get_extruder_overrides(const ExtrusionEntity* entity, int correct_extruder_id, size_t num_of_copies);
 
+    // Following function iterates through all extrusions on the layer and counts those that cannot be used for wipe.
+    // This supports the min_filament_use setting.
+    float nonwiping_extrusions_volume(const Print& print, unsigned int extruder);
+
     // This function goes through all infill entities, decides which ones will be used for wiping and
     // marks them by the extruder id. Returns volume that remains to be wiped on the wipe tower:
     float mark_wiping_extrusions(const Print& print, unsigned int old_extruder, unsigned int new_extruder, float volume_to_wipe);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -483,7 +483,7 @@ const std::vector<std::string>& Preset::printer_options()
             "color_change_gcode", "pause_print_gcode", "template_custom_gcode",
             "between_objects_gcode", "printer_vendor", "printer_model", "printer_variant", "printer_notes", "cooling_tube_retraction",
             "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "max_print_height",
-            "default_print_profile", "inherits",
+            "min_filament_use", "default_print_profile", "inherits",
             "remaining_times", "silent_mode", 
             "machine_limits_usage", "thumbnails"
         };

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -204,6 +204,7 @@ bool Print::invalidate_state_by_config_options(const std::vector<t_config_option
             || opt_key == "gcode_flavor"
             || opt_key == "high_current_on_filament_swap"
             || opt_key == "infill_first"
+            || opt_key == "min_filament_use"
             || opt_key == "single_extruder_multi_material"
             || opt_key == "temperature"
             || opt_key == "wipe_tower"
@@ -2141,6 +2142,9 @@ void Print::_make_wipe_tower()
     // Lets go through the wipe tower layers and determine pairs of extruder changes for each
     // to pass to wipe_tower (so that it can use it for planning the layout of the tower)
     {
+        // WipeTower assumes all filaments have the same diameter so we do too.
+        const float filament_area = float((M_PI/4.f) * pow(m_config.filament_diameter.get_at(m_wipe_tower_data.tool_ordering.first_extruder()), 2));
+        const float min_volume_used = m_config.min_filament_use * filament_area;
         unsigned int current_extruder_id = m_wipe_tower_data.tool_ordering.all_extruders().back();
         for (auto &layer_tools : m_wipe_tower_data.tool_ordering.layer_tools()) { // for all layers
             if (!layer_tools.has_wipe_tower) continue;
@@ -2149,6 +2153,14 @@ void Print::_make_wipe_tower()
             for (const auto extruder_id : layer_tools.extruders) {
                 if ((first_layer && extruder_id == m_wipe_tower_data.tool_ordering.all_extruders().back()) || extruder_id != current_extruder_id) {
                     float volume_to_wipe = wipe_volumes[current_extruder_id][extruder_id];             // total volume to wipe after this toolchange
+
+                    // If we care about the total amount of a given filament:
+                    if (min_volume_used > 0) {
+                      // Make sure we wipe at least enough to extrude the amount of volume we must hit.
+                      const float filament_used = layer_tools.wiping_extrusions().nonwiping_extrusions_volume(*this, extruder_id);
+                      volume_to_wipe = std::max(volume_to_wipe, min_volume_used - filament_used);
+                    }
+
                     // Not all of that can be used for infill purging:
                     volume_to_wipe -= (float)m_config.filament_minimal_purge_on_wipe_tower.get_at(extruder_id);
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1605,6 +1605,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(-2.f));
 
+    def = this->add("min_filament_use", coFloat);
+    def->label = L("Minimum filament use");
+    def->tooltip = L("Minimum length of filament used from each filament before it is switched. "
+                      "This is used for multi-material systems such as the Mosaic Palette, which splice in segments "
+                      "of filament but cannot create extremely short segments.");
+    def->sidetext = L("mm");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("perimeter_acceleration", coFloat);
     def->label = L("Perimeters");
     def->tooltip = L("This is the acceleration your printer will use for perimeters. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -737,6 +737,7 @@ public:
     ConfigOptionBool                remaining_times;
     ConfigOptionBool                silent_mode;
     ConfigOptionFloat               extra_loading_move;
+    ConfigOptionFloat               min_filament_use;
     ConfigOptionString              color_change_gcode;
     ConfigOptionString              pause_print_gcode;
     ConfigOptionString              template_custom_gcode;
@@ -814,6 +815,7 @@ protected:
         OPT_PTR(remaining_times);
         OPT_PTR(silent_mode);
         OPT_PTR(extra_loading_move);
+        OPT_PTR(min_filament_use);
         OPT_PTR(color_change_gcode);
         OPT_PTR(pause_print_gcode);
         OPT_PTR(template_custom_gcode);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2526,6 +2526,7 @@ void TabPrinter::build_unregular_pages()
         optgroup->append_single_option_line("cooling_tube_length");
         optgroup->append_single_option_line("parking_pos_retraction");
         optgroup->append_single_option_line("extra_loading_move");
+        optgroup->append_single_option_line("min_filament_use");
         optgroup->append_single_option_line("high_current_on_filament_swap");
         m_pages.insert(m_pages.end() - n_after_single_extruder_MM, page);
         m_has_single_extruder_MM_page = true;


### PR DESCRIPTION
This is useful for the Mosaic Palette (especially when used with P2PP), as the Palette can only splice segments of at least a given length reliably.

Adds an option on the printer settings to set that length, and, when filled, ensures that at least that amount of filament will be used before switching tools, likely by increasing wipe length. This allows some savings over the previously-recommended P2PP settings of unilaterally increasing wipe volumes, as fixed wipe volumes would rarely be required on every use of a given filament.