### PR TITLE
creality.ini various improvements

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -68,14 +68,14 @@ bed_model = ender2_bed.stl
 bed_texture = ender2.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
-[printer_model:CR6SE]
-name = Creality CR-6 SE
-variants = 0.4
-technology = FFF
-family = CR
-bed_model = ender3_bed.stl
-bed_texture = cr20.svg
-default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
+#[printer_model:CR6SE]
+#name = Creality CR-6 SE
+#variants = 0.4
+#technology = FFF
+#family = CR
+#bed_model = ender3_bed.stl
+#bed_texture = cr20.svg
+#default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10MINI]
 name = Creality CR-10 Mini
@@ -767,10 +767,10 @@ printer_model = ENDER2
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER2\nPRINTER_HAS_BOWDEN
 max_print_height = 200
 
-[printer:Creality CR-6 SE]
-inherits = Creality Ender-3; *fastabl*
-printer_model = CR6SE
-printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR6SE\nPRINTER_HAS_BOWDEN
+#[printer:Creality CR-6 SE]
+#inherits = Creality Ender-3; *fastabl*
+#printer_model = CR6SE
+#printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR6SE\nPRINTER_HAS_BOWDEN
 
 [printer:Creality CR-10 Mini]
 inherits = Creality Ender-3

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -21,7 +21,7 @@ technology = FFF
 family = ENDER
 bed_model = ender3_bed.stl
 bed_texture = ender3.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:ENDER3V2]
 name = Creality Ender-3 V2
@@ -30,7 +30,7 @@ technology = FFF
 family = ENDER
 bed_model = ender3_bed.stl
 bed_texture = ender3.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:ENDER3BLTOUCH]
 name = Creality Ender-3 BLTouch
@@ -39,7 +39,7 @@ technology = FFF
 family = ENDER
 bed_model = ender3_bed.stl
 bed_texture = ender3.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:ENDER5]
 name = Creality Ender-5
@@ -48,7 +48,7 @@ technology = FFF
 family = ENDER
 bed_model = ender3_bed.stl
 bed_texture = ender3.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:ENDER5PLUS]
 name = Creality Ender-5 Plus
@@ -57,7 +57,7 @@ technology = FFF
 family = ENDER
 bed_model = ender5plus_bed.stl
 bed_texture = ender5plus.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:ENDER2]
 name = Creality Ender-2
@@ -66,7 +66,7 @@ technology = FFF
 family = ENDER
 bed_model = ender2_bed.stl
 bed_texture = ender2.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10MINI]
 name = Creality CR-10 Mini
@@ -75,7 +75,7 @@ technology = FFF
 family = CR
 bed_model = cr10mini_bed.stl
 bed_texture = cr10mini.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10]
 name = Creality CR-10
@@ -84,7 +84,7 @@ technology = FFF
 family = CR
 bed_model = cr10_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10V2]
 name = Creality CR-10 V2
@@ -93,7 +93,7 @@ technology = FFF
 family = CR
 bed_model = cr10v2_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10V3]
 name = Creality CR-10 V3
@@ -102,7 +102,7 @@ technology = FFF
 family = CR
 bed_model = cr10v2_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10S]
 name = Creality CR-10 S
@@ -111,7 +111,7 @@ technology = FFF
 family = CR
 bed_model = cr10_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10SPRO]
 name = Creality CR-10 S Pro
@@ -120,7 +120,7 @@ technology = FFF
 family = CR
 bed_model = cr10v2_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10SPROV2]
 name = Creality CR-10 S Pro V2
@@ -129,7 +129,7 @@ technology = FFF
 family = CR
 bed_model = cr10v2_bed.stl
 bed_texture = cr10.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10S4]
 name = Creality CR-10 S4
@@ -138,7 +138,7 @@ technology = FFF
 family = CR
 bed_model = cr10s4_bed.stl
 bed_texture = cr10s4.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10S5]
 name = Creality CR-10 S5
@@ -147,7 +147,7 @@ technology = FFF
 family = CR
 bed_model = cr10s5_bed.stl
 bed_texture = cr10s5.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR20]
 name = Creality CR-20
@@ -156,7 +156,7 @@ technology = FFF
 family = CR
 bed_model = ender3_bed.stl
 bed_texture = cr20.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR20PRO]
 name = Creality CR-20 Pro
@@ -165,7 +165,7 @@ technology = FFF
 family = CR
 bed_model = ender3_bed.stl
 bed_texture = cr20.svg
-default_materials = Creality PLA @CREALITY; Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 # All presets starting with asterisk, for example *common*, are intermediate and they will
 # not make it into the user interface.

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -702,7 +702,6 @@ end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, 
 inherits = Creality Ender-3
 renamed_from = "Creality Ender-3V2"
 printer_model = ENDER3V2
-printer_variant = 0.4
 bed_shape = 0x0,220x0,220x220,0x220
 
 [printer:*fastabl*]

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -68,6 +68,15 @@ bed_model = ender2_bed.stl
 bed_texture = ender2.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
+[printer_model:CR6SE]
+name = Creality CR-6 SE
+variants = 0.4
+technology = FFF
+family = CR
+bed_model = ender3_bed.stl
+bed_texture = cr20.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
+
 [printer_model:CR10MINI]
 name = Creality CR-10 Mini
 variants = 0.4
@@ -757,6 +766,11 @@ bed_shape = 0x0,150x0,150x150,0x150
 printer_model = ENDER2
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER2\nPRINTER_HAS_BOWDEN
 max_print_height = 200
+
+[printer:Creality CR-6 SE]
+inherits = Creality Ender-3; *fastabl*
+printer_model = CR6SE
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR6SE\nPRINTER_HAS_BOWDEN
 
 [printer:Creality CR-10 Mini]
 inherits = Creality Ender-3

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -349,7 +349,14 @@ compatible_printers_condition = printer_model=~/(ENDER|CR).*/ and nozzle_diamete
 inherits = *0.28mm*
 compatible_printers_condition = printer_model=~/(ENDER|CR).*/ and nozzle_diameter[0]==0.4
 
-# Common filament preset
+# When submitting new filaments please print the following temperature tower at 0.1mm layer height:
+#   https://www.thingiverse.com/thing:2615842
+# Pay particular attention to bridging, overhangs and retractions.
+# Also print the following bed adhesion test at 0.1 layer height as well:
+#   https://www.prusaprinters.org/prints/4634-bed-adhesion-warp-test
+# At least for PLA, please keep bed temp at 60, as many Creality printers do not have any ABL
+# So having some leeway to get good bed adhesion is not a luxury for many users
+
 [filament:*common*]
 cooling = 0
 compatible_printers = 
@@ -704,12 +711,15 @@ renamed_from = "Creality Ender-3V2"
 printer_model = ENDER3V2
 bed_shape = 0x0,220x0,220x220,0x220
 
+# Intended for printers with a smaller bed, like the Ender-3
 [printer:*fastabl*]
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nG4 S10 ; wait for partial warmup\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; intro line\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; intro line\nG92 E0
 
+# Intended for printers with a larger bed, like the CR-10
 [printer:*slowabl*]
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; intro line\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; intro line\nG92 E0
 
+# Intended for printers where the Z-axis lowers the print bed during printing
 [printer:*invertedz*]
 end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; present print\n{if max_layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed down further down\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
 

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -720,15 +720,15 @@ renamed_from = "Creality Ender-3V2"
 printer_model = ENDER3V2
 bed_shape = 0x0,220x0,220x220,0x220
 
-# Intended for printers with a smaller bed, like the Ender-3
+# Intended for printers with a smaller bed, like the Ender-3 series
 [printer:*fastabl*]
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nG4 S10 ; wait for partial warmup\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; intro line\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; intro line\nG92 E0
 
-# Intended for printers with a larger bed, like the CR-10
+# Intended for printers with a larger bed, like the CR-10 series
 [printer:*slowabl*]
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set extruder temp for auto bed leveling\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nG28 ; home all\nG29 ; auto bed levelling\nG1 Z50 F240\nG1 X2 Y10 F3000\nM104 S[first_layer_temperature] ; set extruder temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; intro line\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; intro line\nG92 E0
 
-# Intended for printers where the Z-axis lowers the print bed during printing
+# Intended for printers where the Z-axis lowers the print bed during printing, like the Ender-5 series
 [printer:*invertedz*]
 end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; present print\n{if max_layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed down further down\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
 


### PR DESCRIPTION
This adds some comments explaining some less obvious parts of creality.ini

It also enabled more filaments by default, as some users might not even notice the filaments section in the wizard.

I did notice that PrusaSlicer seems to default to the first filament in an alphabetical sort, as far as Creality.ini is concerned.
So we end up with 123-3D Jupiter PLA as default as opposed to default_filament_profile = Generic PLA @CREALITY
I don't see this behavior with TriLAB printers, where it properly shows Fillamentum Extrafill by default.
Any clue why Creality.ini results in different behavior?

The CR-6 SE should probably be marked as ALPHA for the time being