### PR TITLE
A typo in the build instructions for MacOS

### DIFF
--- a/doc/How to build - Mac OS.md
+++ b/doc/How to build - Mac OS.md
@@ -90,8 +90,9 @@ Works on a fresh installation of MacOS Catalina 10.15.6
     
 - Enter:
 
-```brew install cmake git gettext
+```
 brew update
+brew install cmake git gettext
 brew upgrade
 git clone https://github.com/prusa3d/PrusaSlicer/
 cd PrusaSlicer/deps
@@ -105,3 +106,4 @@ cd build
 cmake .. -DCMAKE_PREFIX_PATH="$PWD/../deps/build/destdir/usr/local"
 make
 src/prusa-slicer
+```


### PR DESCRIPTION
I've tried to build PrusaSlicer for a new Macbook Air M1 (new "Apple silicon") and found that the first line, `brew install cmake git gettext` wasn't visible in the installation instructions due to a formatting error.

The instructions are valid for macOS BigSur and M1; PrusaSlicer compiles on it without error (yet there are multiple warnings). The process takes about 20 minutes and requires approx. 6Gb of disk space. 

The produced binary is for a single architecture, 

```
~ file PrusaSlicer/build/src/PrusaSlicer
PrusaSlicer/build/src/PrusaSlicer: Mach-O 64-bit executable arm64
```

Running it on an Intel system returns `bad CPU type in executable: PrusaSlicer`. **Build scripts need to be updated to produce a universal binary for `x86_64` and `arm64e`**.

Slicing is twice faster on M1 compared to Intel's Core i7 (I used a first complex STL file I could think of - "Bernie with mittens" from Thingiverse):

<img width="1182" alt="Compilation on an Apple M1" src="https://user-images.githubusercontent.com/1763243/107876691-83504800-6ed8-11eb-93c6-5f5a3ba022c0.png">

<img width="1219" alt="Performance on an Apple M1" src="https://user-images.githubusercontent.com/1763243/107876696-8cd9b000-6ed8-11eb-8fcd-f46c15add8d6.png">

<img width="1096" alt="Performance on Intel's i7" src="https://user-images.githubusercontent.com/1763243/107876701-95ca8180-6ed8-11eb-8e7b-f0bbc10c750d.png">


