### PR TITLE
Added option to independently set z axis travel speed

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -370,7 +370,7 @@ std::string GCodeWriter::_travel_to_z(double z, const std::string &comment)
     
     std::ostringstream gcode;
     gcode << "G1 Z" << XYZF_NUM(z)
-          <<   " F" << XYZF_NUM(this->config.travel_speed.value * 60.0);
+          <<   " F" << XYZF_NUM(this->config.travel_speed_z.value * 60.0);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -430,7 +430,7 @@ const std::vector<std::string>& Preset::print_options()
 #endif /* HAS_PRESSURE_EQUALIZER */
         "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "infill_speed", "solid_infill_speed",
         "top_solid_infill_speed", "support_material_speed", "support_material_xy_spacing", "support_material_interface_speed",
-        "bridge_speed", "gap_fill_speed", "gap_fill_enabled", "travel_speed", "first_layer_speed", "perimeter_acceleration", "infill_acceleration",
+        "bridge_speed", "gap_fill_speed", "gap_fill_enabled", "travel_speed", "travel_speed_z", "first_layer_speed", "perimeter_acceleration", "infill_acceleration",
         "bridge_acceleration", "first_layer_acceleration", "default_acceleration", "skirts", "skirt_distance", "skirt_height", "draft_shield",
         "min_skirt_length", "brim_width", "brim_offset", "brim_type", "support_material", "support_material_auto", "support_material_threshold", "support_material_enforce_layers",
         "raft_layers", "raft_first_layer_density", "raft_first_layer_expansion", "raft_contact_distance", "raft_expansion",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -197,6 +197,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "cooling_tube_length"
             || opt_key == "extra_loading_move"
             || opt_key == "travel_speed"
+            || opt_key == "travel_speed_z"
             || opt_key == "first_layer_speed"
             || opt_key == "z_offset") {
             steps.emplace_back(psWipeTower);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2738,6 +2738,14 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(130));
 
+    def = this->add("travel_speed_z", coFloat);
+    def->label = L("Z travel");
+    def->tooltip = L("Speed for movements along the Z axis.");
+    def->sidetext = L("mm/s");
+    def->min = 1;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(12));
+
     def = this->add("use_firmware_retraction", coBool);
     def->label = L("Use firmware retraction");
     def->tooltip = L("This experimental setting uses G10 and G11 commands to have the firmware "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -627,6 +627,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                wipe_tower_no_sparse_layers))
     ((ConfigOptionString,              toolchange_gcode))
     ((ConfigOptionFloat,               travel_speed))
+    ((ConfigOptionFloat,               travel_speed_z))
     ((ConfigOptionBool,                use_firmware_retraction))
     ((ConfigOptionBool,                use_relative_e_distances))
     ((ConfigOptionBool,                use_volumetric_e))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1545,6 +1545,7 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Speed for non-print moves"));
         optgroup->append_single_option_line("travel_speed");
+        optgroup->append_single_option_line("travel_speed_z");
 
         optgroup = page->new_optgroup(L("Modifiers"));
         optgroup->append_single_option_line("first_layer_speed");


### PR DESCRIPTION
Added an option `travel_speed_z` to independently set the Z axis travel speed. I've set the default value to `12` which is the default value of `machine_max_feedrate_z`.

This addresses issues https://github.com/prusa3d/PrusaSlicer/issues/2945 , https://github.com/prusa3d/PrusaSlicer/issues/6365 and https://github.com/prusa3d/PrusaSlicer/issues/3995

Currently the same travel speed is used for x, y and z, which can means the z travel speed can be high which causes problems such as Z-banding and even can cause the Z-motor to skip (as reported in the issues).

In theory the z travel speed should be limited by the printer firmware using `M203` and the value `machine_max_feedrate_z`, however not all printer firmware supports this.

This is my first PR for PrusaSlicer, so I'd appreciate it if someone could check if I've made any obvious mistakes.