### PR TITLE
UnsavedChangesDialog: fix wxString casts

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -201,9 +201,9 @@ void ModelNode::UpdateIcons()
 {
     // update icons for the colors, if any exists
     if (!m_old_color.IsEmpty())
-        m_old_color_bmp = get_bitmap(m_toggle ? m_old_color : grey.c_str());
+        m_old_color_bmp = get_bitmap(m_toggle ? m_old_color : wxString::FromUTF8(grey.c_str()));
     if (!m_new_color.IsEmpty())
-        m_new_color_bmp = get_bitmap(m_toggle ? m_new_color : grey.c_str());
+        m_new_color_bmp = get_bitmap(m_toggle ? m_new_color : wxString::FromUTF8(grey.c_str()));
 
     // update main icon, if any exists
     if (m_icon_name.empty())


### PR DESCRIPTION
similar instance: https://github.com/prusa3d/PrusaSlicer/commit/08388d3daac2527ed65516e405c626e51aa5396b

related to: #5752