### PR TITLE
WIP: Display estimated layer printing time per single layer

### DIFF
--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -392,6 +392,26 @@ void Control::SetLayersTimes(const std::vector<double>& layers_times)
         m_layers_times[i] += m_layers_times[i - 1];
 }
 
+double Control::GetCurrentLayerTime()
+{
+    double previousLayerTime = 0;
+
+    int currentLayer = GetHigherValue();
+    int previousLayer = currentLayer - 1;
+
+    // Since the layer times are accumulated, we need to calculate the effective layer time
+    // and not the layer time including all previous layer times.
+
+    if (currentLayer < m_layers_times.size()) {
+        if (previousLayer > 0) {
+            previousLayerTime = m_layers_times[previousLayer];
+        }
+        return m_layers_times[currentLayer] - previousLayerTime;
+    }
+
+    return 0;
+}
+
 void Control::SetDrawMode(bool is_sla_print, bool is_sequential_print)
 { 
     m_draw_mode = is_sla_print          ? dmSlaPrint            : 

--- a/src/slic3r/GUI/DoubleSlider.hpp
+++ b/src/slic3r/GUI/DoubleSlider.hpp
@@ -224,6 +224,8 @@ public:
     void    SetLayersTimes(const std::vector<float>& layers_times);
     void    SetLayersTimes(const std::vector<double>& layers_times);
 
+    double GetCurrentLayerTime();
+
     void    SetDrawMode(bool is_sla_print, bool is_sequential_print);
     void    SetDrawMode(DrawMode mode) { m_draw_mode = mode; }
 

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4418,6 +4418,31 @@ void GCodeViewer::render_legend() const
         ImGui::SameLine();
         imgui.text(short_time(get_time_dhms(time_mode.time)));
 
+        ImGui::AlignTextToFramePadding();
+        switch (m_time_estimate_mode) {
+            case PrintEstimatedTimeStatistics::ETimeMode::Normal: {
+                imgui.text(_u8L("Estimated printing time for Layer #") +
+                           std::to_string(m_current_layer+1)  + " [" +
+                           _u8L("Normal mode") + "]:");
+                break;
+            }
+            case PrintEstimatedTimeStatistics::ETimeMode::Stealth: {
+                imgui.text(_u8L("Estimated printing time for Layer #") +
+                           std::to_string(m_current_layer+1) + " [" +
+                           _u8L("Stealth mode") + "]:");
+                break;
+            }
+            default: {
+                assert(false);
+                break;
+            }
+        }
+
+        ImGui::SameLine();
+        imgui.text(get_time_dhms(m_current_layer_time));
+
+        
+
         auto show_mode_button = [this, &imgui](const wxString& label, PrintEstimatedTimeStatistics::ETimeMode mode) {
             bool show = false;
             for (size_t i = 0; i < m_time_statistics.modes.size(); ++i) {

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -644,6 +644,8 @@ private:
     std::vector<Color> m_tool_colors;
     Layers m_layers;
     std::array<unsigned int, 2> m_layers_z_range;
+    unsigned int m_current_layer;
+    double m_current_layer_time;
     std::vector<ExtrusionRole> m_roles;
     size_t m_extruders_count;
     std::vector<unsigned char> m_extruder_ids;
@@ -704,6 +706,16 @@ public:
     unsigned int get_options_visibility_flags() const;
     void set_options_visibility_from_flags(unsigned int flags);
     void set_layers_z_range(const std::array<unsigned int, 2>& layers_z_range);
+
+    void set_current_layer(unsigned int layerNumber)
+    {
+        m_current_layer = layerNumber;
+    }
+
+    void set_current_layer_time(double layerTime)
+    {
+        m_current_layer_time = layerTime;
+    }
 
     bool is_legend_enabled() const { return m_legend_enabled; }
     void enable_legend(bool enable) { m_legend_enabled = enable; }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1858,6 +1858,19 @@ void GLCanvas3D::set_toolpaths_z_range(const std::array<unsigned int, 2>& range)
         m_gcode_viewer.set_layers_z_range(range);
 }
 
+void GLCanvas3D::set_current_layer(unsigned int layerNumber)
+{
+    if (m_gcode_viewer.has_data())
+        m_gcode_viewer.set_current_layer(layerNumber);
+}
+
+void GLCanvas3D::set_current_layer_time(double layerTime)
+{
+    if (m_gcode_viewer.has_data())
+        m_gcode_viewer.set_current_layer_time(layerTime);
+}
+
+
 std::vector<int> GLCanvas3D::load_object(const ModelObject& model_object, int obj_idx, std::vector<int> instance_idxs)
 {
     if (instance_idxs.empty()) {

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -656,6 +656,8 @@ public:
     void set_toolpath_view_type(GCodeViewer::EViewType type);
     void set_volumes_z_range(const std::array<double, 2>& range);
     void set_toolpaths_z_range(const std::array<unsigned int, 2>& range);
+    void set_current_layer(unsigned int layerNumber);
+    void set_current_layer_time(double layerTime);
 
     std::vector<int> load_object(const ModelObject& model_object, int obj_idx, std::vector<int> instance_idxs);
     std::vector<int> load_object(const Model& model, int obj_idx);

--- a/src/slic3r/GUI/GUI_Preview.cpp
+++ b/src/slic3r/GUI/GUI_Preview.cpp
@@ -639,6 +639,10 @@ void Preview::update_layers_slider(const std::vector<double>& layers_z, bool kee
         m_layers_slider->SetLayersTimes(m_gcode_result->time_statistics.modes.front().layers_times);
 
     m_layers_slider_sizer->Show((size_t)0);
+
+    m_canvas->set_current_layer(m_layers_slider->GetHigherValue());
+    m_canvas->set_current_layer_time(m_layers_slider->GetCurrentLayerTime());
+
     Layout();
 }
 
@@ -918,6 +922,8 @@ void Preview::on_layers_slider_scroll_changed(wxCommandEvent& event)
         if (tech == ptFFF) {
             m_canvas->set_volumes_z_range({ m_layers_slider->GetLowerValueD(), m_layers_slider->GetHigherValueD() });
             m_canvas->set_toolpaths_z_range({ static_cast<unsigned int>(m_layers_slider->GetLowerValue()), static_cast<unsigned int>(m_layers_slider->GetHigherValue()) });
+            m_canvas->set_current_layer(m_layers_slider->GetHigherValue());
+            m_canvas->set_current_layer_time(m_layers_slider->GetCurrentLayerTime());
             m_canvas->set_as_dirty();
         }
         else if (tech == ptSLA) {


### PR DESCRIPTION
This is a WIP PR to display the estimated printing time for each individual layer. To view this information, the option "Legend/Estimated printing Time" must be selected in the preview.

The layer for which the time is displayed is determinated by the upper layer slider.

![image](https://user-images.githubusercontent.com/162974/108866892-ed619f00-75f4-11eb-8407-f5cb9bde4332.png)

Since it's almost 15 years since I last touched C++, please forgive any odd things.

This is a potential fix for #2754
