### PR TITLE
Bridge speed should take precedence over special cases like small perimeter speed

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2572,13 +2572,13 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     if (m_writer.extrusion_axis().empty()) e_per_mm = 0;
 
     // set speed
-    if (speed == -1) {
+    if (is_bridge(path.role())) {
+        speed = m_config.get_abs_value("bridge_speed");
+    } else if (speed == -1) {
         if (path.role() == erPerimeter) {
             speed = m_config.get_abs_value("perimeter_speed");
         } else if (path.role() == erExternalPerimeter) {
             speed = m_config.get_abs_value("external_perimeter_speed");
-        } else if (path.role() == erOverhangPerimeter || path.role() == erBridgeInfill) {
-            speed = m_config.get_abs_value("bridge_speed");
         } else if (path.role() == erInternalInfill) {
             speed = m_config.get_abs_value("infill_speed");
         } else if (path.role() == erSolidInfill) {


### PR DESCRIPTION
This should fix issue #4130 where the small perimeter speed is used instead of the bridge speed. I originally ran into this bug when trying to improve the overhangs on the 3DBenchy door arches (because small perimeter speed was erroneously applied to the curved part of the overhangs).

The change itself is extremely simple. It just always prioritizes the bridge/overhang role over any special-case speed that may be supplied for an extrusion. That seems like the right solution, since generally the bridge/overhang role seems to take priority over other roles elsewhere in the code.