### PR TITLE
Fixes issue #5979 - NULL pointer crash in ModelObject::split()

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -402,7 +402,12 @@ int CLI::run(int argc, char **argv)
             for (Model &model : m_models) {
                 size_t num_objects = model.objects.size();
                 for (size_t i = 0; i < num_objects; ++ i) {
-                    model.objects.front()->split(nullptr);
+                    ModelObjectPtrs new_objects;
+                    ModelObject* front = model.objects.front();
+                    front->split(&new_objects);
+                    unsigned int counter = 1;
+                    for (ModelObject* m : new_objects)
+                        m->name = front->name + "_" + std::to_string(counter++);
                     model.delete_object(size_t(0));
                 }
             }


### PR DESCRIPTION
ModelObject::split() expects a non-NULL new_objects vector where it adds pointers to the new models resulting from the split. But in the CLI case the caller does not care about this and passes NULL which causes a crash. To fix the crash we could pass a dummy vector but it turns out that we actually have a use for the results because we should assign a unique name to each new model the same way as the GUI does. These names show up as comments in the gcode so this change makes the gcode produced by the GUI and the CLI more similar and diffable.