### PR TITLE
Fix boost dependency url.

### DIFF
--- a/deps/deps-windows.cmake
+++ b/deps/deps-windows.cmake
@@ -55,7 +55,7 @@ endmacro()
 
 ExternalProject_Add(dep_boost
     EXCLUDE_FROM_ALL 1
-    URL "https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz"
+    URL "https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz"
     URL_HASH SHA256=aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND bootstrap.bat


### PR DESCRIPTION
Original host's lifetime has ended. New url from here: https://github.com/boostorg/boost/issues/502

#6348