### PR TITLE
Fix build by including missing headers

### DIFF
--- a/src/libslic3r/Brim.cpp
+++ b/src/libslic3r/Brim.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <unordered_set>
 #include <tbb/parallel_for.h>
 
 namespace Slic3r {

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -11,6 +11,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/bind/placeholders.hpp>
+#include <boost/nowide/convert.hpp>
 
 #include <iostream>
 


### PR DESCRIPTION
Include two missing headers as required to build the current master branch.