### PR TITLE
creality.ini: Creality CR-6 SE improvements

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -73,8 +73,8 @@ default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @
 #variants = 0.4
 #technology = FFF
 #family = CR
-#bed_model = ender3_bed.stl
-#bed_texture = cr20.svg
+#bed_model = cr6se_bed.stl
+#bed_texture = cr6se.svg
 #default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA (Galaxy) @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 123-3D Jupiter PLA @CREALITY
 
 [printer_model:CR10MINI]
@@ -769,6 +769,7 @@ max_print_height = 200
 
 #[printer:Creality CR-6 SE]
 #inherits = Creality Ender-3; *fastabl*
+#bed_shape = 5x0,230x0,230x235,5x235
 #printer_model = CR6SE
 #printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR6SE\nPRINTER_HAS_BOWDEN
 

--- a/resources/profiles/Creality/cr6se.svg
+++ b/resources/profiles/Creality/cr6se.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="225mm" height="235mm" version="1.1" viewBox="0 0 225 235" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".25" y=".25" width="224.5" height="234.5" fill="none" stroke="#fff" stroke-width=".5"/>
+</svg>

--- a/resources/profiles/Creality/cr6se_bed.stl
+++ b/resources/profiles/Creality/cr6se_bed.stl
@@ -1,0 +1,2774 @@
+solid OpenSCAD_Model
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.605 -127.498 -3
+      vertex 119.502 -127.498 -3
+      vertex 119.814 -127.484 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 119.814 -127.484 -3
+      vertex 119.502 -127.498 -3
+      vertex 120.021 -127.454 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex 119.502 127.498 -3
+      vertex -122.5 124.5 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 120.021 -127.454 -3
+      vertex 119.502 -127.498 -3
+      vertex 120.226 -127.411 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 120.226 -127.411 -3
+      vertex 119.502 -127.498 -3
+      vertex 120.427 -127.353 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 120.427 -127.353 -3
+      vertex 119.502 -127.498 -3
+      vertex 120.624 -127.282 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 120.624 -127.282 -3
+      vertex 119.502 -127.498 -3
+      vertex 120.815 -127.196 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 120.815 -127.196 -3
+      vertex 119.502 -127.498 -3
+      vertex 121 -127.098 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121 -127.098 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.178 -126.987 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.178 -126.987 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.347 -126.864 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.347 -126.864 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.507 -126.729 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.507 -126.729 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.658 -126.584 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.658 -126.584 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.798 -126.428 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.798 -126.428 -3
+      vertex 119.502 -127.498 -3
+      vertex 121.927 -126.263 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 121.927 -126.263 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.044 -126.09 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.044 -126.09 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.149 -125.908 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.149 -125.908 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.241 -125.72 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.241 -125.72 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.319 -125.526 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.319 -125.526 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.384 -125.327 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.384 -125.327 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.434 -125.124 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.434 -125.124 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.471 -124.918 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.471 -124.918 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.493 -124.709 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 122.493 -124.709 -3
+      vertex 119.502 -127.498 -3
+      vertex 122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 119.5 127.5 -3
+      vertex 119.502 127.498 -3
+      vertex -119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 122.471 124.918 -3
+      vertex 122.493 124.709 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 122.384 125.327 -3
+      vertex 122.434 125.124 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 122.241 125.72 -3
+      vertex 119.502 127.498 -3
+      vertex 122.149 125.908 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 122.241 125.72 -3
+      vertex 122.319 125.526 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 121.507 126.729 -3
+      vertex 121.658 126.584 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121.927 126.263 -3
+      vertex 119.502 127.498 -3
+      vertex 121.798 126.428 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 121.927 126.263 -3
+      vertex 122.044 126.09 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121.798 126.428 -3
+      vertex 119.502 127.498 -3
+      vertex 121.658 126.584 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 120.427 127.353 -3
+      vertex 120.624 127.282 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121.347 126.864 -3
+      vertex 119.502 127.498 -3
+      vertex 121.178 126.987 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 121.347 126.864 -3
+      vertex 121.507 126.729 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121.178 126.987 -3
+      vertex 119.502 127.498 -3
+      vertex 121 127.098 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121 127.098 -3
+      vertex 119.502 127.498 -3
+      vertex 120.815 127.196 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 120.815 127.196 -3
+      vertex 119.502 127.498 -3
+      vertex 120.624 127.282 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 122.149 125.908 -3
+      vertex 119.502 127.498 -3
+      vertex 122.044 126.09 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 120.226 127.411 -3
+      vertex 119.502 127.498 -3
+      vertex 120.021 127.454 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 120.226 127.411 -3
+      vertex 120.427 127.353 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 122.319 125.526 -3
+      vertex 122.384 125.327 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 119.814 127.484 -3
+      vertex 120.021 127.454 -3
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 122.434 125.124 -3
+      vertex 122.471 124.918 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 119.605 127.498 -3
+      vertex 119.814 127.484 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 122.5 124.5 -3
+      vertex 119.502 127.498 -3
+      vertex 122.493 124.709 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -119.5 127.5 -3
+      vertex 119.5 127.5 -3
+      vertex -119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 122.5 124.5 -3
+      vertex -122.5 124.5 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -122.493 124.709 -3
+      vertex -119.502 127.498 -3
+      vertex -122.5 124.5 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.5 124.5 -3
+      vertex 122.5 124.5 -3
+      vertex 122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -119.814 127.484 -3
+      vertex -119.605 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -120.021 127.454 -3
+      vertex -119.814 127.484 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -120.226 127.411 -3
+      vertex -120.021 127.454 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -120.427 127.353 -3
+      vertex -120.226 127.411 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -120.624 127.282 -3
+      vertex -120.427 127.353 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -120.815 127.196 -3
+      vertex -120.624 127.282 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121 127.098 -3
+      vertex -120.815 127.196 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.178 126.987 -3
+      vertex -121 127.098 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.347 126.864 -3
+      vertex -121.178 126.987 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.507 126.729 -3
+      vertex -121.347 126.864 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.658 126.584 -3
+      vertex -121.507 126.729 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.798 126.428 -3
+      vertex -121.658 126.584 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -121.927 126.263 -3
+      vertex -121.798 126.428 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.044 126.09 -3
+      vertex -121.927 126.263 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.149 125.908 -3
+      vertex -122.044 126.09 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.241 125.72 -3
+      vertex -122.149 125.908 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.319 125.526 -3
+      vertex -122.241 125.72 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.384 125.327 -3
+      vertex -122.319 125.526 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.434 125.124 -3
+      vertex -122.384 125.327 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.471 124.918 -3
+      vertex -122.434 125.124 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -122.493 124.709 -3
+      vertex -122.471 124.918 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.5 -124.5 -3
+      vertex -122.5 124.5 -3
+      vertex 122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 -127.498 -3
+      vertex -122.5 -124.5 -3
+      vertex 122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.502 -127.498 -3
+      vertex -119.502 -127.498 -3
+      vertex -122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -122.471 -124.918 -3
+      vertex -122.493 -124.709 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.384 -125.327 -3
+      vertex -122.434 -125.124 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.241 -125.72 -3
+      vertex -119.502 -127.498 -3
+      vertex -122.149 -125.908 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.241 -125.72 -3
+      vertex -122.319 -125.526 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -121.507 -126.729 -3
+      vertex -121.658 -126.584 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.927 -126.263 -3
+      vertex -119.502 -127.498 -3
+      vertex -121.798 -126.428 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.927 -126.263 -3
+      vertex -122.044 -126.09 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.798 -126.428 -3
+      vertex -119.502 -127.498 -3
+      vertex -121.658 -126.584 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -120.427 -127.353 -3
+      vertex -120.624 -127.282 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.347 -126.864 -3
+      vertex -119.502 -127.498 -3
+      vertex -121.178 -126.987 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.347 -126.864 -3
+      vertex -121.507 -126.729 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.178 -126.987 -3
+      vertex -119.502 -127.498 -3
+      vertex -121 -127.098 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121 -127.098 -3
+      vertex -119.502 -127.498 -3
+      vertex -120.815 -127.196 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -120.815 -127.196 -3
+      vertex -119.502 -127.498 -3
+      vertex -120.624 -127.282 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.149 -125.908 -3
+      vertex -119.502 -127.498 -3
+      vertex -122.044 -126.09 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -120.226 -127.411 -3
+      vertex -119.502 -127.498 -3
+      vertex -120.021 -127.454 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -120.226 -127.411 -3
+      vertex -120.427 -127.353 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.319 -125.526 -3
+      vertex -122.384 -125.327 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.814 -127.484 -3
+      vertex -120.021 -127.454 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -122.434 -125.124 -3
+      vertex -122.471 -124.918 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -119.605 -127.498 -3
+      vertex -119.814 -127.484 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 119.502 -127.498 -3
+      vertex 119.5 -127.5 -3
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex 119.5 -127.5 -3
+      vertex -119.5 -127.5 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.5 -124.5 -3
+      vertex -119.502 -127.498 -3
+      vertex -122.493 -124.709 -3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.814 -127.484 0
+      vertex 119.502 -127.498 0
+      vertex 119.605 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.021 -127.454 0
+      vertex 119.502 -127.498 0
+      vertex 119.814 -127.484 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.5 124.5 0
+      vertex 119.502 127.498 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.226 -127.411 0
+      vertex 119.502 -127.498 0
+      vertex 120.021 -127.454 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.427 -127.353 0
+      vertex 119.502 -127.498 0
+      vertex 120.226 -127.411 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.624 -127.282 0
+      vertex 119.502 -127.498 0
+      vertex 120.427 -127.353 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.815 -127.196 0
+      vertex 119.502 -127.498 0
+      vertex 120.624 -127.282 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121 -127.098 0
+      vertex 119.502 -127.498 0
+      vertex 120.815 -127.196 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.178 -126.987 0
+      vertex 119.502 -127.498 0
+      vertex 121 -127.098 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.347 -126.864 0
+      vertex 119.502 -127.498 0
+      vertex 121.178 -126.987 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.507 -126.729 0
+      vertex 119.502 -127.498 0
+      vertex 121.347 -126.864 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.658 -126.584 0
+      vertex 119.502 -127.498 0
+      vertex 121.507 -126.729 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.798 -126.428 0
+      vertex 119.502 -127.498 0
+      vertex 121.658 -126.584 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.927 -126.263 0
+      vertex 119.502 -127.498 0
+      vertex 121.798 -126.428 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.044 -126.09 0
+      vertex 119.502 -127.498 0
+      vertex 121.927 -126.263 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.149 -125.908 0
+      vertex 119.502 -127.498 0
+      vertex 122.044 -126.09 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.241 -125.72 0
+      vertex 119.502 -127.498 0
+      vertex 122.149 -125.908 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.319 -125.526 0
+      vertex 119.502 -127.498 0
+      vertex 122.241 -125.72 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.384 -125.327 0
+      vertex 119.502 -127.498 0
+      vertex 122.319 -125.526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.434 -125.124 0
+      vertex 119.502 -127.498 0
+      vertex 122.384 -125.327 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.471 -124.918 0
+      vertex 119.502 -127.498 0
+      vertex 122.434 -125.124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.493 -124.709 0
+      vertex 119.502 -127.498 0
+      vertex 122.471 -124.918 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.5 -124.5 0
+      vertex 119.502 -127.498 0
+      vertex 122.493 -124.709 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 127.498 0
+      vertex 119.502 127.498 0
+      vertex 119.5 127.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.493 124.709 0
+      vertex 122.471 124.918 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 122.434 125.124 0
+      vertex 122.384 125.327 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.149 125.908 0
+      vertex 119.502 127.498 0
+      vertex 122.241 125.72 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 122.319 125.526 0
+      vertex 122.241 125.72 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.658 126.584 0
+      vertex 121.507 126.729 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.798 126.428 0
+      vertex 119.502 127.498 0
+      vertex 121.927 126.263 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 122.044 126.09 0
+      vertex 121.927 126.263 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.658 126.584 0
+      vertex 119.502 127.498 0
+      vertex 121.798 126.428 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.624 127.282 0
+      vertex 120.427 127.353 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.178 126.987 0
+      vertex 119.502 127.498 0
+      vertex 121.347 126.864 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 121.507 126.729 0
+      vertex 121.347 126.864 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121 127.098 0
+      vertex 119.502 127.498 0
+      vertex 121.178 126.987 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.815 127.196 0
+      vertex 119.502 127.498 0
+      vertex 121 127.098 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.624 127.282 0
+      vertex 119.502 127.498 0
+      vertex 120.815 127.196 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.044 126.09 0
+      vertex 119.502 127.498 0
+      vertex 122.149 125.908 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 120.021 127.454 0
+      vertex 119.502 127.498 0
+      vertex 120.226 127.411 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 120.427 127.353 0
+      vertex 120.226 127.411 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 122.384 125.327 0
+      vertex 122.319 125.526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.502 127.498 0
+      vertex 120.021 127.454 0
+      vertex 119.814 127.484 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.471 124.918 0
+      vertex 122.434 125.124 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.814 127.484 0
+      vertex 119.605 127.498 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.493 124.709 0
+      vertex 119.502 127.498 0
+      vertex 122.5 124.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 127.498 0
+      vertex 119.5 127.5 0
+      vertex -119.5 127.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.5 124.5 0
+      vertex 122.5 124.5 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.5 124.5 0
+      vertex -119.502 127.498 0
+      vertex -122.493 124.709 0
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 122.5 -124.5 0
+      vertex 122.5 124.5 0
+      vertex -122.5 124.5 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -119.605 127.498 0
+      vertex -119.814 127.484 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -119.814 127.484 0
+      vertex -120.021 127.454 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.021 127.454 0
+      vertex -120.226 127.411 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.226 127.411 0
+      vertex -120.427 127.353 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.427 127.353 0
+      vertex -120.624 127.282 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.624 127.282 0
+      vertex -120.815 127.196 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.815 127.196 0
+      vertex -121 127.098 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121 127.098 0
+      vertex -121.178 126.987 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.178 126.987 0
+      vertex -121.347 126.864 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.347 126.864 0
+      vertex -121.507 126.729 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.507 126.729 0
+      vertex -121.658 126.584 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.658 126.584 0
+      vertex -121.798 126.428 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.798 126.428 0
+      vertex -121.927 126.263 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -121.927 126.263 0
+      vertex -122.044 126.09 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.044 126.09 0
+      vertex -122.149 125.908 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.149 125.908 0
+      vertex -122.241 125.72 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.241 125.72 0
+      vertex -122.319 125.526 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.319 125.526 0
+      vertex -122.384 125.327 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.384 125.327 0
+      vertex -122.434 125.124 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.434 125.124 0
+      vertex -122.471 124.918 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.471 124.918 0
+      vertex -122.493 124.709 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.5 -124.5 0
+      vertex -122.5 124.5 0
+      vertex -122.5 -124.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 122.5 -124.5 0
+      vertex -122.5 -124.5 0
+      vertex 119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.5 -124.5 0
+      vertex -119.502 -127.498 0
+      vertex 119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.493 -124.709 0
+      vertex -122.471 -124.918 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -122.434 -125.124 0
+      vertex -122.384 -125.327 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -122.149 -125.908 0
+      vertex -119.502 -127.498 0
+      vertex -122.241 -125.72 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -122.319 -125.526 0
+      vertex -122.241 -125.72 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -121.658 -126.584 0
+      vertex -121.507 -126.729 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -121.798 -126.428 0
+      vertex -119.502 -127.498 0
+      vertex -121.927 -126.263 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -122.044 -126.09 0
+      vertex -121.927 -126.263 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -121.658 -126.584 0
+      vertex -119.502 -127.498 0
+      vertex -121.798 -126.428 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -120.624 -127.282 0
+      vertex -120.427 -127.353 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -121.178 -126.987 0
+      vertex -119.502 -127.498 0
+      vertex -121.347 -126.864 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -121.507 -126.729 0
+      vertex -121.347 -126.864 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -121 -127.098 0
+      vertex -119.502 -127.498 0
+      vertex -121.178 -126.987 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -120.815 -127.196 0
+      vertex -119.502 -127.498 0
+      vertex -121 -127.098 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -120.624 -127.282 0
+      vertex -119.502 -127.498 0
+      vertex -120.815 -127.196 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -122.044 -126.09 0
+      vertex -119.502 -127.498 0
+      vertex -122.149 -125.908 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -120.021 -127.454 0
+      vertex -119.502 -127.498 0
+      vertex -120.226 -127.411 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -120.427 -127.353 0
+      vertex -120.226 -127.411 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -122.384 -125.327 0
+      vertex -122.319 -125.526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex -120.021 -127.454 0
+      vertex -119.814 -127.484 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.471 -124.918 0
+      vertex -122.434 -125.124 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.814 -127.484 0
+      vertex -119.605 -127.498 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -119.502 -127.498 0
+      vertex 119.5 -127.5 0
+      vertex 119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -119.5 -127.5 0
+      vertex 119.5 -127.5 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -122.493 -124.709 0
+      vertex -119.502 -127.498 0
+      vertex -122.5 -124.5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 119.605 -127.498 -3
+      vertex 119.502 -127.498 0
+      vertex 119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 119.605 -127.498 -3
+      vertex 119.605 -127.498 0
+      vertex 119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 119.814 -127.484 -3
+      vertex 119.605 -127.498 0
+      vertex 119.605 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 119.814 -127.484 -3
+      vertex 119.814 -127.484 0
+      vertex 119.605 -127.498 0
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 120.021 -127.454 -3
+      vertex 119.814 -127.484 0
+      vertex 119.814 -127.484 -3
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 120.021 -127.454 -3
+      vertex 120.021 -127.454 0
+      vertex 119.814 -127.484 0
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 120.226 -127.411 -3
+      vertex 120.021 -127.454 0
+      vertex 120.021 -127.454 -3
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 120.226 -127.411 -3
+      vertex 120.226 -127.411 0
+      vertex 120.021 -127.454 0
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 120.427 -127.353 -3
+      vertex 120.226 -127.411 0
+      vertex 120.226 -127.411 -3
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 120.427 -127.353 -3
+      vertex 120.427 -127.353 0
+      vertex 120.226 -127.411 0
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 120.624 -127.282 -3
+      vertex 120.427 -127.353 0
+      vertex 120.427 -127.353 -3
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 120.624 -127.282 -3
+      vertex 120.624 -127.282 0
+      vertex 120.427 -127.353 0
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 120.815 -127.196 -3
+      vertex 120.624 -127.282 0
+      vertex 120.624 -127.282 -3
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 120.815 -127.196 -3
+      vertex 120.815 -127.196 0
+      vertex 120.624 -127.282 0
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 121 -127.098 -3
+      vertex 120.815 -127.196 0
+      vertex 120.815 -127.196 -3
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 121 -127.098 -3
+      vertex 121 -127.098 0
+      vertex 120.815 -127.196 0
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 121.178 -126.987 -3
+      vertex 121 -127.098 0
+      vertex 121 -127.098 -3
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 121.178 -126.987 -3
+      vertex 121.178 -126.987 0
+      vertex 121 -127.098 0
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 121.347 -126.864 -3
+      vertex 121.178 -126.987 0
+      vertex 121.178 -126.987 -3
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 121.347 -126.864 -3
+      vertex 121.347 -126.864 0
+      vertex 121.178 -126.987 0
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 121.507 -126.729 -3
+      vertex 121.347 -126.864 0
+      vertex 121.347 -126.864 -3
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 121.507 -126.729 -3
+      vertex 121.507 -126.729 0
+      vertex 121.347 -126.864 0
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 121.658 -126.584 -3
+      vertex 121.507 -126.729 0
+      vertex 121.507 -126.729 -3
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 121.658 -126.584 -3
+      vertex 121.658 -126.584 0
+      vertex 121.507 -126.729 0
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 121.798 -126.428 -3
+      vertex 121.658 -126.584 0
+      vertex 121.658 -126.584 -3
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 121.798 -126.428 -3
+      vertex 121.798 -126.428 0
+      vertex 121.658 -126.584 0
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 121.927 -126.263 -3
+      vertex 121.798 -126.428 0
+      vertex 121.798 -126.428 -3
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 121.927 -126.263 -3
+      vertex 121.927 -126.263 0
+      vertex 121.798 -126.428 0
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 122.044 -126.09 -3
+      vertex 121.927 -126.263 0
+      vertex 121.927 -126.263 -3
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 122.044 -126.09 -3
+      vertex 122.044 -126.09 0
+      vertex 121.927 -126.263 0
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 122.149 -125.908 -3
+      vertex 122.044 -126.09 0
+      vertex 122.044 -126.09 -3
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 122.149 -125.908 -3
+      vertex 122.149 -125.908 0
+      vertex 122.044 -126.09 0
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 122.241 -125.72 -3
+      vertex 122.149 -125.908 0
+      vertex 122.149 -125.908 -3
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 122.241 -125.72 -3
+      vertex 122.241 -125.72 0
+      vertex 122.149 -125.908 0
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 122.319 -125.526 -3
+      vertex 122.241 -125.72 0
+      vertex 122.241 -125.72 -3
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 122.319 -125.526 -3
+      vertex 122.319 -125.526 0
+      vertex 122.241 -125.72 0
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 122.384 -125.327 -3
+      vertex 122.319 -125.526 0
+      vertex 122.319 -125.526 -3
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 122.384 -125.327 -3
+      vertex 122.384 -125.327 0
+      vertex 122.319 -125.526 0
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 122.434 -125.124 -3
+      vertex 122.384 -125.327 0
+      vertex 122.384 -125.327 -3
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 122.434 -125.124 -3
+      vertex 122.434 -125.124 0
+      vertex 122.384 -125.327 0
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 122.471 -124.918 -3
+      vertex 122.434 -125.124 0
+      vertex 122.434 -125.124 -3
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 122.471 -124.918 -3
+      vertex 122.471 -124.918 0
+      vertex 122.434 -125.124 0
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 122.493 -124.709 -3
+      vertex 122.471 -124.918 0
+      vertex 122.471 -124.918 -3
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 122.493 -124.709 -3
+      vertex 122.493 -124.709 0
+      vertex 122.471 -124.918 0
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 122.5 -124.5 -3
+      vertex 122.493 -124.709 0
+      vertex 122.493 -124.709 -3
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 122.5 -124.5 -3
+      vertex 122.5 -124.5 0
+      vertex 122.493 -124.709 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 122.5 124.5 -3
+      vertex 122.5 -124.5 0
+      vertex 122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal 1 0 -0
+    outer loop
+      vertex 122.5 124.5 -3
+      vertex 122.5 124.5 0
+      vertex 122.5 -124.5 0
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 0
+    outer loop
+      vertex 122.493 124.709 -3
+      vertex 122.5 124.5 0
+      vertex 122.5 124.5 -3
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 -0
+    outer loop
+      vertex 122.493 124.709 -3
+      vertex 122.493 124.709 0
+      vertex 122.5 124.5 0
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex 122.471 124.918 -3
+      vertex 122.493 124.709 0
+      vertex 122.493 124.709 -3
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 -0
+    outer loop
+      vertex 122.471 124.918 -3
+      vertex 122.471 124.918 0
+      vertex 122.493 124.709 0
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 0
+    outer loop
+      vertex 122.434 125.124 -3
+      vertex 122.471 124.918 0
+      vertex 122.471 124.918 -3
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 -0
+    outer loop
+      vertex 122.434 125.124 -3
+      vertex 122.434 125.124 0
+      vertex 122.471 124.918 0
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 0
+    outer loop
+      vertex 122.384 125.327 -3
+      vertex 122.434 125.124 0
+      vertex 122.434 125.124 -3
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 -0
+    outer loop
+      vertex 122.384 125.327 -3
+      vertex 122.384 125.327 0
+      vertex 122.434 125.124 0
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 0
+    outer loop
+      vertex 122.319 125.526 -3
+      vertex 122.384 125.327 0
+      vertex 122.384 125.327 -3
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 -0
+    outer loop
+      vertex 122.319 125.526 -3
+      vertex 122.319 125.526 0
+      vertex 122.384 125.327 0
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 0
+    outer loop
+      vertex 122.241 125.72 -3
+      vertex 122.319 125.526 0
+      vertex 122.319 125.526 -3
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 -0
+    outer loop
+      vertex 122.241 125.72 -3
+      vertex 122.241 125.72 0
+      vertex 122.319 125.526 0
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 0
+    outer loop
+      vertex 122.149 125.908 -3
+      vertex 122.241 125.72 0
+      vertex 122.241 125.72 -3
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 -0
+    outer loop
+      vertex 122.149 125.908 -3
+      vertex 122.149 125.908 0
+      vertex 122.241 125.72 0
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 0
+    outer loop
+      vertex 122.044 126.09 -3
+      vertex 122.149 125.908 0
+      vertex 122.149 125.908 -3
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 -0
+    outer loop
+      vertex 122.044 126.09 -3
+      vertex 122.044 126.09 0
+      vertex 122.149 125.908 0
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 0
+    outer loop
+      vertex 121.927 126.263 -3
+      vertex 122.044 126.09 0
+      vertex 122.044 126.09 -3
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 -0
+    outer loop
+      vertex 121.927 126.263 -3
+      vertex 121.927 126.263 0
+      vertex 122.044 126.09 0
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 0
+    outer loop
+      vertex 121.798 126.428 -3
+      vertex 121.927 126.263 0
+      vertex 121.927 126.263 -3
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 -0
+    outer loop
+      vertex 121.798 126.428 -3
+      vertex 121.798 126.428 0
+      vertex 121.927 126.263 0
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 0
+    outer loop
+      vertex 121.658 126.584 -3
+      vertex 121.798 126.428 0
+      vertex 121.798 126.428 -3
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 -0
+    outer loop
+      vertex 121.658 126.584 -3
+      vertex 121.658 126.584 0
+      vertex 121.798 126.428 0
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 0
+    outer loop
+      vertex 121.507 126.729 -3
+      vertex 121.658 126.584 0
+      vertex 121.658 126.584 -3
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 -0
+    outer loop
+      vertex 121.507 126.729 -3
+      vertex 121.507 126.729 0
+      vertex 121.658 126.584 0
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 0
+    outer loop
+      vertex 121.347 126.864 -3
+      vertex 121.507 126.729 0
+      vertex 121.507 126.729 -3
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 -0
+    outer loop
+      vertex 121.347 126.864 -3
+      vertex 121.347 126.864 0
+      vertex 121.507 126.729 0
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 0
+    outer loop
+      vertex 121.178 126.987 -3
+      vertex 121.347 126.864 0
+      vertex 121.347 126.864 -3
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 -0
+    outer loop
+      vertex 121.178 126.987 -3
+      vertex 121.178 126.987 0
+      vertex 121.347 126.864 0
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 0
+    outer loop
+      vertex 121 127.098 -3
+      vertex 121.178 126.987 0
+      vertex 121.178 126.987 -3
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 -0
+    outer loop
+      vertex 121 127.098 -3
+      vertex 121 127.098 0
+      vertex 121.178 126.987 0
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 0
+    outer loop
+      vertex 120.815 127.196 -3
+      vertex 121 127.098 0
+      vertex 121 127.098 -3
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 -0
+    outer loop
+      vertex 120.815 127.196 -3
+      vertex 120.815 127.196 0
+      vertex 121 127.098 0
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 0
+    outer loop
+      vertex 120.624 127.282 -3
+      vertex 120.815 127.196 0
+      vertex 120.815 127.196 -3
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 -0
+    outer loop
+      vertex 120.624 127.282 -3
+      vertex 120.624 127.282 0
+      vertex 120.815 127.196 0
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 0
+    outer loop
+      vertex 120.427 127.353 -3
+      vertex 120.624 127.282 0
+      vertex 120.624 127.282 -3
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 -0
+    outer loop
+      vertex 120.427 127.353 -3
+      vertex 120.427 127.353 0
+      vertex 120.624 127.282 0
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 0
+    outer loop
+      vertex 120.226 127.411 -3
+      vertex 120.427 127.353 0
+      vertex 120.427 127.353 -3
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 -0
+    outer loop
+      vertex 120.226 127.411 -3
+      vertex 120.226 127.411 0
+      vertex 120.427 127.353 0
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 0
+    outer loop
+      vertex 120.021 127.454 -3
+      vertex 120.226 127.411 0
+      vertex 120.226 127.411 -3
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 -0
+    outer loop
+      vertex 120.021 127.454 -3
+      vertex 120.021 127.454 0
+      vertex 120.226 127.411 0
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 0
+    outer loop
+      vertex 119.814 127.484 -3
+      vertex 120.021 127.454 0
+      vertex 120.021 127.454 -3
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 -0
+    outer loop
+      vertex 119.814 127.484 -3
+      vertex 119.814 127.484 0
+      vertex 120.021 127.454 0
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 0
+    outer loop
+      vertex 119.605 127.498 -3
+      vertex 119.814 127.484 0
+      vertex 119.814 127.484 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 -0
+    outer loop
+      vertex 119.605 127.498 -3
+      vertex 119.605 127.498 0
+      vertex 119.814 127.484 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 119.605 127.498 0
+      vertex 119.605 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 119.502 127.498 -3
+      vertex 119.502 127.498 0
+      vertex 119.605 127.498 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 119.5 127.5 -3
+      vertex 119.502 127.498 0
+      vertex 119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 -0
+    outer loop
+      vertex 119.5 127.5 -3
+      vertex 119.5 127.5 0
+      vertex 119.502 127.498 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -119.5 127.5 -3
+      vertex 119.5 127.5 0
+      vertex 119.5 127.5 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -119.5 127.5 -3
+      vertex -119.5 127.5 0
+      vertex 119.5 127.5 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -119.5 127.5 0
+      vertex -119.5 127.5 -3
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -119.502 127.498 -3
+      vertex -119.502 127.498 0
+      vertex -119.5 127.5 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -119.605 127.498 -3
+      vertex -119.502 127.498 0
+      vertex -119.502 127.498 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -119.605 127.498 -3
+      vertex -119.605 127.498 0
+      vertex -119.502 127.498 0
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -119.814 127.484 -3
+      vertex -119.605 127.498 0
+      vertex -119.605 127.498 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -119.814 127.484 -3
+      vertex -119.814 127.484 0
+      vertex -119.605 127.498 0
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -120.021 127.454 -3
+      vertex -119.814 127.484 0
+      vertex -119.814 127.484 -3
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -120.021 127.454 -3
+      vertex -120.021 127.454 0
+      vertex -119.814 127.484 0
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -120.226 127.411 -3
+      vertex -120.021 127.454 0
+      vertex -120.021 127.454 -3
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -120.226 127.411 -3
+      vertex -120.226 127.411 0
+      vertex -120.021 127.454 0
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -120.427 127.353 -3
+      vertex -120.226 127.411 0
+      vertex -120.226 127.411 -3
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -120.427 127.353 -3
+      vertex -120.427 127.353 0
+      vertex -120.226 127.411 0
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -120.624 127.282 -3
+      vertex -120.427 127.353 0
+      vertex -120.427 127.353 -3
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -120.624 127.282 -3
+      vertex -120.624 127.282 0
+      vertex -120.427 127.353 0
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -120.815 127.196 -3
+      vertex -120.624 127.282 0
+      vertex -120.624 127.282 -3
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -120.815 127.196 -3
+      vertex -120.815 127.196 0
+      vertex -120.624 127.282 0
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -121 127.098 -3
+      vertex -120.815 127.196 0
+      vertex -120.815 127.196 -3
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -121 127.098 -3
+      vertex -121 127.098 0
+      vertex -120.815 127.196 0
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -121.178 126.987 -3
+      vertex -121 127.098 0
+      vertex -121 127.098 -3
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -121.178 126.987 -3
+      vertex -121.178 126.987 0
+      vertex -121 127.098 0
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -121.347 126.864 -3
+      vertex -121.178 126.987 0
+      vertex -121.178 126.987 -3
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -121.347 126.864 -3
+      vertex -121.347 126.864 0
+      vertex -121.178 126.987 0
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -121.507 126.729 -3
+      vertex -121.347 126.864 0
+      vertex -121.347 126.864 -3
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -121.507 126.729 -3
+      vertex -121.507 126.729 0
+      vertex -121.347 126.864 0
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -121.658 126.584 -3
+      vertex -121.507 126.729 0
+      vertex -121.507 126.729 -3
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -121.658 126.584 -3
+      vertex -121.658 126.584 0
+      vertex -121.507 126.729 0
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -121.798 126.428 -3
+      vertex -121.658 126.584 0
+      vertex -121.658 126.584 -3
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -121.798 126.428 -3
+      vertex -121.798 126.428 0
+      vertex -121.658 126.584 0
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -121.927 126.263 -3
+      vertex -121.798 126.428 0
+      vertex -121.798 126.428 -3
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -121.927 126.263 -3
+      vertex -121.927 126.263 0
+      vertex -121.798 126.428 0
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -122.044 126.09 -3
+      vertex -121.927 126.263 0
+      vertex -121.927 126.263 -3
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -122.044 126.09 -3
+      vertex -122.044 126.09 0
+      vertex -121.927 126.263 0
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -122.149 125.908 -3
+      vertex -122.044 126.09 0
+      vertex -122.044 126.09 -3
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -122.149 125.908 -3
+      vertex -122.149 125.908 0
+      vertex -122.044 126.09 0
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -122.241 125.72 -3
+      vertex -122.149 125.908 0
+      vertex -122.149 125.908 -3
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -122.241 125.72 -3
+      vertex -122.241 125.72 0
+      vertex -122.149 125.908 0
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -122.319 125.526 -3
+      vertex -122.241 125.72 0
+      vertex -122.241 125.72 -3
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -122.319 125.526 -3
+      vertex -122.319 125.526 0
+      vertex -122.241 125.72 0
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -122.384 125.327 -3
+      vertex -122.319 125.526 0
+      vertex -122.319 125.526 -3
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -122.384 125.327 -3
+      vertex -122.384 125.327 0
+      vertex -122.319 125.526 0
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -122.434 125.124 -3
+      vertex -122.384 125.327 0
+      vertex -122.384 125.327 -3
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -122.434 125.124 -3
+      vertex -122.434 125.124 0
+      vertex -122.384 125.327 0
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -122.471 124.918 -3
+      vertex -122.434 125.124 0
+      vertex -122.434 125.124 -3
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -122.471 124.918 -3
+      vertex -122.471 124.918 0
+      vertex -122.434 125.124 0
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -122.493 124.709 -3
+      vertex -122.471 124.918 0
+      vertex -122.471 124.918 -3
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -122.493 124.709 -3
+      vertex -122.493 124.709 0
+      vertex -122.471 124.918 0
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -122.5 124.5 -3
+      vertex -122.493 124.709 0
+      vertex -122.493 124.709 -3
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -122.5 124.5 -3
+      vertex -122.5 124.5 0
+      vertex -122.493 124.709 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -122.5 -124.5 -3
+      vertex -122.5 124.5 0
+      vertex -122.5 124.5 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -122.5 -124.5 -3
+      vertex -122.5 -124.5 0
+      vertex -122.5 124.5 0
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -122.493 -124.709 -3
+      vertex -122.5 -124.5 0
+      vertex -122.5 -124.5 -3
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -122.493 -124.709 -3
+      vertex -122.493 -124.709 0
+      vertex -122.5 -124.5 0
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -122.471 -124.918 -3
+      vertex -122.493 -124.709 0
+      vertex -122.493 -124.709 -3
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -122.471 -124.918 -3
+      vertex -122.471 -124.918 0
+      vertex -122.493 -124.709 0
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -122.434 -125.124 -3
+      vertex -122.471 -124.918 0
+      vertex -122.471 -124.918 -3
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -122.434 -125.124 -3
+      vertex -122.434 -125.124 0
+      vertex -122.471 -124.918 0
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -122.384 -125.327 -3
+      vertex -122.434 -125.124 0
+      vertex -122.434 -125.124 -3
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -122.384 -125.327 -3
+      vertex -122.384 -125.327 0
+      vertex -122.434 -125.124 0
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -122.319 -125.526 -3
+      vertex -122.384 -125.327 0
+      vertex -122.384 -125.327 -3
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -122.319 -125.526 -3
+      vertex -122.319 -125.526 0
+      vertex -122.384 -125.327 0
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -122.241 -125.72 -3
+      vertex -122.319 -125.526 0
+      vertex -122.319 -125.526 -3
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -122.241 -125.72 -3
+      vertex -122.241 -125.72 0
+      vertex -122.319 -125.526 0
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -122.149 -125.908 -3
+      vertex -122.241 -125.72 0
+      vertex -122.241 -125.72 -3
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -122.149 -125.908 -3
+      vertex -122.149 -125.908 0
+      vertex -122.241 -125.72 0
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -122.044 -126.09 -3
+      vertex -122.149 -125.908 0
+      vertex -122.149 -125.908 -3
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -122.044 -126.09 -3
+      vertex -122.044 -126.09 0
+      vertex -122.149 -125.908 0
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -121.927 -126.263 -3
+      vertex -122.044 -126.09 0
+      vertex -122.044 -126.09 -3
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -121.927 -126.263 -3
+      vertex -121.927 -126.263 0
+      vertex -122.044 -126.09 0
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -121.798 -126.428 -3
+      vertex -121.927 -126.263 0
+      vertex -121.927 -126.263 -3
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -121.798 -126.428 -3
+      vertex -121.798 -126.428 0
+      vertex -121.927 -126.263 0
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -121.658 -126.584 -3
+      vertex -121.798 -126.428 0
+      vertex -121.798 -126.428 -3
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -121.658 -126.584 -3
+      vertex -121.658 -126.584 0
+      vertex -121.798 -126.428 0
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -121.507 -126.729 -3
+      vertex -121.658 -126.584 0
+      vertex -121.658 -126.584 -3
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -121.507 -126.729 -3
+      vertex -121.507 -126.729 0
+      vertex -121.658 -126.584 0
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -121.347 -126.864 -3
+      vertex -121.507 -126.729 0
+      vertex -121.507 -126.729 -3
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -121.347 -126.864 -3
+      vertex -121.347 -126.864 0
+      vertex -121.507 -126.729 0
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -121.178 -126.987 -3
+      vertex -121.347 -126.864 0
+      vertex -121.347 -126.864 -3
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -121.178 -126.987 -3
+      vertex -121.178 -126.987 0
+      vertex -121.347 -126.864 0
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -121 -127.098 -3
+      vertex -121.178 -126.987 0
+      vertex -121.178 -126.987 -3
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -121 -127.098 -3
+      vertex -121 -127.098 0
+      vertex -121.178 -126.987 0
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -120.815 -127.196 -3
+      vertex -121 -127.098 0
+      vertex -121 -127.098 -3
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -120.815 -127.196 -3
+      vertex -120.815 -127.196 0
+      vertex -121 -127.098 0
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -120.624 -127.282 -3
+      vertex -120.815 -127.196 0
+      vertex -120.815 -127.196 -3
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -120.624 -127.282 -3
+      vertex -120.624 -127.282 0
+      vertex -120.815 -127.196 0
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -120.427 -127.353 -3
+      vertex -120.624 -127.282 0
+      vertex -120.624 -127.282 -3
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -120.427 -127.353 -3
+      vertex -120.427 -127.353 0
+      vertex -120.624 -127.282 0
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -120.226 -127.411 -3
+      vertex -120.427 -127.353 0
+      vertex -120.427 -127.353 -3
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -120.226 -127.411 -3
+      vertex -120.226 -127.411 0
+      vertex -120.427 -127.353 0
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -120.021 -127.454 -3
+      vertex -120.226 -127.411 0
+      vertex -120.226 -127.411 -3
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -120.021 -127.454 -3
+      vertex -120.021 -127.454 0
+      vertex -120.226 -127.411 0
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -119.814 -127.484 -3
+      vertex -120.021 -127.454 0
+      vertex -120.021 -127.454 -3
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -119.814 -127.484 -3
+      vertex -119.814 -127.484 0
+      vertex -120.021 -127.454 0
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -119.605 -127.498 -3
+      vertex -119.814 -127.484 0
+      vertex -119.814 -127.484 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -119.605 -127.498 -3
+      vertex -119.605 -127.498 0
+      vertex -119.814 -127.484 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -119.605 -127.498 0
+      vertex -119.605 -127.498 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -119.502 -127.498 -3
+      vertex -119.502 -127.498 0
+      vertex -119.605 -127.498 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -119.5 -127.5 -3
+      vertex -119.502 -127.498 0
+      vertex -119.502 -127.498 -3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -119.5 -127.5 -3
+      vertex -119.5 -127.5 0
+      vertex -119.502 -127.498 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 119.5 -127.5 -3
+      vertex -119.5 -127.5 0
+      vertex -119.5 -127.5 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 119.5 -127.5 -3
+      vertex 119.5 -127.5 0
+      vertex -119.5 -127.5 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 119.502 -127.498 -3
+      vertex 119.5 -127.5 0
+      vertex 119.5 -127.5 -3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 119.502 -127.498 -3
+      vertex 119.502 -127.498 0
+      vertex 119.5 -127.5 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Add a representative bed model
Adjust bed_shape to maximize available print space while retaining safe space for the prime line (start_gcode)
Adjust bed texture to represent the valid bed print space