### PR TITLE
Adding support for 3d-fuel filament

### DIFF
--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -1839,17 +1839,6 @@ first_layer_temperature = 240
 bed_temperature = 60
 first_layer_bed_temperature = 60
 
-[filament:Workday PLA]
-inherits = *PLA*
-filament_vendor = 3D-Fuel
-filament_cost = 29.99
-filament_density = 1.25
-min_print_speed = 40
-temperature = 200
-first_layer_temperature = 230
-bed_temperature = 45
-first_layer_bed_temperature = 60
-
 [filament:Entwined]
 inherits = *PLA*
 filament_vendor = 3D-Fuel

--- a/resources/profiles/PrusaResearch.ini
+++ b/resources/profiles/PrusaResearch.ini
@@ -1817,6 +1817,120 @@ filament_density = 1.05
 first_layer_temperature = 270
 temperature = 270
 
+[filament:Standard PLA]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 24.99
+filament_density = 1.24
+min_print_speed = 40
+temperature = 190
+first_layer_temperature = 220
+bed_temperature = 45
+first_layer_bed_temperature = 60
+
+[filament:Pro PLA]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 31.99
+filament_density = 1.22
+min_print_speed = 40
+temperature = 210
+first_layer_temperature = 240
+bed_temperature = 60
+first_layer_bed_temperature = 60
+
+[filament:Workday PLA]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 29.99
+filament_density = 1.25
+min_print_speed = 40
+temperature = 200
+first_layer_temperature = 230
+bed_temperature = 45
+first_layer_bed_temperature = 60
+
+[filament:Entwined]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 76.99
+filament_density = 1.24
+temperature = 180
+first_layer_temperature = 210
+bed_temperature = 45
+first_layer_bed_temperature = 60
+
+[filament:HydroPro]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 89.99
+filament_density = 1.15
+min_print_speed = 20
+temperature = 210
+first_layer_temperature = 230
+bed_temperature = 45
+first_layer_bed_temperature = 60
+filament_retract_length = 5
+filament_retract_speed = 20
+filament_soluble = 1
+
+[filament:HydroSupport v2]
+inherits = *PLA*
+filament_vendor = 3D-Fuel
+filament_cost = 124.99
+filament_density = 1.15
+min_print_speed = 20
+temperature = 215
+first_layer_temperature = 230
+bed_temperature = 45
+first_layer_bed_temperature = 60
+filament_retract_length = 5
+filament_retract_speed = 20
+filament_soluble = 1
+
+[filament:Workday PETG]
+inherits = *PET*
+filament_vendor = 3D-Fuel
+filament_cost = 29.99
+filament_density = 1.28
+temperature = 245
+first_layer_temperature = 265
+bed_temperature = 70
+first_layer_bed_temperature = 90
+
+[filament:Workday ABS]
+inherits = *ABS*
+filament_vendor = 3D-Fuel
+filament_cost = 29.99
+filament_density = 1.04
+temperature = 240
+first_layer_temperature = 260
+bed_temperature = 100
+first_layer_bed_temperature = 110
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 1
+min_fan_speed = 10
+max_fan_speed = 10
+
+[filament:Workday ASA]
+inherits = *ABS*
+filament_vendor = 3D-Fuel
+filament_cost = 29.99
+filament_density = 1.06
+temperature = 230
+first_layer_temperature = 260
+bed_temperature = 110
+first_layer_bed_temperature = 110
+fan_always_on = 1
+cooling = 1
+min_fan_speed = 20
+max_fan_speed = 20
+min_print_speed = 15
+slowdown_below_layer_time = 15
+disable_fan_first_layers = 4
+filament_type = ASA
+
 [filament:Fillamentum PLA]
 inherits = *PLA*
 filament_vendor = Fillamentum


### PR DESCRIPTION
Adding support for 3d-Fuel filament: https://www.3dfuel.com/
Per SDS, TDS, and Pricing, doesn't look like there are recommended differences between their 1.75mm and 2.85mm filaments.