### PR TITLE
Min travel Speed slower than 1mm/s

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2446,7 +2446,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Speed for travel moves (jumps between distant extrusion points).");
     def->sidetext = L("mm/s");
     def->aliases = { "travel_feed_rate" };
-    def->min = 1;
+    def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(130));
 


### PR DESCRIPTION
Hello Prusa Team,

I am pulling this simple request on behalf of Laser physics group of KTH Royal Institute of Technology (Stockholm). 
We use your slicer to generate a GCODE for fine material processing. 
The base version of the slicer has a limit on how slow one can travel between distant extrusion points (set to 1mm/s). Unfortunately for us this can lead to sample destruction at some cases (when printing speed is < 0.2mm/s).

This pull will effectively sets minimal travel speed to 0mm/s, which will not only solve our problem but also will make this parameter consistent with the other (which can be set to values < 1mm/s already).
![5](https://user-images.githubusercontent.com/52491713/108399609-93d72a00-721a-11eb-9f3e-93e668d0da56.png)


Summary:
Minimal travel speed is set to 0 for scientific needs (to allow very slow movements to be consistent)

Thank you!