### PR TITLE
Postprocessing moved to temp dir

### DIFF
--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -149,9 +149,13 @@ void BackgroundSlicingProcess::process_fff()
 	if (this->set_step_started(bspsGCodeFinalize)) {
 	    if (! m_export_path.empty()) {
 			wxQueueEvent(GUI::wxGetApp().mainframe->m_plater, new wxCommandEvent(m_event_export_began_id));
-	    	//FIXME localize the messages
-	    	// Perform the final post-processing of the export path by applying the print statistics over the file name.
-	    	std::string export_path = m_fff_print->print_statistics().finalize_output_path(m_export_path);
+		
+            m_print->set_status(95, _utf8(L("Running post-processing scripts")));
+            run_post_process_scripts(m_temp_output_path, m_fff_print->full_print_config());
+
+            //FIXME localize the messages
+            // Perform the final post-processing of the export path by applying the print statistics over the file name.
+            std::string export_path = m_fff_print->print_statistics().finalize_output_path(m_export_path);
 			std::string error_message;
 			int copy_ret_val = CopyFileResult::SUCCESS;
 			try
@@ -184,8 +188,7 @@ void BackgroundSlicingProcess::process_fff()
 				BOOST_LOG_TRIVIAL(error) << "Unexpected fail code(" << (int)copy_ret_val << ") durring copy_file() to " << export_path << ".";
 				break;
 			}
-	    	m_print->set_status(95, _utf8(L("Running post-processing scripts")));
-	    	run_post_process_scripts(export_path, m_fff_print->full_print_config());
+
 	    	m_print->set_status(100, (boost::format(_utf8(L("G-code file exported to %1%"))) % export_path).str());
 	    } else if (! m_upload_job.empty()) {
 			wxQueueEvent(GUI::wxGetApp().mainframe->m_plater, new wxCommandEvent(m_event_export_began_id));

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -149,13 +149,13 @@ void BackgroundSlicingProcess::process_fff()
 	if (this->set_step_started(bspsGCodeFinalize)) {
 	    if (! m_export_path.empty()) {
 			wxQueueEvent(GUI::wxGetApp().mainframe->m_plater, new wxCommandEvent(m_event_export_began_id));
-		
-            m_print->set_status(95, _utf8(L("Running post-processing scripts")));
-            run_post_process_scripts(m_temp_output_path, m_fff_print->full_print_config());
-
-            //FIXME localize the messages
-            // Perform the final post-processing of the export path by applying the print statistics over the file name.
-            std::string export_path = m_fff_print->print_statistics().finalize_output_path(m_export_path);
+			
+			m_print->set_status(95, _utf8(L("Running post-processing scripts")));
+			run_post_process_scripts(m_temp_output_path, m_fff_print->full_print_config());
+			
+			//FIXME localize the messages
+			// Perform the final post-processing of the export path by applying the print statistics over the file name.
+			std::string export_path = m_fff_print->print_statistics().finalize_output_path(m_export_path);
 			std::string error_message;
 			int copy_ret_val = CopyFileResult::SUCCESS;
 			try


### PR DESCRIPTION
*Why this change in needed?
I upload my gcode files onto network storage over 2.4GHz wifi and it takes noticeable time. 
It becomes worse if also use post-processing scripts, since it is now implemented in way that post-processing happens after gcode file was move to its final path.

*What is the change?
I moved post-processing step to happen before gcode files move from temp dir to final. Temp directory is usually a fast SSD so it eliminates the problem