### PR TITLE
Clang warning fixes

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -671,7 +671,7 @@ bool CLI::setup(int argc, char **argv)
 
     // Initialize with defaults.
     for (const t_optiondef_map *options : { &cli_actions_config_def.options, &cli_transform_config_def.options, &cli_misc_config_def.options })
-        for (const std::pair<t_config_option_key, ConfigOptionDef> &optdef : *options)
+        for (const std::pair<const t_config_option_key, ConfigOptionDef> &optdef : *options)
             m_config.option(optdef.first, true);
 
     set_data_dir(m_config.opt_string("datadir"));

--- a/src/admesh/connect.cpp
+++ b/src/admesh/connect.cpp
@@ -216,7 +216,7 @@ private:
 					// This is a match.  Record result in neighbors list.
 					match_neighbors(edge, *link->next);
 					// Delete the matched edge from the list.
-					HashEdge *temp = link->next;
+					// HashEdge *temp = link->next;
 					link->next = link->next->next;
 					// pool.destroy(temp);
 #ifndef NDEBUG

--- a/src/admesh/normals.cpp
+++ b/src/admesh/normals.cpp
@@ -192,7 +192,7 @@ void stl_fix_normal_directions(stl_file *stl)
         		norm_sw[facet_num] = 1; // Record this one as being fixed.
         		++ checked;
       		}
-      		stl_normal *temp = head->next;	// Delete this facet from the list.
+      		// stl_normal *temp = head->next;	// Delete this facet from the list.
       		head->next = head->next->next;
       		// pool.destroy(temp);
     	} else { // If we ran out of facets to fix: All of the facets in this part have been fixed.

--- a/src/libnest2d/include/libnest2d/nester.hpp
+++ b/src/libnest2d/include/libnest2d/nester.hpp
@@ -836,7 +836,7 @@ public:
     inline ItemIteratorOnly<It, size_t> execute(It from, It to)
     {
         auto infl = static_cast<Coord>(std::ceil(min_obj_distance_/2.0));
-        if(infl > 0) std::for_each(from, to, [this, infl](Item& item) {
+        if(infl > 0) std::for_each(from, to, [infl](Item& item) {
             item.inflate(infl);
         });
         

--- a/src/libslic3r/AABBTreeIndirect.hpp
+++ b/src/libslic3r/AABBTreeIndirect.hpp
@@ -652,10 +652,10 @@ inline bool intersect_ray_all_hits(
 	// All intersections of the ray with the indexed triangle set, sorted by parameter t.
 	std::vector<igl::Hit> 				&hits)
 {
-    auto ray_intersector = detail::RayIntersectorHits<VertexType, IndexedFaceType, TreeType, VectorType> {
+    auto ray_intersector = detail::RayIntersectorHits<VertexType, IndexedFaceType, TreeType, VectorType> {{
 		vertices, faces, tree,
         origin, dir, VectorType(dir.cwiseInverse())
-	};
+	}};
 	if (! tree.empty()) {
         ray_intersector.hits.reserve(8);
 		detail::intersect_ray_recursive_all_hits(ray_intersector, 0);

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -266,14 +266,14 @@ void AppConfig::save()
     else
         c << "# " << Slic3r::header_gcodeviewer_generated() << std::endl;
     // Make sure the "no" category is written first.
-    for (const std::pair<std::string, std::string> &kvp : m_storage[""])
+    for (const std::pair<const std::string, std::string> &kvp : m_storage[""])
         c << kvp.first << " = " << kvp.second << std::endl;
     // Write the other categories.
     for (const auto category : m_storage) {
     	if (category.first.empty())
     		continue;
     	c << std::endl << "[" << category.first << "]" << std::endl;
-    	for (const std::pair<std::string, std::string> &kvp : category.second)
+    	for (const std::pair<const std::string, std::string> &kvp : category.second)
 	        c << kvp.first << " = " << kvp.second << std::endl;
 	}
     // Write vendor sections
@@ -395,7 +395,7 @@ std::vector<std::string> AppConfig::get_mouse_device_names() const
     static constexpr const char   *prefix     = "mouse_device:";
     static const size_t  prefix_len = strlen(prefix);
     std::vector<std::string> out;
-    for (const std::pair<std::string, std::map<std::string, std::string>>& key_value_pair : m_storage)
+    for (const std::pair<const std::string, std::map<std::string, std::string>>& key_value_pair : m_storage)
         if (boost::starts_with(key_value_pair.first, prefix) && key_value_pair.first.size() > prefix_len)
             out.emplace_back(key_value_pair.first.substr(prefix_len));
     return out;

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -269,7 +269,7 @@ void AppConfig::save()
     for (const std::pair<const std::string, std::string> &kvp : m_storage[""])
         c << kvp.first << " = " << kvp.second << std::endl;
     // Write the other categories.
-    for (const auto category : m_storage) {
+    for (const auto &category : m_storage) {
     	if (category.first.empty())
     		continue;
     	c << std::endl << "[" << category.first << "]" << std::endl;

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -1344,7 +1344,7 @@ public:
 
     static bool has(T value) 
     {
-        for (const std::pair<std::string, int> &kvp : ConfigOptionEnum<T>::get_enum_values())
+        for (const std::pair<const std::string, int> &kvp : ConfigOptionEnum<T>::get_enum_values())
             if (kvp.second == value)
                 return true;
         return false;
@@ -1358,11 +1358,11 @@ public:
             // Initialize the map.
             const t_config_enum_values &enum_keys_map = ConfigOptionEnum<T>::get_enum_values();
             int cnt = 0;
-            for (const std::pair<std::string, int> &kvp : enum_keys_map)
+            for (const std::pair<const std::string, int> &kvp : enum_keys_map)
                 cnt = std::max(cnt, kvp.second);
             cnt += 1;
             names.assign(cnt, "");
-            for (const std::pair<std::string, int> &kvp : enum_keys_map)
+            for (const std::pair<const std::string, int> &kvp : enum_keys_map)
                 names[kvp.second] = kvp.first;
         }
         return names;

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -1696,6 +1696,7 @@ public:
     virtual const ConfigDef*        def() const = 0;
     // Find ando/or create a ConfigOption instance for a given name.
     virtual ConfigOption*           optptr(const t_config_option_key &opt_key, bool create = false) = 0;
+    using ConfigOptionResolver::optptr;
     // Collect names of all configuration values maintained by this configuration store.
     virtual t_config_option_keys    keys() const = 0;
 

--- a/src/libslic3r/ElephantFootCompensation.cpp
+++ b/src/libslic3r/ElephantFootCompensation.cpp
@@ -441,6 +441,7 @@ Points resample_polygon(const Points &contour, double dist, std::vector<Resample
     return out;
 }
 
+/*
 static inline void smooth_compensation(std::vector<float> &compensation, float strength, size_t num_iterations)
 {
 	std::vector<float> out(compensation);
@@ -455,6 +456,7 @@ static inline void smooth_compensation(std::vector<float> &compensation, float s
 		out.swap(compensation);
 	}
 }
+*/
 
 static inline void smooth_compensation_banded(const Points &contour, float band, std::vector<float> &compensation, float strength, size_t num_iterations)
 {

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -678,6 +678,7 @@ static inline bool line_rounded_thick_segment_collision(
     return intersects;
 }
 
+#ifndef NDEBUG
 static inline bool inside_interval(double low, double high, double p)
 {
     return p >= low && p <= high;
@@ -702,6 +703,7 @@ static inline bool cyclic_interval_inside_interval(double outer_low, double oute
     }
     return interval_inside_interval(outer_low, outer_high, inner_low, inner_high, double(SCALED_EPSILON));
 }
+#endif // NDEBUG
 
 // #define INFILL_DEBUG_OUTPUT
 

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -2330,7 +2330,7 @@ static std::vector<MonotonicRegionLink> chain_monotonic_regions(
     }
 
     // Probability (unnormalized) of traversing a link between two monotonic regions.
-	auto path_probability = [pheromone_alpha, pheromone_beta](AntPath &path) {
+	auto path_probability = [](AntPath &path) {
 		return pow(path.pheromone, pheromone_alpha) * pow(path.visibility, pheromone_beta);
 	};
 

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -2186,10 +2186,8 @@ static std::vector<MonotonicRegionLink> chain_monotonic_regions(
 	};
 	std::vector<NextCandidate> next_candidates;
 
-    [[maybe_unused]]auto validate_unprocessed =
-#ifdef NDEBUG
-        []() { return true; };
-#else
+#ifndef NDEBUG
+    auto validate_unprocessed = 
         [&regions, &left_neighbors_unprocessed, &path, &queue]() {
             std::vector<unsigned char> regions_processed(regions.size(), false);
             std::vector<unsigned char> regions_in_queue(regions.size(), false);

--- a/src/libslic3r/Fill/FillRectilinear.hpp
+++ b/src/libslic3r/Fill/FillRectilinear.hpp
@@ -37,7 +37,7 @@ public:
 
 protected:
     // Always generate infill at the same angle.
-    virtual float _layer_angle(size_t idx) const { return 0.f; }
+    virtual float _layer_angle(size_t idx) const override { return 0.f; }
 };
 
 class FillMonotonic : public FillRectilinear

--- a/src/libslic3r/Format/3mf.cpp
+++ b/src/libslic3r/Format/3mf.cpp
@@ -123,7 +123,6 @@ const char* VALID_OBJECT_TYPES[] =
     "model"
 };
 
-const unsigned int INVALID_OBJECT_TYPES_COUNT = 4;
 const char* INVALID_OBJECT_TYPES[] =
 {
     "solidsupport",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -891,6 +891,7 @@ namespace DoExport {
     }
 }
 
+/*
 // Sort the PrintObjects by their increasing Z, likely useful for avoiding colisions on Deltas during sequential prints.
 static inline std::vector<const PrintInstance*> sort_object_instances_by_max_z(const Print &print)
 {
@@ -903,6 +904,7 @@ static inline std::vector<const PrintInstance*> sort_object_instances_by_max_z(c
             instances.emplace_back(&object->instances()[i]);
     return instances;
 }
+*/
 
 // Produce a vector of PrintObjects in the order of their respective ModelObjects in print.model().
 std::vector<const PrintInstance*> sort_object_instances_by_model_order(const Print& print)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -851,7 +851,7 @@ namespace DoExport {
 	            double extruded_volume = extruder.extruded_volume() + (has_wipe_tower ? wipe_tower_data.used_filament[extruder.id()] * 2.4052f : 0.f); // assumes 1.75mm filament diameter
 	            double filament_weight = extruded_volume * extruder.filament_density() * 0.001;
 	            double filament_cost   = filament_weight * extruder.filament_cost()    * 0.001;
-	            auto append = [&extruder, &extruders](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
+	            auto append = [&extruder](std::pair<std::string, unsigned int> &dst, const char *tmpl, double value) {
 	                while (dst.second < extruder.id()) {
 	                    // Fill in the non-printing extruders with zeros.
 	                    dst.first += (dst.second > 0) ? ", 0" : "0";

--- a/src/libslic3r/GCode/SeamPlacer.cpp
+++ b/src/libslic3r/GCode/SeamPlacer.cpp
@@ -664,7 +664,7 @@ static std::vector<size_t> find_enforcer_centers(const Polygon& polygon,
     if (polygon.size() < 2 || enforcers_idxs.empty())
         return out;
 
-    auto get_center_idx = [&polygon, &lengths](size_t start_idx, size_t end_idx) -> size_t {
+    auto get_center_idx = [&lengths](size_t start_idx, size_t end_idx) -> size_t {
         assert(end_idx >= start_idx);
         if (start_idx == end_idx)
             return start_idx;

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -513,7 +513,7 @@ WipeTower::ToolChangeResult WipeTower::construct_tcr(WipeTowerWriter& writer,
     result.end_pos      = priming ? writer.pos() : writer.pos_rotated();
     result.gcode        = std::move(writer.gcode());
     result.extrusions   = std::move(writer.extrusions());
-    result.wipe_path    = std::move(writer.wipe_path());
+    result.wipe_path    = writer.wipe_path();
     return result;
 }
 

--- a/src/libslic3r/Geometry.hpp
+++ b/src/libslic3r/Geometry.hpp
@@ -213,7 +213,7 @@ inline bool liang_barsky_line_clipping_interval(
     double t0 = 0.0;
     double t1 = 1.0;
     // Traverse through left, right, bottom, top edges.
-    auto clip_side = [&x0, &v, &bbox, &t0, &t1](double p, double q) -> bool {
+    auto clip_side = [&t0, &t1](double p, double q) -> bool {
         if (p == 0) {
             if (q < 0)
                 // Line parallel to the bounding box edge is fully outside of the bounding box.

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -290,7 +290,7 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
                 surfaces_append(bottom, union_ex(grown, true), bridges[idx_last]);
             }
 
-            fill_boundaries = std::move(to_polygons(fill_boundaries_ex));
+            fill_boundaries = to_polygons(fill_boundaries_ex);
 			BOOST_LOG_TRIVIAL(trace) << "Processing external surface, detecting bridges - done";
 		}
 
@@ -327,7 +327,7 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
             surfaces_append(
                 new_surfaces,
                 // Don't use a safety offset as fill_boundaries were already united using the safety offset.
-                std::move(intersection_ex(polys, fill_boundaries, false)),
+                intersection_ex(polys, fill_boundaries, false),
                 s1);
         }
     }
@@ -424,7 +424,7 @@ void LayerRegion::elephant_foot_compensation_step(const float elephant_foot_comp
     Polygons   slices_polygons   = to_polygons(slices_expolygons);
     Polygons   tmp               = intersection(slices_polygons, trimming_polygons, false);
     append(tmp, diff(slices_polygons, offset(offset_ex(slices_expolygons, -elephant_foot_compensation_perimeter_step), elephant_foot_compensation_perimeter_step)));
-    this->slices.set(std::move(union_ex(tmp)), stInternal);
+    this->slices.set(union_ex(tmp), stInternal);
 }
 
 void LayerRegion::export_region_slices_to_svg(const char *path) const

--- a/src/libslic3r/MarchingSquares.hpp
+++ b/src/libslic3r/MarchingSquares.hpp
@@ -297,7 +297,7 @@ template<class Rst> class Grid {
         case SquareTag::full:
         case SquareTag::none: {
             Coord crd{tl(cell) + Coord{m_cellsize.r / 2, m_cellsize.c / 2}};
-            return {{crd, Dir::none, m_rst}, crd};
+            return {{crd, Dir::none, m_rst}, {crd}};
         }
         }
         

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2099,7 +2099,7 @@ void check_model_ids_validity(const Model &model)
         for (const ModelInstance *model_instance : model_object->instances)
             check(model_instance->id());
     }
-    for (const auto mm : model.materials) {
+    for (const auto &mm : model.materials) {
         check(mm.second->id());
         check(mm.second->config.id());
     }

--- a/src/libslic3r/Polyline.hpp
+++ b/src/libslic3r/Polyline.hpp
@@ -23,6 +23,7 @@ public:
     explicit Polyline(const Point &p1, const Point &p2) { points.reserve(2); points.emplace_back(p1); points.emplace_back(p2); }
     explicit Polyline(const Points &points) : MultiPoint(points) {}
     explicit Polyline(Points &&points) : MultiPoint(std::move(points)) {}
+    virtual ~Polyline() {}
     Polyline& operator=(const Polyline &other) { points = other.points; return *this; }
     Polyline& operator=(Polyline &&other) { points = std::move(other.points); return *this; }
 	static Polyline new_scale(const std::vector<Vec2d> &points) {

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -890,7 +890,7 @@ void PresetBundle::load_config_file_config_bundle(const std::string &path, const
     std::string bundle_name = std::string(" - ") + boost::filesystem::path(path).filename().string();
 
     // 2) Extract active configs from the config bundle, copy them and activate them in this bundle.
-    auto load_one = [this, &path, &bundle_name](PresetCollection &collection_dst, PresetCollection &collection_src, const std::string &preset_name_src, bool activate) -> std::string {
+    auto load_one = [&path, &bundle_name](PresetCollection &collection_dst, PresetCollection &collection_src, const std::string &preset_name_src, bool activate) -> std::string {
         Preset *preset_src = collection_src.find_preset(preset_name_src, false);
         Preset *preset_dst = collection_dst.find_preset(preset_name_src, false);
         assert(preset_src != nullptr);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1399,7 +1399,7 @@ std::string Print::validate() const
                 return L("One or more object were assigned an extruder that the printer does not have.");
 #endif
 
-		auto validate_extrusion_width = [min_nozzle_diameter, max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
+		auto validate_extrusion_width = [/*min_nozzle_diameter,*/ max_nozzle_diameter](const ConfigBase &config, const char *opt_key, double layer_height, std::string &err_msg) -> bool {
             // This may change in the future, if we switch to "extrusion width wrt. nozzle diameter"
             // instead of currently used logic "extrusion width wrt. layer height", see GH issues #1923 #2829.
 //        	double extrusion_width_min = config.get_abs_value(opt_key, min_nozzle_diameter);

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -908,7 +908,7 @@ void PrintObject::detect_surfaces_type()
         // Fill in layerm->fill_surfaces by trimming the layerm->slices by the cummulative layerm->fill_surfaces.
         tbb::parallel_for(
             tbb::blocked_range<size_t>(0, m_layers.size()),
-            [this, idx_region, interface_shells](const tbb::blocked_range<size_t>& range) {
+            [this, idx_region](const tbb::blocked_range<size_t>& range) {
                 for (size_t idx_layer = range.begin(); idx_layer < range.end(); ++ idx_layer) {
                     m_print->throw_if_canceled();
                     LayerRegion *layerm = m_layers[idx_layer]->m_regions[idx_region];

--- a/src/libslic3r/SLA/Concurrency.hpp
+++ b/src/libslic3r/SLA/Concurrency.hpp
@@ -41,7 +41,7 @@ template<> struct _ccr<true>
     static void for_each(It from, It to, Fn &&fn, size_t granularity = 1)
     {
         tbb::parallel_for(tbb::blocked_range{from, to, granularity},
-                          [&fn, from](const auto &range) {
+                          [&fn](const auto &range) {
             loop_(range, std::forward<Fn>(fn));
         });
     }

--- a/src/libslic3r/SLA/IndexedMesh.cpp
+++ b/src/libslic3r/SLA/IndexedMesh.cpp
@@ -55,8 +55,6 @@ public:
     }
 };
 
-static const constexpr double MESH_EPS = 1e-6;
-
 IndexedMesh::IndexedMesh(const TriangleMesh& tmesh)
     : m_aabb(new AABBImpl()), m_tm(&tmesh)
 {

--- a/src/libslic3r/SLAPrint.hpp
+++ b/src/libslic3r/SLAPrint.hpp
@@ -424,7 +424,7 @@ public:
     void                clear() override;
     bool                empty() const override { return m_objects.empty(); }
     // List of existing PrintObject IDs, to remove notifications for non-existent IDs.
-    std::vector<ObjectID> print_object_ids() const;
+    std::vector<ObjectID> print_object_ids() const override;
     ApplyStatus         apply(const Model &model, DynamicPrintConfig config) override;
     void                set_task(const TaskParams &params) override;
     void                process() override;

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -12,6 +12,7 @@
 
 #include <cmath>
 #include <cassert>
+#include <limits>
 
 namespace Slic3r {
 

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -1423,7 +1423,7 @@ static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vect
 		const std::pair<size_t, size_t> &span2, bool reversed2, bool flipped2,
 		const std::pair<size_t, size_t> &span3, bool reversed3, bool flipped3) {
 		auto it_edges_out = edges_out.begin();
-		auto copy_span = [&edges_in, &edges_out, &it_edges_out](std::pair<size_t, size_t> span, bool reversed, bool flipped) {
+		auto copy_span = [&edges_in, &it_edges_out](std::pair<size_t, size_t> span, bool reversed, bool flipped) {
 			assert(span.first < span.second);
 			auto it = it_edges_out;
 			if (reversed)
@@ -1466,7 +1466,7 @@ static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vect
 		const std::pair<size_t, size_t> &span3, bool reversed3, bool flipped3,
 		const std::pair<size_t, size_t> &span4, bool reversed4, bool flipped4) {
 		auto it_edges_out = edges_out.begin();
-		auto copy_span = [&edges_in, &edges_out, &it_edges_out](std::pair<size_t, size_t> span, bool reversed, bool flipped) {
+		auto copy_span = [&edges_in, &it_edges_out](std::pair<size_t, size_t> span, bool reversed, bool flipped) {
 			assert(span.first < span.second);
 			auto it = it_edges_out;
 			if (reversed)

--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -1083,6 +1083,7 @@ void svg_draw_polyline_chain(const char *name, size_t idx, const Polylines &poly
 }
 #endif /* DEBUG_SVG_OUTPUT */
 
+#if 0
 // Flip the sequences of polylines to lower the total length of connecting lines.
 static inline void improve_ordering_by_segment_flipping(Polylines &polylines, bool fixed_start)
 {
@@ -1253,6 +1254,7 @@ static inline void improve_ordering_by_segment_flipping(Polylines &polylines, bo
 	assert(cost_final <= cost_initial);
 #endif /* NDEBUG */
 }
+#endif
 
 struct FlipEdge {
 	FlipEdge(const Vec2d &p1, const Vec2d &p2, size_t source_index) : p1(p1), p2(p2), source_index(source_index) {}
@@ -1337,6 +1339,7 @@ static inline std::pair<double, size_t> minimum_crossover_cost(
 	return std::make_pair(cost_min, flip_min);
 }
 
+/*
 static inline std::pair<double, size_t> minimum_crossover_cost(
 	const std::vector<FlipEdge>		  &edges,
 	const std::pair<size_t, size_t>   &span1, const ConnectionCost &cost1,
@@ -1381,7 +1384,7 @@ static inline std::pair<double, size_t> minimum_crossover_cost(
 		double c = connection_cost(span1, cost1, false, false, span2, cost2, false, false, span3, cost3, false, false, span4, cost4, false, false);
 		assert(std::abs(c - cost_current) < SCALED_EPSILON);
 	}
-#endif /* NDEBUG */
+#endif // NDEBUG
 
 	double cost_min = cost_current;
 	size_t flip_min = 0; // no flip, no improvement
@@ -1412,6 +1415,7 @@ static inline std::pair<double, size_t> minimum_crossover_cost(
 	}
 	return std::make_pair(cost_min, flip_min);
 }
+*/
 
 static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vector<FlipEdge> &edges_out,
 	const std::pair<size_t, size_t> &span1, const std::pair<size_t, size_t> &span2, const std::pair<size_t, size_t> &span3,
@@ -1454,7 +1458,7 @@ static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vect
 	assert(edges_in.size() == edges_out.size());
 }
 
-
+/*
 static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vector<FlipEdge> &edges_out,
 	const std::pair<size_t, size_t> &span1, const std::pair<size_t, size_t> &span2, const std::pair<size_t, size_t> &span3, const std::pair<size_t, size_t> &span4,
 	size_t i)
@@ -1526,6 +1530,7 @@ static inline void do_crossover(const std::vector<FlipEdge> &edges_in, std::vect
 	}
 	assert(edges_in.size() == edges_out.size());
 }
+*/
 
 static inline void reorder_by_two_exchanges_with_segment_flipping(std::vector<FlipEdge> &edges)
 {
@@ -1600,6 +1605,7 @@ static inline void reorder_by_two_exchanges_with_segment_flipping(std::vector<Fl
 	}
 }
 
+/*
 static inline void reorder_by_three_exchanges_with_segment_flipping(std::vector<FlipEdge> &edges)
 {
 	if (edges.size() < 3) {
@@ -1680,6 +1686,7 @@ static inline void reorder_by_three_exchanges_with_segment_flipping(std::vector<
 		}
 	}
 }
+*/
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::DontAlign> Matrixd;
 
@@ -1693,6 +1700,7 @@ private:
 	const ConnectionCost* costs[4];
 };
 
+/*
 static inline std::pair<double, size_t> minimum_crossover_cost(
 	const FourOptCosts				  &segment_costs,
 	const Matrixd 					  &segment_end_point_distance_matrix,
@@ -1719,7 +1727,7 @@ static inline std::pair<double, size_t> minimum_crossover_cost(
 		double c = connection_cost(0, false, false, 1, false, false, 2, false, false, 3, false, false);
 		assert(std::abs(c - cost_current) < SCALED_EPSILON);
 	}
-#endif /* NDEBUG */
+#endif // NDEBUG
 
 	double cost_min = cost_current;
 	size_t flip_min = 0; // no flip, no improvement
@@ -1750,7 +1758,9 @@ static inline std::pair<double, size_t> minimum_crossover_cost(
 	}
 	return std::make_pair(cost_min, flip_min);
 }
+*/
 
+/*
 static inline void reorder_by_three_exchanges_with_segment_flipping2(std::vector<FlipEdge> &edges)
 {
 	if (edges.size() < 3) {
@@ -1783,9 +1793,9 @@ static inline void reorder_by_three_exchanges_with_segment_flipping2(std::vector
 		// Distances between the end points of the four pieces of the current segment sequence.
 #ifdef NDEBUG
 		Matrixd segment_end_point_distance_matrix(4 * 4, 4 * 4);
-#else /* NDEBUG */
+#else // NDEBUG
 		Matrixd segment_end_point_distance_matrix = Matrixd::Constant(4 * 4, 4 * 4, std::numeric_limits<double>::max());
-#endif /* NDEBUG */
+#endif // NDEBUG
         for (const std::pair<double, size_t> &first_crossover_candidate : connection_lengths) {
             size_t longest_connection_idx = first_crossover_candidate.second;
             connection_tried[longest_connection_idx] = true;
@@ -1845,6 +1855,7 @@ static inline void reorder_by_three_exchanges_with_segment_flipping2(std::vector
 		}
 	}
 }
+*/
 
 // Flip the sequences of polylines to lower the total length of connecting lines.
 static inline void improve_ordering_by_two_exchanges_with_segment_flipping(Polylines &polylines, bool fixed_start)

--- a/src/libslic3r/SlicingAdaptive.cpp
+++ b/src/libslic3r/SlicingAdaptive.cpp
@@ -52,7 +52,7 @@ static inline std::pair<float, float> face_z_span(const stl_facet &f)
 // https://tams.informatik.uni-hamburg.de/publications/2017/Adaptive%20Slicing%20for%20the%20FDM%20Process%20Revisited.pdf
 // (page 51, formula (8))
 // Currenty @platch's error metric formula is not used.
-static constexpr double SURFACE_CONST = 0.18403;
+// static constexpr double SURFACE_CONST = 0.18403;
 
 // for a given facet, compute maximum height within the allowed surface roughness / stairstepping deviation
 static inline float layer_height_from_slope(const SlicingAdaptive::FaceZ &face, float max_surface_deviation)

--- a/src/libslic3r/SupportMaterial.cpp
+++ b/src/libslic3r/SupportMaterial.cpp
@@ -1582,7 +1582,7 @@ PrintObjectSupportMaterial::MyLayersPtr PrintObjectSupportMaterial::bottom_conta
                 });
 
             Polygons &layer_support_area = layer_support_areas[layer_id];
-            task_group.run([this, &projection, &projection_raw, &layer, &layer_support_area, layer_id] {
+            task_group.run([this, &projection, &projection_raw, &layer, &layer_support_area] {
                 // Remove the areas that touched from the projection that will continue on next, lower, top surfaces.
     //            Polygons trimming = union_(to_polygons(layer.slices), touching, true);
                 Polygons trimming = offset(layer.lslices, float(SCALED_EPSILON));
@@ -1724,7 +1724,7 @@ void PrintObjectSupportMaterial::trim_top_contacts_by_bottom_contacts(
     const PrintObject &object, const MyLayersPtr &bottom_contacts, MyLayersPtr &top_contacts) const
 {
     tbb::parallel_for(tbb::blocked_range<int>(0, int(top_contacts.size())),
-        [this, &object, &bottom_contacts, &top_contacts](const tbb::blocked_range<int>& range) {
+        [&bottom_contacts, &top_contacts](const tbb::blocked_range<int>& range) {
             int idx_bottom_overlapping_first = -2;
             // For all top contact layers, counting downwards due to the way idx_higher_or_equal caches the last index to avoid repeated binary search.
             for (int idx_top = range.end() - 1; idx_top >= range.begin(); -- idx_top) {
@@ -1953,7 +1953,7 @@ void PrintObjectSupportMaterial::generate_base_layers(
     BOOST_LOG_TRIVIAL(debug) << "PrintObjectSupportMaterial::generate_base_layers() in parallel - start";
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, intermediate_layers.size()),
-        [this, &object, &bottom_contacts, &top_contacts, &intermediate_layers, &layer_support_areas](const tbb::blocked_range<size_t>& range) {
+        [&object, &bottom_contacts, &top_contacts, &intermediate_layers, &layer_support_areas](const tbb::blocked_range<size_t>& range) {
             // index -2 means not initialized yet, -1 means intialized and decremented to 0 and then -1.
             int idx_top_contact_above           = -2;
             int idx_bottom_contact_overlapping  = -2;
@@ -3318,7 +3318,7 @@ void PrintObjectSupportMaterial::generate_toolpaths(
 
     // Now modulate the support layer height in parallel.
     tbb::parallel_for(tbb::blocked_range<size_t>(n_raft_layers, object.support_layers().size()),
-        [this, &object, &layer_caches]
+        [&object, &layer_caches]
             (const tbb::blocked_range<size_t>& range) {
         for (size_t support_layer_id = range.begin(); support_layer_id < range.end(); ++ support_layer_id) {
             SupportLayer &support_layer = *object.support_layers()[support_layer_id];

--- a/src/libslic3r/SupportMaterial.cpp
+++ b/src/libslic3r/SupportMaterial.cpp
@@ -2316,6 +2316,7 @@ PrintObjectSupportMaterial::MyLayersPtr PrintObjectSupportMaterial::generate_int
     return interface_layers;
 }
 
+/*
 static inline void fill_expolygons_generate_paths(
     ExtrusionEntitiesPtr    &dst, 
     const ExPolygons        &expolygons,
@@ -2341,6 +2342,7 @@ static inline void fill_expolygons_generate_paths(
             flow.mm3_per_mm(), flow.width, flow.height);
     }
 }
+*/
 
 static inline void fill_expolygons_generate_paths(
     ExtrusionEntitiesPtr    &dst,

--- a/src/libslic3r/SupportMaterial.hpp
+++ b/src/libslic3r/SupportMaterial.hpp
@@ -245,8 +245,7 @@ private:
 	// Is merging of regions allowed? Could the interface & base support regions be printed with the same extruder?
 	bool 				 m_can_merge_support_regions;
 
-    coordf_t 			 m_support_layer_height_min;
-	coordf_t		 	 m_support_layer_height_max;
+	coordf_t 			 m_support_layer_height_min;
 
 	coordf_t			 m_gap_xy;
 };

--- a/src/libslic3r/TriangleMesh.cpp
+++ b/src/libslic3r/TriangleMesh.cpp
@@ -1146,6 +1146,7 @@ TriangleMeshSlicer::FacetSliceType TriangleMeshSlicer::slice_facet(
     return NoSlice;
 }
 
+/*
 //FIXME Should this go away? For valid meshes the function slice_facet() returns Slicing
 // and sets edges of vertical triangles to produce only a single edge per pair of neighbor faces.
 // So the following code makes only sense now to handle degenerate meshes with more than two faces
@@ -1209,6 +1210,7 @@ static inline void remove_tangent_edges(std::vector<IntersectionLine> &lines)
         }
     }
 }
+*/
 
 
 struct OpenPolyline {

--- a/src/libslic3r/VoronoiOffset.cpp
+++ b/src/libslic3r/VoronoiOffset.cpp
@@ -666,19 +666,21 @@ void annotate_inside_outside(VD &vd, const Lines &lines)
 
     // Set a VertexCategory, verify validity of the operation.
     auto annotate_vertex = [](const VD::vertex_type *vertex, VertexCategory new_vertex_category) {
+#ifndef NDEBUG
         VertexCategory vc = vertex_category(vertex);
         assert(vc == VertexCategory::Unknown || vc == new_vertex_category);
         assert(new_vertex_category == VertexCategory::Inside || 
                new_vertex_category == VertexCategory::Outside ||
                new_vertex_category == VertexCategory::OnContour);
+#endif
         set_vertex_category(const_cast<VD::vertex_type*>(vertex), new_vertex_category);
     };
 
     // Set an EdgeCategory, verify validity of the operation.
     auto annotate_edge = [](const VD::edge_type *edge, EdgeCategory new_edge_category) {
+#ifndef NDEBUG
         EdgeCategory ec = edge_category(edge);
         assert(ec == EdgeCategory::Unknown || ec == new_edge_category);
-#ifndef NDEBUG
         switch (new_edge_category) {
         case EdgeCategory::PointsInside:
             assert(edge->vertex0() != nullptr);
@@ -760,10 +762,12 @@ void annotate_inside_outside(VD &vd, const Lines &lines)
                 // Only one of the two vertices may lie on input contour.
                 const VD::vertex_type  *v0          = edge.vertex0();
                 const VD::vertex_type  *v1          = edge.vertex1();
+#ifndef NDEBUG
                 VertexCategory          v0_category = vertex_category(v0);
                 VertexCategory          v1_category = vertex_category(v1);
                 assert(v0_category != VertexCategory::OnContour || v1_category != VertexCategory::OnContour);
                 assert(! (on_contour(v0) && on_contour(v1)));
+#endif // NDEBUG
                 if (on_contour(v0))
                     annotate_vertex(v0, VertexCategory::OnContour);
                 else {

--- a/src/qhull/src/libqhullcpp/RoadError.cpp
+++ b/src/qhull/src/libqhullcpp/RoadError.cpp
@@ -15,10 +15,6 @@
 #include <sstream>
 #include <iostream>
 
-using std::cerr;
-using std::cout;
-using std::string;
-
 #ifdef _MSC_VER  // Microsoft Visual C++ -- warning level 4
 #endif
 
@@ -150,7 +146,7 @@ what() const throw()
 void RoadError::
 logErrorLastResort() const
 {
-    global_log << what() << endl;
+    global_log << what() << std::endl;
 }//logError
 
 

--- a/src/qhull/src/libqhullcpp/RoadError.h
+++ b/src/qhull/src/libqhullcpp/RoadError.h
@@ -64,7 +64,7 @@ public:
 
     static void         clearGlobalLog() { global_log.seekp(0); }
     static bool         emptyGlobalLog() { return global_log.tellp()<=0; }
-    static const char  *stringGlobalLog() { return global_log.str().c_str(); }
+    static std::string  stringGlobalLog() { return global_log.str(); }
 
 #//!\name Virtual
     virtual const char *what() const throw();

--- a/src/qhull/src/libqhullcpp/RoadError.h
+++ b/src/qhull/src/libqhullcpp/RoadError.h
@@ -17,8 +17,6 @@
 #include <stdexcept>
 #include <string>
 
-using std::endl;
-
 namespace orgQhull {
 
 #//!\name Defined here

--- a/src/slic3r/Config/Snapshot.cpp
+++ b/src/slic3r/Config/Snapshot.cpp
@@ -251,7 +251,7 @@ bool Snapshot::equal_to_active(const AppConfig &app_config) const
                 return false;
             matched.insert(vc.name);
         }
-        for (const std::pair<std::string, std::map<std::string, std::set<std::string>>> &v : app_config.vendors())
+        for (const std::pair<const std::string, std::map<std::string, std::set<std::string>>> &v : app_config.vendors())
             if (matched.find(v.first) == matched.end() && ! v.second.empty())
                 // There are more vendors currently installed than enabled in the snapshot.
                 return false;
@@ -402,7 +402,7 @@ const Snapshot&	SnapshotDB::take_snapshot(const AppConfig &app_config, Snapshot:
         snapshot.filaments.emplace_back(app_config.get("presets", name));
     }
     // Vendor specific config bundles and installed printers.
-    for (const std::pair<std::string, std::map<std::string, std::set<std::string>>> &vendor : app_config.vendors()) {
+    for (const std::pair<const std::string, std::map<std::string, std::set<std::string>>> &vendor : app_config.vendors()) {
         Snapshot::VendorConfig cfg;
         cfg.name = vendor.first;
         cfg.models_variants_installed = vendor.second;

--- a/src/slic3r/GUI/BonjourDialog.cpp
+++ b/src/slic3r/GUI/BonjourDialog.cpp
@@ -119,7 +119,7 @@ bool BonjourDialog::show_and_lookup()
 	// Note: More can be done here when we support discovery of hosts other than Octoprint and SL1
 	Bonjour::TxtKeys txt_keys { "version", "model" };
 
-	bonjour = std::move(Bonjour("octoprint")
+	bonjour = Bonjour("octoprint")
 		.set_txt_keys(std::move(txt_keys))
 		.set_retries(3)
 		.set_timeout(4)
@@ -139,8 +139,7 @@ bool BonjourDialog::show_and_lookup()
 				wxQueueEvent(dialog, evt);
 			}
 		})
-		.lookup()
-	);
+		.lookup();
 
 	bool res = ShowModal() == wxID_OK && list->GetFirstSelected() >= 0;
 	{

--- a/src/slic3r/GUI/Camera.cpp
+++ b/src/slic3r/GUI/Camera.cpp
@@ -10,15 +10,6 @@
 
 #include <GL/glew.h>
 
-// phi / theta angles to orient the camera.
-static const float VIEW_DEFAULT[2] = { 45.0f, 45.0f };
-static const float VIEW_LEFT[2] = { 90.0f, 90.0f };
-static const float VIEW_RIGHT[2] = { -90.0f, 90.0f };
-static const float VIEW_TOP[2] = { 0.0f, 0.0f };
-static const float VIEW_BOTTOM[2] = { 0.0f, 180.0f };
-static const float VIEW_FRONT[2] = { 0.0f, 90.0f };
-static const float VIEW_REAR[2] = { 180.0f, 90.0f };
-
 namespace Slic3r {
 namespace GUI {
 

--- a/src/slic3r/GUI/ConfigSnapshotDialog.cpp
+++ b/src/slic3r/GUI/ConfigSnapshotDialog.cpp
@@ -68,7 +68,7 @@ static wxString generate_html_row(const Config::Snapshot &snapshot, bool row_eve
         if (vc.version.max_slic3r_version != Semver::inf())
             text += ", " + _(L("max PrusaSlicer version")) + ": " + vc.version.max_slic3r_version.to_string();
         text += "<br>";
-        for (const std::pair<std::string, std::set<std::string>> &model : vc.models_variants_installed) {
+        for (const std::pair<const std::string, std::set<std::string>> &model : vc.models_variants_installed) {
             text += _(L("model")) + ": " + model.first + ", " + _(L("variants")) + ": ";
             for (const std::string &variant : model.second) {
                 if (&variant != &*model.second.begin())

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1872,7 +1872,7 @@ void ConfigWizard::priv::load_vendors()
 		std::map<std::string, std::string> section_new;
 		if (app_config->has_section(section_name)) {
 			const std::map<std::string, std::string> &section_old = app_config->get_section(section_name);
-			for (const std::pair<std::string, std::string> &material_name_and_installed : section_old)
+			for (const std::pair<const std::string, std::string> &material_name_and_installed : section_old)
 				if (material_name_and_installed.second == "1") {
 					// Material is installed. Resolve it in bundles.
                     size_t num_found = 0;
@@ -2248,7 +2248,7 @@ bool ConfigWizard::priv::check_and_install_missing_materials(Technology technolo
 	            	if ((only_for_model_id.empty() || only_for_model_id == printer_model->id) &&
 	            		printer_models_without_material.find(printer_model) == printer_models_without_material.end()) {
                     	bool has_material = false;
-			            for (const std::pair<std::string, std::string> &preset : appconfig_presets) {
+			            for (const std::pair<const std::string, std::string> &preset : appconfig_presets) {
 			            	if (preset.second == "1") {
 			            		const Preset *material = materials.find_preset(preset.first, false);
 			            		if (material != nullptr && is_compatible_with_printer(PresetWithVendorProfile(*material, nullptr), PresetWithVendorProfile(printer, nullptr))) {

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -1889,7 +1889,7 @@ void Control::show_cog_icon_context_menu()
             []() { return true; }, [this]() { return m_extra_style & wxSL_VALUE_LABEL; }, GUI::wxGetApp().plater());
 
         append_submenu(&menu, ruler_mode_menu, wxID_ANY, _L("Ruler mode"), _L("Set ruler mode"), "",
-            [this]() { return true; }, this);
+            []() { return true; }, this);
     }
 
     if (m_mode == MultiAsSingle && m_draw_mode == dmRegular)

--- a/src/slic3r/GUI/Field.hpp
+++ b/src/slic3r/GUI/Field.hpp
@@ -320,7 +320,7 @@ public:
 		dynamic_cast<wxSpinCtrl*>(window)->SetValue(value);
 		m_disable_change_event = false;
 	}
-	void			set_value(const boost::any& value, bool change_event = false) {
+	void			set_value(const boost::any& value, bool change_event = false) override {
 		m_disable_change_event = !change_event;
 		tmp_value = boost::any_cast<int>(value);
         m_value = value;

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -648,7 +648,7 @@ void FirmwareDialog::priv::perform_upload()
 				}
 			}
 		})
-		.on_message(std::move([q, extra_verbose](const char *msg, unsigned /* size */) {
+		.on_message([q, extra_verbose](const char *msg, unsigned /* size */) {
 			if (extra_verbose) {
 				BOOST_LOG_TRIVIAL(debug) << "avrdude: " << msg;
 			}
@@ -665,19 +665,19 @@ void FirmwareDialog::priv::perform_upload()
 			evt->SetExtraLong(AE_MESSAGE);
 			evt->SetString(std::move(wxmsg));
 			wxQueueEvent(q, evt);
-		}))
-		.on_progress(std::move([q](const char * /* task */, unsigned progress) {
+		})
+		.on_progress([q](const char * /* task */, unsigned progress) {
 			auto evt = new wxCommandEvent(EVT_AVRDUDE, q->GetId());
 			evt->SetExtraLong(AE_PROGRESS);
 			evt->SetInt(progress);
 			wxQueueEvent(q, evt);
-		}))
-		.on_complete(std::move([this]() {
+		})
+		.on_complete([this]() {
 			auto evt = new wxCommandEvent(EVT_AVRDUDE, this->q->GetId());
 			evt->SetExtraLong(AE_EXIT);
 			evt->SetInt(this->avrdude->exit_code());
 			wxQueueEvent(this->q, evt);
-		}))
+		})
 		.run();
 }
 

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -648,7 +648,7 @@ void FirmwareDialog::priv::perform_upload()
 				}
 			}
 		})
-		.on_message([q, extra_verbose](const char *msg, unsigned /* size */) {
+		.on_message([q](const char *msg, unsigned /* size */) {
 			if (extra_verbose) {
 				BOOST_LOG_TRIVIAL(debug) << "avrdude: " << msg;
 			}

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -2653,7 +2653,7 @@ void GCodeViewer::refresh_render_paths(bool keep_sequential_current_first, bool 
         return color;
     };
 
-    auto travel_color = [this](const Path& path) {
+    auto travel_color = [](const Path& path) {
         return (path.delta_extruder < 0.0f) ? Travel_Colors[2] /* Retract */ :
             ((path.delta_extruder > 0.0f) ? Travel_Colors[1] /* Extrude */ :
                 Travel_Colors[0] /* Move */);
@@ -3168,7 +3168,11 @@ void GCodeViewer::render_toolpaths() const
         shader.set_uniform("uniform_color", color4);
     };
 
-    auto render_as_points = [this, zoom, point_size, near_plane_height, set_uniform_color]
+    auto render_as_points = [
+#if ENABLE_GCODE_VIEWER_STATISTICS
+                             this,
+#endif // ENABLE_GCODE_VIEWER_STATISTICS
+                             zoom, point_size, near_plane_height, set_uniform_color]
         (const TBuffer& buffer, unsigned int ibuffer_id, GLShaderProgram& shader) {
 #if ENABLE_FIXED_SCREEN_SIZE_POINT_MARKERS
         shader.set_uniform("use_fixed_screen_size", 1);
@@ -3198,7 +3202,11 @@ void GCodeViewer::render_toolpaths() const
         glsafe(::glDisable(GL_VERTEX_PROGRAM_POINT_SIZE));
     };
 
-    auto render_as_lines = [this, light_intensity, set_uniform_color](const TBuffer& buffer, unsigned int ibuffer_id, GLShaderProgram& shader) {
+    auto render_as_lines = [
+#if ENABLE_GCODE_VIEWER_STATISTICS
+                            this,
+#endif // ENABLE_GCODE_VIEWER_STATISTICS
+                            light_intensity, set_uniform_color](const TBuffer& buffer, unsigned int ibuffer_id, GLShaderProgram& shader) {
         shader.set_uniform("light_intensity", light_intensity);
         for (const RenderPath& path : buffer.render_paths) {
             if (path.index_buffer_id == ibuffer_id) {
@@ -3211,7 +3219,11 @@ void GCodeViewer::render_toolpaths() const
         }
     };
 
-    auto render_as_triangles = [this, set_uniform_color](const TBuffer& buffer, unsigned int ibuffer_id, GLShaderProgram& shader) {
+    auto render_as_triangles = [
+#if ENABLE_GCODE_VIEWER_STATISTICS
+                                this,
+#endif // ENABLE_GCODE_VIEWER_STATISTICS
+                                set_uniform_color](const TBuffer& buffer, unsigned int ibuffer_id, GLShaderProgram& shader) {
         for (const RenderPath& path : buffer.render_paths) {
             if (path.index_buffer_id == ibuffer_id) {
                 set_uniform_color(path.color, shader);
@@ -3304,7 +3316,7 @@ void GCodeViewer::render_toolpaths() const
         shader.set_uniform("uniform_color", color4);
     };
 
-    auto render_as_points = [this, zoom, point_size, near_plane_height, set_uniform_color]
+    auto render_as_points = [zoom, point_size, near_plane_height, set_uniform_color]
     (const TBuffer& buffer, unsigned int index_buffer_id, EOptionsColors color_id, GLShaderProgram& shader) {
         set_uniform_color(Options_Colors[static_cast<unsigned int>(color_id)], shader);
 #if ENABLE_FIXED_SCREEN_SIZE_POINT_MARKERS
@@ -3334,7 +3346,7 @@ void GCodeViewer::render_toolpaths() const
         glsafe(::glDisable(GL_VERTEX_PROGRAM_POINT_SIZE));
     };
 
-    auto render_as_lines = [this, light_intensity, set_uniform_color](const TBuffer& buffer, unsigned int index_buffer_id, GLShaderProgram& shader) {
+    auto render_as_lines = [light_intensity, set_uniform_color](const TBuffer& buffer, unsigned int index_buffer_id, GLShaderProgram& shader) {
         shader.set_uniform("light_intensity", light_intensity);
         for (const RenderPath& path : buffer.render_paths) {
             if (path.index_buffer_id == index_buffer_id) {
@@ -3347,7 +3359,7 @@ void GCodeViewer::render_toolpaths() const
         }
     };
 
-    auto render_as_triangles = [this, set_uniform_color](const TBuffer& buffer, unsigned int index_buffer_id, GLShaderProgram& shader) {
+    auto render_as_triangles = [set_uniform_color](const TBuffer& buffer, unsigned int index_buffer_id, GLShaderProgram& shader) {
         for (const RenderPath& path : buffer.render_paths) {
             if (path.index_buffer_id == index_buffer_id) {
                 set_uniform_color(path.color, shader);
@@ -3565,8 +3577,8 @@ void GCodeViewer::render_legend() const
                 ImGui::PopStyleVar();
     };
 
-    auto append_range = [this, draw_list, &imgui, append_item](const Extrusions::Range& range, unsigned int decimals) {
-        auto append_range_item = [this, draw_list, &imgui, append_item](int i, float value, unsigned int decimals) {
+    auto append_range = [append_item](const Extrusions::Range& range, unsigned int decimals) {
+        auto append_range_item = [append_item](int i, float value, unsigned int decimals) {
             char buf[1024];
             ::sprintf(buf, "%.*f", decimals, value);
             append_item(EItemType::Rect, Range_Colors[i], buf);
@@ -3660,7 +3672,7 @@ void GCodeViewer::render_legend() const
         return _u8L("from") + " " + std::string(buf1) + " " + _u8L("to") + " " + std::string(buf2) + " " + _u8L("mm");
     };
 
-    auto role_time_and_percent = [this, time_mode](ExtrusionRole role) {
+    auto role_time_and_percent = [time_mode](ExtrusionRole role) {
         auto it = std::find_if(time_mode.roles_times.begin(), time_mode.roles_times.end(), [role](const std::pair<ExtrusionRole, float>& item) { return role == item.first; });
         return (it != time_mode.roles_times.end()) ? std::make_pair(it->second, it->second / time_mode.time) : std::make_pair(0.0f, 0.0f);
     };
@@ -3867,7 +3879,7 @@ void GCodeViewer::render_legend() const
             return items;
         };
 
-        auto append_color_change = [this, &imgui](const Color& color1, const Color& color2, const std::array<float, 2>& offsets, const Times& times) {
+        auto append_color_change = [&imgui](const Color& color1, const Color& color2, const std::array<float, 2>& offsets, const Times& times) {
             imgui.text(_u8L("Color change"));
             ImGui::SameLine();
 
@@ -3886,7 +3898,7 @@ void GCodeViewer::render_legend() const
             imgui.text(short_time(get_time_dhms(times.second - times.first)));
         };
 
-        auto append_print = [this, &imgui](const Color& color, const std::array<float, 2>& offsets, const Times& times) {
+        auto append_print = [&imgui](const Color& color, const std::array<float, 2>& offsets, const Times& times) {
             imgui.text(_u8L("Print"));
             ImGui::SameLine();
 
@@ -4146,7 +4158,7 @@ void GCodeViewer::render_statistics() const
 
     ImGuiWrapper& imgui = *wxGetApp().imgui();
 
-    auto add_time = [this, &imgui](const std::string& label, int64_t time) {
+    auto add_time = [&imgui](const std::string& label, int64_t time) {
         char buf[1024];
         sprintf(buf, "%lld ms (%s)", time, get_time_dhms(static_cast<float>(time) * 0.001f).c_str());
         imgui.text_colored(ImGuiWrapper::COL_ORANGE_LIGHT, label);
@@ -4154,7 +4166,7 @@ void GCodeViewer::render_statistics() const
         imgui.text(buf);
     };
 
-    auto add_memory = [this, &imgui](const std::string& label, int64_t memory) {
+    auto add_memory = [&imgui](const std::string& label, int64_t memory) {
         auto format_string = [memory](const std::string& units, float value) {
             char buf[1024];
             sprintf(buf, "%lld bytes (%.3f %s)", memory, static_cast<float>(memory) * value, units.c_str());
@@ -4177,7 +4189,7 @@ void GCodeViewer::render_statistics() const
             imgui.text(format_string("GB", inv_gb));
     };
 
-    auto add_counter = [this, &imgui](const std::string& label, int64_t counter) {
+    auto add_counter = [&imgui](const std::string& label, int64_t counter) {
         char buf[1024];
         sprintf(buf, "%lld", counter);
         imgui.text_colored(ImGuiWrapper::COL_ORANGE_LIGHT, label);

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -2216,7 +2216,6 @@ void GCodeViewer::load_toolpaths(const GCodeProcessor::Result& gcode_result)
                     displacement = half_width * ::tan(::acos(std::clamp(dir.dot(med_dir), -1.0f, 1.0f)));
                 }
 
-                Vec3f displacement_vec = displacement * prev_dir;
                 bool can_displace = displacement > 0.0f && displacement < prev_length && displacement < length;
 
                 bool is_right_turn = prev_up.dot(prev_dir.cross(dir)) <= 0.0f;

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -2949,14 +2949,6 @@ void GCodeViewer::refresh_render_paths(bool keep_sequential_current_first, bool 
     };
 
     auto is_travel_in_layers_range = [this](size_t path_id, size_t min_id, size_t max_id) {
-        auto is_in_z_range = [](const Path& path, double min_z, double max_z) {
-            auto in_z_range = [min_z, max_z](double z) {
-                return min_z - EPSILON < z&& z < max_z + EPSILON;
-            };
-
-            return in_z_range(path.first.position[2]) || in_z_range(path.last.position[2]);
-        };
-
         const TBuffer& buffer = m_buffers[buffer_id(EMoveType::Travel)];
         if (path_id >= buffer.paths.size())
             return false;

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -80,8 +80,6 @@ static const float ERROR_BG_LIGHT_COLOR[3] = { 0.753f, 0.192f, 0.039f };
 static const size_t MAX_VERTEX_BUFFER_SIZE     = 131072 * 6; // 3.15MB
 // Reserve size in number of floats.
 static const size_t VERTEX_BUFFER_RESERVE_SIZE = 131072 * 2; // 1.05MB
-// Reserve size in number of floats, maximum sum of all preallocated buffers.
-static const size_t VERTEX_BUFFER_RESERVE_SIZE_SUM_MAX = 1024 * 1024 * 128 / 4; // 128MB
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4580,9 +4580,9 @@ bool GLCanvas3D::_init_main_toolbar()
                                                 "\n" + "[" + GUI::shortkey_ctrl_prefix() + "4] - " + _u8L("Printer Settings Tab") ;
     item.sprite_id = 10;
     item.enabling_callback    = GLToolbarItem::Default_Enabling_Callback;
-    item.visibility_callback  = [this]() { return (wxGetApp().app_config->get("new_settings_layout_mode") == "1" ||
+    item.visibility_callback  = []() { return (wxGetApp().app_config->get("new_settings_layout_mode") == "1" ||
                                                    wxGetApp().app_config->get("dlg_settings_layout_mode") == "1"); };
-    item.left.action_callback = [this]() { wxGetApp().mainframe->select_tab(); };
+    item.left.action_callback = []() { wxGetApp().mainframe->select_tab(); };
     if (!m_main_toolbar.add_item(item))
         return false;
 
@@ -5909,7 +5909,7 @@ void GLCanvas3D::_load_print_object_toolpaths(const PrintObject& print_object, c
         [&ctxt, &new_volume, is_selected_separate_extruder, this](const tbb::blocked_range<size_t>& range) {
         GLVolumePtrs 		vols;
         std::vector<size_t>	color_print_layer_to_glvolume;
-        auto                volume = [&ctxt, &vols, &color_print_layer_to_glvolume, &range](size_t layer_idx, int extruder, int feature) -> GLVolume& {            
+        auto                volume = [&ctxt, &vols](size_t layer_idx, int extruder, int feature) -> GLVolume& {            
             return *vols[ctxt.color_by_color_print()?
                 ctxt.color_print_color_idx_by_layer_idx_and_extruder(layer_idx, extruder) :
 				ctxt.color_by_tool() ? 

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -394,12 +394,10 @@ class GLCanvas3D
     class Slope
     {
         bool m_enabled{ false };
-        bool m_dialog_shown{ false };
-        GLCanvas3D& m_canvas;
         GLVolumeCollection& m_volumes;
         static float s_window_width;
     public:
-        Slope(GLCanvas3D& canvas, GLVolumeCollection& volumes) : m_canvas(canvas), m_volumes(volumes) {}
+        Slope(GLCanvas3D& canvas, GLVolumeCollection& volumes) : m_volumes(volumes) {}
 
         void enable(bool enable) { m_enabled = enable; }
         bool is_enabled() const { return m_enabled; }

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -35,7 +35,7 @@ void disable_screensaver()
 {
     #if __APPLE__
     CFStringRef reasonForActivity = CFSTR("Slic3r");
-    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, 
+    /*IOReturn success =*/ IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, 
         kIOPMAssertionLevelOn, reasonForActivity, &assertionID); 
     // ignore result: success == kIOReturnSuccess
     #elif _WIN32
@@ -46,7 +46,7 @@ void disable_screensaver()
 void enable_screensaver()
 {
     #if __APPLE__
-    IOReturn success = IOPMAssertionRelease(assertionID);
+    IOPMAssertionRelease(assertionID);
     #elif _WIN32
     SetThreadExecutionState(ES_CONTINUOUS);
     #endif

--- a/src/slic3r/GUI/GUI_ObjectLayers.cpp
+++ b/src/slic3r/GUI/GUI_ObjectLayers.cpp
@@ -132,7 +132,7 @@ wxSizer* ObjectLayers::create_layer(const t_layer_height_range& range, PlusMinus
     // Add control for the "Layer height"
 
     editor = new LayerRangeEditor(this, double_to_string(m_object->layer_config_ranges[range].option("layer_height")->getFloat()), etLayerHeight, set_focus_data,
-        [range, this](coordf_t layer_height, bool, bool)
+        [range](coordf_t layer_height, bool, bool)
     {
         return wxGetApp().obj_list()->edit_layer_range(range, layer_height);
     });

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -113,10 +113,12 @@ ObjectList::ObjectList(wxWindow* parent) :
 
     // describe control behavior 
     Bind(wxEVT_DATAVIEW_SELECTION_CHANGED, [this](wxDataViewEvent& event) {
+#ifndef __WXOSX__
         // detect the current mouse position here, to pass it to list_manipulation() method
         // if we detect it later, the user may have moved the mouse pointer while calculations are performed, and this would mess-up the HitTest() call performed into list_manipulation()
         // see: https://github.com/prusa3d/PrusaSlicer/issues/3802
         const wxPoint mouse_pos = this->get_mouse_position_in_control();
+#endif //__WXOSX__
 
 #ifndef __APPLE__
         // On Windows and Linux, forces a kill focus emulation on the object manipulator fields because this event handler is called

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1843,7 +1843,7 @@ void ObjectList::append_menu_item_export_stl(wxMenu* menu) const
 void ObjectList::append_menu_item_reload_from_disk(wxMenu* menu) const
 {
     append_menu_item(menu, wxID_ANY, _(L("Reload from disk")), _(L("Reload the selected volumes from disk")),
-        [this](wxCommandEvent&) { wxGetApp().plater()->reload_from_disk(); }, "", menu,
+        [](wxCommandEvent&) { wxGetApp().plater()->reload_from_disk(); }, "", menu,
         []() { return wxGetApp().plater()->can_reload_from_disk(); }, wxGetApp().plater());
 }
 
@@ -2066,7 +2066,7 @@ wxMenu* ObjectList::create_settings_popupmenu(wxMenu *parent_menu)
         append_menu_item(menu, wxID_ANY, _(cat.first), "",
                         [menu, this](wxCommandEvent& event) { get_settings_choice(menu->GetLabel(event.GetId())); }, 
                         CATEGORY_ICON.find(cat.first) == CATEGORY_ICON.end() ? wxNullBitmap : CATEGORY_ICON.at(cat.first), parent_menu,
-                        [this]() { return true; }, wxGetApp().plater());
+                        []() { return true; }, wxGetApp().plater());
     }
 
     return menu;
@@ -2087,7 +2087,7 @@ void ObjectList::create_freq_settings_popupmenu(wxMenu *menu, const bool is_obje
         append_menu_item(menu, wxID_ANY, _(it.first), "",
                         [menu, this](wxCommandEvent& event) { get_freq_settings_choice(menu->GetLabel(event.GetId())); }, 
                         CATEGORY_ICON.find(it.first) == CATEGORY_ICON.end() ? wxNullBitmap : CATEGORY_ICON.at(it.first), menu,
-                        [this]() { return true; }, wxGetApp().plater());
+                        []() { return true; }, wxGetApp().plater());
     }
 #if 0
     // Add "Quick" settings bundles
@@ -4601,7 +4601,7 @@ void ObjectList::show_multi_selection_menu()
         append_menu_item_change_extruder(menu);
 
     append_menu_item(menu, wxID_ANY, _(L("Reload from disk")), _(L("Reload the selected volumes from disk")),
-        [this](wxCommandEvent&) { wxGetApp().plater()->reload_from_disk(); }, "", menu, []() {
+        [](wxCommandEvent&) { wxGetApp().plater()->reload_from_disk(); }, "", menu, []() {
         return wxGetApp().plater()->can_reload_from_disk();
     }, wxGetApp().plater());
 

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -753,7 +753,7 @@ void ObjectList::copy_layers_to_clipboard()
         return;
     }
 
-    for (const auto layer_item : sel_layers)
+    for (const auto &layer_item : sel_layers)
         if (m_objects_model->GetItemType(layer_item) & itLayer) {
             auto range = m_objects_model->GetLayerRangeByItem(layer_item);
             auto it = ranges.find(range);
@@ -779,7 +779,7 @@ void ObjectList::paste_layers_into_list()
     t_layer_config_ranges& ranges = object(obj_idx)->layer_config_ranges;
 
     // and create Layer item(s) according to the layer_config_ranges
-    for (const auto range : cache_ranges)
+    for (const auto &range : cache_ranges)
         ranges.emplace(range);
 
     layers_item = add_layer_root_item(object_item);

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
@@ -31,17 +31,17 @@ public:
     std::string get_tooltip() const override;
 
 protected:
-    virtual bool on_init();
-    virtual void on_load(cereal::BinaryInputArchive& ar) { ar(m_cut_z, m_keep_upper, m_keep_lower, m_rotate_lower); }
-    virtual void on_save(cereal::BinaryOutputArchive& ar) const { ar(m_cut_z, m_keep_upper, m_keep_lower, m_rotate_lower); }
-    virtual std::string on_get_name() const;
-    virtual void on_set_state();
-    virtual bool on_is_activable() const;
-    virtual void on_start_dragging();
-    virtual void on_update(const UpdateData& data);
-    virtual void on_render() const;
-    virtual void on_render_for_picking() const;
-    virtual void on_render_input_window(float x, float y, float bottom_limit);
+    virtual bool on_init() override;
+    virtual void on_load(cereal::BinaryInputArchive& ar) override { ar(m_cut_z, m_keep_upper, m_keep_lower, m_rotate_lower); }
+    virtual void on_save(cereal::BinaryOutputArchive& ar) const override { ar(m_cut_z, m_keep_upper, m_keep_lower, m_rotate_lower); }
+    virtual std::string on_get_name() const override;
+    virtual void on_set_state() override;
+    virtual bool on_is_activable() const override;
+    virtual void on_start_dragging() override;
+    virtual void on_update(const UpdateData& data) override;
+    virtual void on_render() const override;
+    virtual void on_render_for_picking() const override;
+    virtual void on_render_input_window(float x, float y, float bottom_limit) override;
 
 private:
     void update_max_z(const Selection& selection) const;

--- a/src/slic3r/GUI/Gizmos/GLGizmoMove.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMove.hpp
@@ -33,14 +33,14 @@ public:
     std::string get_tooltip() const override;
 
 protected:
-    virtual bool on_init();
-    virtual std::string on_get_name() const;
-    virtual bool on_is_activable() const;
-    virtual void on_start_dragging();
-    virtual void on_stop_dragging();
-    virtual void on_update(const UpdateData& data);
-    virtual void on_render() const;
-    virtual void on_render_for_picking() const;
+    virtual bool on_init() override;
+    virtual std::string on_get_name() const override;
+    virtual bool on_is_activable() const override;
+    virtual void on_start_dragging() override;
+    virtual void on_stop_dragging() override;
+    virtual void on_update(const UpdateData& data) override;
+    virtual void on_render() const override;
+    virtual void on_render_for_picking() const override;
 
 private:
     double calc_projection(const UpdateData& data) const;

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
@@ -59,8 +59,8 @@ class GLGizmoPainterBase : public GLGizmoBase
 private:
     ObjectID m_old_mo_id;
     size_t m_old_volumes_size = 0;
-    virtual void on_render() const {}
-    virtual void on_render_for_picking() const {}
+    virtual void on_render() const override {}
+    virtual void on_render_for_picking() const override {}
 
 public:
     GLGizmoPainterBase(GLCanvas3D& parent, const std::string& icon_filename, unsigned int sprite_id);

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
@@ -47,13 +47,13 @@ public:
     std::string get_tooltip() const override;
 
 protected:
-    virtual bool on_init();
-    virtual std::string on_get_name() const;
-    virtual bool on_is_activable() const;
-    virtual void on_start_dragging();
-    virtual void on_update(const UpdateData& data);
-    virtual void on_render() const;
-    virtual void on_render_for_picking() const;
+    virtual bool on_init() override;
+    virtual std::string on_get_name() const override;
+    virtual bool on_is_activable() const override;
+    virtual void on_start_dragging() override;
+    virtual void on_update(const UpdateData& data) override;
+    virtual void on_render() const override;
+    virtual void on_render_for_picking() const override;
 
 private:
     void render_grabbers_connection(unsigned int id_1, unsigned int id_2) const;

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -893,7 +893,7 @@ void GLGizmoSlaSupports::on_set_state()
             // Only take the snapshot when the USER opens the gizmo. Common gizmos
             // data are not yet available, the CallAfter will postpone taking the
             // snapshot until they are. No, it does not feel right.
-            wxGetApp().CallAfter([this]() {
+            wxGetApp().CallAfter([]() {
                 Plater::TakeSnapshot snapshot(wxGetApp().plater(), _(L("SLA gizmo turned on")));
             });
         }

--- a/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
@@ -161,7 +161,6 @@ protected:
 
 private:
     ModelObject* m_model_object = nullptr;
-    int m_active_inst = -1;
     float m_z_shift = 0.f;
 };
 

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -940,7 +940,10 @@ void ImGuiWrapper::init_font(bool compress)
     config.MergeMode = true;
     if (! m_font_cjk) {
 		// Apple keyboard shortcuts are only contained in the CJK fonts.
-		ImFont *font_cjk = io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/NotoSansCJK-Regular.ttc").c_str(), m_font_size, &config, ranges_keyboard_shortcuts);
+#ifndef NDEBUG
+		ImFont *font_cjk =
+#endif // NDEBUG
+                  io.Fonts->AddFontFromFileTTF((Slic3r::resources_dir() + "/fonts/NotoSansCJK-Regular.ttc").c_str(), m_font_size, &config, ranges_keyboard_shortcuts);
         assert(font_cjk != nullptr);
     }
 #endif

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -63,10 +63,10 @@ public:
             // Only allow opening a new PrusaSlicer instance on OSX if "single_instance" is disabled, 
             // as starting new instances would interfere with the locking mechanism of "single_instance" support.
             append_menu_item(menu, wxID_ANY, _L("Open new instance"), _L("Open a new PrusaSlicer instance"),
-            [this](wxCommandEvent&) { start_new_slicer(); }, "", nullptr);
+            [](wxCommandEvent&) { start_new_slicer(); }, "", nullptr);
         }
         append_menu_item(menu, wxID_ANY, _L("G-code preview") + dots, _L("Open G-code viewer"),
-            [this](wxCommandEvent&) { start_new_gcodeviewer_open_file(); }, "", nullptr);
+            [](wxCommandEvent&) { start_new_gcodeviewer_open_file(); }, "", nullptr);
         return menu;
     }
 };
@@ -77,9 +77,9 @@ public:
     wxMenu *CreatePopupMenu() override {
         wxMenu *menu = new wxMenu;
         append_menu_item(menu, wxID_ANY, _L("Open PrusaSlicer"), _L("Open a new PrusaSlicer instance"),
-            [this](wxCommandEvent&) { start_new_slicer(nullptr, true); }, "", nullptr);
+            [](wxCommandEvent&) { start_new_slicer(nullptr, true); }, "", nullptr);
         append_menu_item(menu, wxID_ANY, _L("G-code preview") + dots, _L("Open new G-code viewer"),
-            [this](wxCommandEvent&) { start_new_gcodeviewer_open_file(); }, "", nullptr);
+            [](wxCommandEvent&) { start_new_gcodeviewer_open_file(); }, "", nullptr);
         return menu;
     }
 };
@@ -230,7 +230,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxDEFAULT_FRAME_S
 // So, redraw explicitly canvas, when application is moved
 //FIXME maybe this is useful for __WXGTK3__ as well?
 #if __APPLE__
-    Bind(wxEVT_MOVE, [this](wxMoveEvent& event) {
+    Bind(wxEVT_MOVE, [](wxMoveEvent& event) {
         wxGetApp().plater()->get_current_canvas3D()->set_as_dirty();
         wxGetApp().plater()->get_current_canvas3D()->request_extra_frame();
         event.Skip();
@@ -1189,7 +1189,7 @@ void MainFrame::init_menubar_as_editor()
         
         windowMenu->AppendSeparator();
         append_menu_item(windowMenu, wxID_ANY, _L("Open new instance") + "\tCtrl+Shift+I", _L("Open a new PrusaSlicer instance"),
-			[this](wxCommandEvent&) { start_new_slicer(); }, "", nullptr, [this]() {return m_plater != nullptr && wxGetApp().app_config->get("single_instance") != "1"; }, this);
+			[](wxCommandEvent&) { start_new_slicer(); }, "", nullptr, [this]() {return m_plater != nullptr && wxGetApp().app_config->get("single_instance") != "1"; }, this);
     }
 
     // View menu
@@ -1258,8 +1258,8 @@ void MainFrame::init_menubar_as_gcodeviewer()
             [this](wxCommandEvent&) { if (m_plater != nullptr) m_plater->export_toolpaths_to_obj(); }, "export_plater", nullptr,
             [this]() {return can_export_toolpaths(); }, this);
         append_menu_item(fileMenu, wxID_ANY, _L("Open &PrusaSlicer") + dots, _L("Open PrusaSlicer"),
-            [this](wxCommandEvent&) { start_new_slicer(); }, "", nullptr,
-            [this]() {return true; }, this);
+            [](wxCommandEvent&) { start_new_slicer(); }, "", nullptr,
+            []() {return true; }, this);
         fileMenu->AppendSeparator();
         append_menu_item(fileMenu, wxID_EXIT, _L("&Quit"), wxString::Format(_L("Quit %s"), SLIC3R_APP_NAME),
             [this](wxCommandEvent&) { Close(false); });

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -132,7 +132,7 @@ class MainFrame : public DPIFrame
     ESettingsLayout m_layout{ ESettingsLayout::Unknown };
 
 protected:
-    virtual void on_dpi_changed(const wxRect &suggested_rect);
+    virtual void on_dpi_changed(const wxRect &suggested_rect) override;
     virtual void on_sys_color_changed() override;
 
 public:

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -397,7 +397,7 @@ void Mouse3DController::save_config(AppConfig &appconfig) const
 	// We do not synchronize m_params_by_device with the background thread explicitely 
 	// as there should be a full memory barrier executed once the background thread is stopped.
 
-	for (const std::pair<std::string, Params> &key_value_pair : m_params_by_device) {
+	for (const std::pair<const std::string, Params> &key_value_pair : m_params_by_device) {
 		const std::string &device_name = key_value_pair.first;
 		const Params      &params      = key_value_pair.second;
 	    // Store current device parameters into the config

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -1208,7 +1208,7 @@ void ObjectDataViewModel::AddAllChildren(const wxDataViewItem& parent)
         ItemAdded(parent, wxDataViewItem((void*)child));
     }
 
-    for (const auto item : array)
+    for (const auto &item : array)
         AddAllChildren(item);
 
     m_ctrl->Expand(parent);
@@ -1362,7 +1362,7 @@ void ObjectDataViewModel::GetAllChildren(const wxDataViewItem &parent, wxDataVie
     }
 
     wxDataViewItemArray new_array = array;
-    for (const auto item : new_array)
+    for (const auto &item : new_array)
     {
         wxDataViewItemArray children;
         GetAllChildren(item, children);

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -27,20 +27,20 @@ const t_field& OptionsGroup::build_field(const t_config_option_key& id, const Co
     // is the normal type.
     if (opt.gui_type == "select") {
     } else if (opt.gui_type == "select_open") {
-		m_fields.emplace(id, std::move(Choice::Create<Choice>(this->ctrl_parent(), opt, id)));
+		m_fields.emplace(id, Choice::Create<Choice>(this->ctrl_parent(), opt, id));
     } else if (opt.gui_type == "color") {
-		m_fields.emplace(id, std::move(ColourPicker::Create<ColourPicker>(this->ctrl_parent(), opt, id)));
+		m_fields.emplace(id, ColourPicker::Create<ColourPicker>(this->ctrl_parent(), opt, id));
     } else if (opt.gui_type == "f_enum_open" || 
                 opt.gui_type == "i_enum_open" ||
                 opt.gui_type == "i_enum_closed") {
-		m_fields.emplace(id, std::move(Choice::Create<Choice>(this->ctrl_parent(), opt, id)));
+		m_fields.emplace(id, Choice::Create<Choice>(this->ctrl_parent(), opt, id));
     } else if (opt.gui_type == "slider") {
-		m_fields.emplace(id, std::move(SliderCtrl::Create<SliderCtrl>(this->ctrl_parent(), opt, id)));
+		m_fields.emplace(id, SliderCtrl::Create<SliderCtrl>(this->ctrl_parent(), opt, id));
     } else if (opt.gui_type == "i_spin") { // Spinctrl
     } else if (opt.gui_type == "legend") { // StaticText
-		m_fields.emplace(id, std::move(StaticText::Create<StaticText>(this->ctrl_parent(), opt, id)));
+		m_fields.emplace(id, StaticText::Create<StaticText>(this->ctrl_parent(), opt, id));
     } else if (opt.gui_type == "one_string") {
-        m_fields.emplace(id, std::move(TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id)));
+        m_fields.emplace(id, TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id));
     } else { 
         switch (opt.type) {
             case coFloatOrPercent:
@@ -50,21 +50,21 @@ const t_field& OptionsGroup::build_field(const t_config_option_key& id, const Co
 			case coPercents:
 			case coString:
 			case coStrings:
-				m_fields.emplace(id, std::move(TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id)));
+				m_fields.emplace(id, TextCtrl::Create<TextCtrl>(this->ctrl_parent(), opt, id));
                 break;
 			case coBool:
 			case coBools:
-				m_fields.emplace(id, std::move(CheckBox::Create<CheckBox>(this->ctrl_parent(), opt, id)));
+				m_fields.emplace(id, CheckBox::Create<CheckBox>(this->ctrl_parent(), opt, id));
 				break;
 			case coInt:
 			case coInts:
-				m_fields.emplace(id, std::move(SpinCtrl::Create<SpinCtrl>(this->ctrl_parent(), opt, id)));
+				m_fields.emplace(id, SpinCtrl::Create<SpinCtrl>(this->ctrl_parent(), opt, id));
 				break;
             case coEnum:
-				m_fields.emplace(id, std::move(Choice::Create<Choice>(this->ctrl_parent(), opt, id)));
+				m_fields.emplace(id, Choice::Create<Choice>(this->ctrl_parent(), opt, id));
 				break;
             case coPoints:
-				m_fields.emplace(id, std::move(PointCtrl::Create<PointCtrl>(this->ctrl_parent(), opt, id)));
+				m_fields.emplace(id, PointCtrl::Create<PointCtrl>(this->ctrl_parent(), opt, id));
 				break;
             case coNone:   break;
             default:

--- a/src/slic3r/GUI/OptionsGroup.hpp
+++ b/src/slic3r/GUI/OptionsGroup.hpp
@@ -273,7 +273,6 @@ private:
     const DynamicPrintConfig*	m_config {nullptr};
     // If the config is modelconfig, then ModelConfig::touch() has to be called after value change.
     ModelConfig*				m_modelconfig { nullptr };
-	bool						m_full_labels{ 0 };
 	t_opt_map					m_opt_map;
     std::string             	m_config_category;
 

--- a/src/slic3r/GUI/OptionsGroup.hpp
+++ b/src/slic3r/GUI/OptionsGroup.hpp
@@ -166,7 +166,7 @@ public:
 
 	OptionsGroup(	wxWindow* _parent, const wxString& title, bool is_tab_opt = false, 
                     column_t extra_clmn = nullptr);
-	~OptionsGroup() { clear(true); }
+	virtual ~OptionsGroup() { clear(true); }
 
     wxGridSizer*        get_grid_sizer() { return m_grid_sizer; }
 	const std::vector<Line>& get_lines() { return m_lines; }

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -275,7 +275,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
 
     m_optgroup->append_single_option_line("host_type");
 
-    auto create_sizer_with_btn = [this](wxWindow* parent, ScalableButton** btn, const std::string& icon_name, const wxString& label) {
+    auto create_sizer_with_btn = [](wxWindow* parent, ScalableButton** btn, const std::string& icon_name, const wxString& label) {
         *btn = new ScalableButton(parent, wxID_ANY, icon_name, label, wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
         (*btn)->SetFont(wxGetApp().normal_font());
 
@@ -379,7 +379,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
 
         Line cafile_hint{ "", "" };
         cafile_hint.full_width = 1;
-        cafile_hint.widget = [this, ca_file_hint](wxWindow* parent) {
+        cafile_hint.widget = [ca_file_hint](wxWindow* parent) {
             auto txt = new wxStaticText(parent, wxID_ANY, ca_file_hint);
             auto sizer = new wxBoxSizer(wxHORIZONTAL);
             sizer->Add(txt);
@@ -420,7 +420,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     {
         wxTextCtrl* temp = dynamic_cast<wxTextCtrl*>(printhost_field->getWindow());
         if (temp)
-            temp->Bind(wxEVT_TEXT, ([this, printhost_field, temp](wxEvent& e)
+            temp->Bind(wxEVT_TEXT, ([printhost_field, temp](wxEvent& e)
             {
 #ifndef __WXGTK__
                 e.Skip();

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -290,7 +290,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
         m_printhost_browse_btn->Bind(wxEVT_BUTTON, [=](wxCommandEvent& e) {
             BonjourDialog dialog(this, Preset::printer_technology(m_printer.config));
             if (dialog.show_and_lookup()) {
-                m_optgroup->set_value("print_host", std::move(dialog.get_selected()), true);
+                m_optgroup->set_value("print_host", dialog.get_selected(), true);
                 m_optgroup->get_field("print_host")->field_changed();
             }
         });
@@ -366,7 +366,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
                 static const auto filemasks = _L("Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*");
                 wxFileDialog openFileDialog(this, _L("Open CA certificate file"), "", "", filemasks, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
                 if (openFileDialog.ShowModal() != wxID_CANCEL) {
-                    m_optgroup->set_value("printhost_cafile", std::move(openFileDialog.GetPath()), true);
+                    m_optgroup->set_value("printhost_cafile", openFileDialog.GetPath(), true);
                     m_optgroup->get_field("printhost_cafile")->field_changed();
                 }
                 });

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2054,7 +2054,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     view3D_canvas->Bind(EVT_GLCANVAS_UPDATE_BED_SHAPE, [q](SimpleEvent&) { q->set_bed_shape(); });
 
     // Preview events:
-    preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_QUESTION_MARK, [this](SimpleEvent&) { wxGetApp().keyboard_shortcuts(); });
+    preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_QUESTION_MARK, [](SimpleEvent&) { wxGetApp().keyboard_shortcuts(); });
     preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_UPDATE_BED_SHAPE, [q](SimpleEvent&) { q->set_bed_shape(); });
     if (wxGetApp().is_editor()) {
         preview->get_wxglcanvas()->Bind(EVT_GLCANVAS_TAB, [this](SimpleEvent&) { select_next_view_3D(); });
@@ -2116,8 +2116,8 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     if (wxGetApp().is_editor()) {
         this->q->Bind(EVT_EJECT_DRIVE_NOTIFICAION_CLICKED, [this](EjectDriveNotificationClickedEvent&) { this->q->eject_drive(); });
         this->q->Bind(EVT_EXPORT_GCODE_NOTIFICAION_CLICKED, [this](ExportGcodeNotificationClickedEvent&) { this->q->export_gcode(true); });
-        this->q->Bind(EVT_PRESET_UPDATE_AVAILABLE_CLICKED, [this](PresetUpdateAvailableClickedEvent&) {  wxGetApp().get_preset_updater()->on_update_notification_confirm(); });
-	    this->q->Bind(EVT_REMOVABLE_DRIVE_EJECTED, [this, q](RemovableDriveEjectEvent &evt) {
+        this->q->Bind(EVT_PRESET_UPDATE_AVAILABLE_CLICKED, [](PresetUpdateAvailableClickedEvent&) {  wxGetApp().get_preset_updater()->on_update_notification_confirm(); });
+	    this->q->Bind(EVT_REMOVABLE_DRIVE_EJECTED, [this](RemovableDriveEjectEvent &evt) {
 		    if (evt.data.second) {
 			    this->show_action_buttons(this->ready_to_slice);
                 notification_manager->close_notification_of_type(NotificationType::ExportFinished);
@@ -2132,7 +2132,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                     );
             }
 	    });
-        this->q->Bind(EVT_REMOVABLE_DRIVES_CHANGED, [this, q](RemovableDrivesChangedEvent &) {
+        this->q->Bind(EVT_REMOVABLE_DRIVES_CHANGED, [this](RemovableDrivesChangedEvent &) {
 		    this->show_action_buttons(this->ready_to_slice); 
 		    // Close notification ExportingFinished but only if last export was to removable
 		    notification_manager->device_ejected();
@@ -4948,7 +4948,7 @@ ProjectDropDialog::ProjectDropDialog(const std::string& filename)
 
     wxBoxSizer* bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
     wxCheckBox* check = new wxCheckBox(this, wxID_ANY, _L("Don't show again"));
-    check->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent& evt) {
+    check->Bind(wxEVT_CHECKBOX, [](wxCommandEvent& evt) {
         wxGetApp().app_config->set("show_drop_project_dialog", evt.IsChecked() ? "0" : "1");
         });
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -274,7 +274,7 @@ public:
     wxButton*       get_wiping_dialog_button() { return m_wiping_dialog_button; }
     wxSizer*        get_sizer() override;
     ConfigOptionsGroup* get_og(const bool is_fff);
-    void            Show(const bool is_fff);
+    void            Show(const bool is_fff) override;
 
     void            msw_rescale();
 };

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -705,7 +705,7 @@ void PlaterPresetComboBox::show_add_menu()
     wxMenu* menu = new wxMenu();
 
     append_menu_item(menu, wxID_ANY, _L("Add/Remove presets"), "",
-        [this](wxCommandEvent&) { 
+        [](wxCommandEvent&) { 
             wxTheApp->CallAfter([]() { wxGetApp().run_wizard(ConfigWizard::RR_USER, ConfigWizard::SP_PRINTERS); });
         }, "edit_uni", menu, []() { return true; }, wxGetApp().plater());
 
@@ -735,7 +735,7 @@ void PlaterPresetComboBox::show_edit_menu()
     }
     else
         append_menu_item(menu, wxID_ANY, _L("Add/Remove presets"), "",
-            [this](wxCommandEvent&) {
+            [](wxCommandEvent&) {
                 wxTheApp->CallAfter([]() { wxGetApp().run_wizard(ConfigWizard::RR_USER, ConfigWizard::SP_PRINTERS); });
             }, "edit_uni", menu, []() { return true; }, wxGetApp().plater());
 

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -854,7 +854,7 @@ void PlaterPresetComboBox::update()
             const PhysicalPrinterCollection& ph_printers = m_preset_bundle->physical_printers;
 
             for (PhysicalPrinterCollection::ConstIterator it = ph_printers.begin(); it != ph_printers.end(); ++it) {
-                for (const std::string preset_name : it->get_preset_names()) {
+                for (const std::string &preset_name : it->get_preset_names()) {
                     Preset* preset = m_collection->find_preset(preset_name);
                     if (!preset)
                         continue;
@@ -1026,7 +1026,7 @@ void TabPresetComboBox::update()
             const PhysicalPrinterCollection& ph_printers = m_preset_bundle->physical_printers;
 
             for (PhysicalPrinterCollection::ConstIterator it = ph_printers.begin(); it != ph_printers.end(); ++it) {
-                for (const std::string preset_name : it->get_preset_names()) {
+                for (const std::string &preset_name : it->get_preset_names()) {
                     Preset* preset = m_collection->find_preset(preset_name);
                     if (!preset)
                         continue;

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -203,6 +203,8 @@ namespace search_for_drives_internal
 		}
 	}
 
+#if __APPLE__
+#else
 	static void search_path(const std::string &path, const std::string &parent_path, std::vector<DriveData> &out)
 	{
 	    glob_t globbuf;
@@ -217,6 +219,7 @@ namespace search_for_drives_internal
 		}
 		globfree(&globbuf);
 	}
+#endif
 }
 
 std::vector<DriveData> RemovableDriveManager::search_for_removable_drives() const

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -121,7 +121,7 @@ Tab::Tab(wxNotebook* parent, const wxString& title, Preset::Type type) :
 
     m_config_manipulation = get_config_manipulation();
 
-    Bind(wxEVT_SIZE, ([this](wxSizeEvent &evt) {
+    Bind(wxEVT_SIZE, ([](wxSizeEvent &evt) {
         //for (auto page : m_pages)
         //    if (! page.get()->IsShown())
         //        page->layout_valid = false;
@@ -240,7 +240,7 @@ void Tab::create_preset_tab()
         if (dlg.ShowModal() == wxID_OK)
             wxGetApp().update_label_colours();
     });
-    m_search_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent) { wxGetApp().plater()->search(false); });
+    m_search_btn->Bind(wxEVT_BUTTON, [](wxCommandEvent) { wxGetApp().plater()->search(false); });
 
     // Colors for ui "decoration"
     m_sys_label_clr			= wxGetApp().get_label_clr_sys();
@@ -1719,7 +1719,7 @@ void TabFilament::add_filament_overrides_page()
         line.near_label_widget = [this, optgroup, opt_key, opt_index](wxWindow* parent) {
             wxCheckBox* check_box = new wxCheckBox(parent, wxID_ANY, "");
 
-            check_box->Bind(wxEVT_CHECKBOX, [this, optgroup, opt_key, opt_index](wxCommandEvent& evt) {
+            check_box->Bind(wxEVT_CHECKBOX, [optgroup, opt_key, opt_index](wxCommandEvent& evt) {
                 const bool is_checked = evt.IsChecked();
                 Field* field = optgroup->get_fieldc(opt_key, opt_index);
                 if (field != nullptr) {
@@ -3896,7 +3896,7 @@ ConfigOptionsGroupShp Page::new_optgroup(const wxString& title, int noncommon_la
 #else
     auto tab = parent()->GetParent();// GetParent();
 #endif
-    optgroup->m_on_change = [this, tab](t_config_option_key opt_key, boost::any value) {
+    optgroup->m_on_change = [tab](t_config_option_key opt_key, boost::any value) {
         //! This function will be called from OptionGroup.
         //! Using of CallAfter is redundant.
         //! And in some cases it causes update() function to be recalled again
@@ -3906,21 +3906,21 @@ ConfigOptionsGroupShp Page::new_optgroup(const wxString& title, int noncommon_la
 //!        });
     };
 
-    optgroup->m_get_initial_config = [this, tab]() {
+    optgroup->m_get_initial_config = [tab]() {
         DynamicPrintConfig config = static_cast<Tab*>(tab)->m_presets->get_selected_preset().config;
         return config;
     };
 
-    optgroup->m_get_sys_config = [this, tab]() {
+    optgroup->m_get_sys_config = [tab]() {
         DynamicPrintConfig config = static_cast<Tab*>(tab)->m_presets->get_selected_preset_parent()->config;
         return config;
     };
 
-    optgroup->have_sys_config = [this, tab]() {
+    optgroup->have_sys_config = [tab]() {
         return static_cast<Tab*>(tab)->m_presets->get_selected_preset_parent() != nullptr;
     };
 
-    optgroup->rescale_extra_column_item = [this](wxWindow* win) {
+    optgroup->rescale_extra_column_item = [](wxWindow* win) {
         auto *ctrl = dynamic_cast<wxStaticBitmap*>(win);
         if (ctrl == nullptr)
             return;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3330,13 +3330,14 @@ bool Tab::tree_sel_change_delayed()
     // clear pages from the controls
     m_active_page = page;
     
-    auto throw_if_canceled = std::function<void()>([this](){
+    std::function<void()> throw_if_canceled;
 #ifdef WIN32
+    throw_if_canceled = std::function<void()>([this](){
             wxCheckForInterrupt(m_treectrl);
             if (m_page_switch_planned)
                 throw UIBuildCanceled();
-#endif // WIN32
         });
+#endif // WIN32
 
     try {
         clear_pages();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -485,7 +485,7 @@ void Tab::update_label_colours()
     m_modified_label_clr = wxGetApp().get_label_clr_modified();
 
     //update options "decoration"
-    for (const auto opt : m_options_list)
+    for (const auto &opt : m_options_list)
     {
         const wxColour *color = &m_sys_label_clr;
 
@@ -535,7 +535,7 @@ void Tab::update_label_colours()
 
 void Tab::decorate()
 {
-    for (const auto opt : m_options_list)
+    for (const auto &opt : m_options_list)
     {
         Field*      field = nullptr;
         wxColour*   colored_label_clr = nullptr;
@@ -633,7 +633,7 @@ void Tab::init_options_list()
     if (!m_options_list.empty())
         m_options_list.clear();
 
-    for (const auto opt_key : m_config->keys())
+    for (const auto &opt_key : m_config->keys())
         m_options_list.emplace(opt_key, m_opt_status_value);
 }
 
@@ -650,7 +650,7 @@ void TabPrinter::init_options_list()
     if (!m_options_list.empty())
         m_options_list.clear();
 
-    for (const auto opt_key : m_config->keys())
+    for (const auto &opt_key : m_config->keys())
     {
         if (opt_key == "bed_shape" || opt_key == "thumbnails") {
             m_options_list.emplace(opt_key, m_opt_status_value);
@@ -702,7 +702,7 @@ void TabSLAMaterial::init_options_list()
     if (!m_options_list.empty())
         m_options_list.clear();
 
-    for (const auto opt_key : m_config->keys())
+    for (const auto &opt_key : m_config->keys())
     {
         if (opt_key == "compatible_prints" || opt_key == "compatible_printers") {
             m_options_list.emplace(opt_key, m_opt_status_value);

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -381,7 +381,6 @@ public:
 private:
 	ogStaticText*	m_recommended_thin_wall_thickness_description_line = nullptr;
 	ogStaticText*	m_top_bottom_shell_thickness_explanation = nullptr;
-	bool			m_support_material_overhangs_queried = false;
 };
 
 class TabFilament : public Tab

--- a/src/slic3r/Utils/Bonjour.cpp
+++ b/src/slic3r/Utils/Bonjour.cpp
@@ -226,10 +226,10 @@ struct DnsResource
 		}
 
 		dataoffset = offset;
-		res.data = std::move(std::vector<char>(buffer.begin() + offset, buffer.begin() + offset + rdlength));
+		res.data = std::vector<char>(buffer.begin() + offset, buffer.begin() + offset + rdlength);
 		offset += rdlength;
 
-		return std::move(res);
+		return res;
 	}
 };
 

--- a/src/slic3r/Utils/FlashAir.cpp
+++ b/src/slic3r/Utils/FlashAir.cpp
@@ -50,7 +50,7 @@ bool FlashAir::test(wxString &msg) const
 			res = false;
 			msg = format_error(body, error, status);
 		})
-		.on_complete([&, this](std::string body, unsigned) {
+		.on_complete([&](std::string body, unsigned) {
 			BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got upload enabled: %2%") % name % body;
 
 			res = boost::starts_with(body, "1");

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -553,7 +553,7 @@ void Http::cancel()
 
 Http Http::get(std::string url)
 {
-	return std::move(Http{std::move(url)});
+	return Http{std::move(url)};
 }
 
 Http Http::post(std::string url)

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -20,7 +20,7 @@ public:
     OctoPrint(DynamicPrintConfig *config);
     ~OctoPrint() override = default;
 
-    const char* get_name() const;
+    const char* get_name() const override;
 
     bool test(wxString &curl_msg) const override;
     wxString get_test_ok_msg () const override;

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -406,7 +406,7 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
 	BOOST_LOG_TRIVIAL(info) << "Checking for cached configuration updates...";
 
 	// Over all indices from the cache directory:
-	for (const auto idx : index_db) {
+	for (const auto &idx : index_db) {
 		auto bundle_path = vendor_path / (idx.vendor() + ".ini");
 		auto bundle_path_idx = vendor_path / idx.path().filename();
 

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -679,11 +679,11 @@ void PresetUpdater::sync(PresetBundle *preset_bundle)
 	// into the closure (but perhaps the compiler can elide this).
 	VendorMap vendors = preset_bundle->vendors;
 
-	p->thread = std::move(std::thread([this, vendors]() {
+	p->thread = std::thread([this, vendors]() {
 		this->p->prune_tmps();
 		this->p->sync_version();
 		this->p->sync_config(std::move(vendors));
-	}));
+	});
 }
 
 void PresetUpdater::slic3r_update_notify()

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -206,7 +206,7 @@ bool PresetUpdater::priv::get_file(const std::string &url, const fs::path &targe
 		tmp_path.string());
 
 	Http::get(url)
-		.on_progress([this](Http::Progress, bool &cancel) {
+		.on_progress([](Http::Progress, bool &cancel) {
 			if (cancel) { cancel = true; }
 		})
 		.on_error([&](std::string body, std::string error, unsigned http_status) {

--- a/src/slic3r/Utils/Repetier.cpp
+++ b/src/slic3r/Utils/Repetier.cpp
@@ -190,7 +190,7 @@ bool Repetier::get_groups(wxArrayString& groups) const
     http.on_error([&](std::string body, std::string error, unsigned status) {
             BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error getting version: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
         })
-        .on_complete([&, this](std::string body, unsigned) {
+        .on_complete([&](std::string body, unsigned) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got groups: %2%") % name % body;
 
             try {
@@ -233,7 +233,7 @@ bool Repetier::get_printers(wxArrayString& printers) const
             BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Error listing printers: %2%, HTTP %3%, body: `%4%`") % name % error % status % body;
             res = false;
         })
-        .on_complete([&, this](std::string body, unsigned http_status) {
+        .on_complete([&](std::string body, unsigned http_status) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: Got printers: %2%, HTTP status: %3%") % name % body % http_status;
             
             if (http_status != 200)

--- a/src/slic3r/Utils/Repetier.hpp
+++ b/src/slic3r/Utils/Repetier.hpp
@@ -19,7 +19,7 @@ public:
     Repetier(DynamicPrintConfig *config);
     ~Repetier() override = default;
 
-    const char* get_name() const;
+    const char* get_name() const override;
 
     bool test(wxString &curl_msg) const override;
     wxString get_test_ok_msg () const override;

--- a/src/slic3r/Utils/UndoRedo.cpp
+++ b/src/slic3r/Utils/UndoRedo.cpp
@@ -209,7 +209,7 @@ public:
 	bool is_immutable() const override { return true; }
 	bool is_optional() const override { return m_optional; }
 	// If it is an immutable object, return its pointer. There is a map assigning a temporary ObjectID to the immutable object pointer.
-	const void* immutable_object_ptr() const { return (const void*)m_shared_object.get(); }
+	const void* immutable_object_ptr() const override { return (const void*)m_shared_object.get(); }
 
 	// Estimated size in memory, to be used to drop least recently used snapshots.
 	size_t memsize() const override {

--- a/src/stb_dxt/stb_dxt.h
+++ b/src/stb_dxt/stb_dxt.h
@@ -357,10 +357,10 @@ static void stb__OptimizeColorsBlock(unsigned char *block, unsigned short *pmax1
     int muv,minv,maxv;
 
 #ifdef NEW_OPTIMISATIONS
-#   define MIN(a,b)      (int)a + ( ((int)b-a) & ( ((int)b-a) >> 31 ) )
-#   define MAX(a,b)      (int)a + ( ((int)b-a) & ( ((int)a-b) >> 31 ) )
-#   define RANGE(a,b,n)  int min##n = MIN(a,b); int max##n = a+b - min##n; muv += a+b;
-#   define MINMAX(a,b,n) int min##n = MIN(min##a, min##b); int max##n = MAX(max##a, max##b); 
+#   define STB_MIN(a,b)      (int)a + ( ((int)b-a) & ( ((int)b-a) >> 31 ) )
+#   define STB_MAX(a,b)      (int)a + ( ((int)b-a) & ( ((int)a-b) >> 31 ) )
+#   define RANGE(a,b,n)  int min##n = STB_MIN(a,b); int max##n = a+b - min##n; muv += a+b;
+#   define MINMAX(a,b,n) int min##n = STB_MIN(min##a, min##b); int max##n = STB_MAX(max##a, max##b); 
 
 	muv = 0;
 	RANGE(bp[0],  bp[4],  1);
@@ -380,8 +380,8 @@ static void stb__OptimizeColorsBlock(unsigned char *block, unsigned short *pmax1
 	MINMAX(9,10,13);
 	MINMAX(11,12,14);
 
-	minv = MIN(min13,min14);
-	maxv = MAX(max13,max14);
+	minv = STB_MIN(min13,min14);
+	maxv = STB_MAX(max13,max14);
 
 #else
 	muv = minv = maxv = bp[0];

--- a/src/stb_dxt/stb_dxt.h
+++ b/src/stb_dxt/stb_dxt.h
@@ -979,6 +979,7 @@ void rygCompressYCoCg( unsigned char *dst, unsigned char *src, int w, int h )
 
 }
 
+/*
 static void stbgl__compress(unsigned char *p, unsigned char *rgba, int w, int h, int isDxt5)
 {
    int i,j,y,y2;
@@ -1021,6 +1022,7 @@ static void stbgl__compress(unsigned char *p, unsigned char *rgba, int w, int h,
    }
   // assert(p <= end);
 }
+*/
 
 static inline unsigned char linearize(unsigned char inByte)
 {

--- a/tests/fff_print/test_skirt_brim.cpp
+++ b/tests/fff_print/test_skirt_brim.cpp
@@ -11,6 +11,7 @@
 using namespace Slic3r::Test;
 using namespace Slic3r;
 
+/*
 /// Helper method to find the tool used for the brim (always the first extrusion)
 static int get_brim_tool(const std::string &gcode)
 {
@@ -28,6 +29,7 @@ static int get_brim_tool(const std::string &gcode)
     });
     return brim_tool;
 }
+*/
 
 TEST_CASE("Skirt height is honored", "[Skirt]") {
     DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();

--- a/tests/libslic3r/test_voronoi.cpp
+++ b/tests/libslic3r/test_voronoi.cpp
@@ -176,13 +176,13 @@ TEST_CASE("Voronoi missing edges - Alessandro gapfill 12707", "[Voronoi]")
 
     std::mt19937 gen;
     std::uniform_int_distribution<coord_t> dist(-100, 100);
-    for (Point &p : poly.points) {
 #if 0
+    for (Point &p : poly.points) {
       // Wiggle the points a bit to find out whether this fixes the voronoi diagram for this particular polygon.
       p.x() = (p.x() += dist(gen));
       p.y() = (p.y() += dist(gen));
-#endif
     }
+#endif
 
     REQUIRE(intersecting_edges({ poly }).empty());
 
@@ -267,7 +267,6 @@ TEST_CASE("Voronoi weirdness", "[Voronoi]")
     };
 
 //    coord_t shift = 35058881;
-    coord_t shift_ok = 17000000;
     coord_t shift = 35058881;
     Polygon poly {
         // <-4, 0>: bug


### PR DESCRIPTION
This branch contains a few fixes which mostly correct compiler warnings. As I have seen today another batch of similar commits let's fast create the pull request, maybe it can avoid duplicate work.

I used clang++ 12.0.0 for my work and the remaining warnings are dubious and have to be checked.

Example (not included):

src/libslic3r/TriangleSelector.cpp:422
if (! m_orig_size_indices != 0) // unless this is run from constructor
should be probably negated to
if (m_orig_size_indices != 0) // unless this is run from constructor
