### PR TITLE
increase hole diameter

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
@@ -640,7 +640,7 @@ RENDER_AGAIN:
 
     ImGui::Separator();
 
-    float diameter_upper_cap = 15.;
+    float diameter_upper_cap = 25.;
     if (m_new_hole_radius > diameter_upper_cap)
         m_new_hole_radius = diameter_upper_cap;
     m_imgui->text(m_desc.at("hole_diameter"));


### PR DESCRIPTION
This very small patch increases the maximum possible hole diameter in the hollow-tool.

Background:

A cheap way to "magnetise" miniature bases is to glue small coins into them. This way they attach to magnetic surfaces which makes them easy to transport. The hollow-tool in PrusaSlicer is ideal for making such cavities in the bases of miniatures, so that one can stick 1¢, 2¢ or 5¢ coins into them. However, the current maximum of 15mm is too small.

This patch increases the maximum to 25mm which covers most european coins:
http://euro.raddos.de/pages/muenze.php?eusprache=en&euland=

I don't think it should affect anyone negatively since everyone can still choose smaller sizes :)