### PR TITLE
Remove unneeded inclusion of boost::nowide

### DIFF
--- a/src/libslic3r/Format/3mf.cpp
+++ b/src/libslic3r/Format/3mf.cpp
@@ -19,8 +19,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/nowide/fstream.hpp>
-#include <boost/nowide/cstdio.hpp>
 #include <boost/spirit/include/karma.hpp>
 
 #include <boost/property_tree/ptree.hpp>

--- a/src/libslic3r/Format/PRUS.cpp
+++ b/src/libslic3r/Format/PRUS.cpp
@@ -2,8 +2,6 @@
 #include <exception>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/nowide/convert.hpp>
-#include <boost/nowide/cstdio.hpp>
 
 #include "miniz_extension.hpp"
 

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -34,8 +34,6 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
-#include <boost/nowide/cstdio.hpp>
-
 #include <Eigen/Dense>
 
 #ifdef HAS_GLSAFE

--- a/src/slic3r/GUI/BedShapeDialog.cpp
+++ b/src/slic3r/GUI/BedShapeDialog.cpp
@@ -12,7 +12,6 @@
 #include "libslic3r/Model.hpp"
 #include "libslic3r/Polygon.hpp"
 
-#include "boost/nowide/iostream.hpp"
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 


### PR DESCRIPTION
A few source files no longer need some headers.

In this PR we remove the inclusion of boost::nowide from a few cases as spotted by [iwyu](https://include-what-you-use.org/) when building on linux.

Removing unneeded headers is useful to reduce build times.
There are quite a few more cases. I could provide some more targeted PRs if that's helpful