### PR TITLE
Fix #4768 Infill before perimeter

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -242,8 +242,11 @@ static ExtrusionEntityCollection traverse_loops(const PerimeterGenerator &perime
     }
     
     // Traverse children and build the final collection.
-	Point zero_point(0, 0);
-	std::vector<std::pair<size_t, bool>> chain = chain_extrusion_entities(coll.entities, &zero_point);
+    Point start_point(0, 0);
+    if (!coll.entities.empty())
+        start_point = Point(coll.entities.front()->as_polyline().first_point().x(), coll.entities.front()->as_polyline().first_point().y());
+
+    std::vector<std::pair<size_t, bool>> chain = chain_extrusion_entities(coll.entities, &start_point);
     ExtrusionEntityCollection out;
     for (const std::pair<size_t, bool> &idx : chain) {
 		assert(coll.entities[idx.first] != nullptr);


### PR DESCRIPTION
Ensure that perimeter are printed before thin walls.

See https://github.com/prusa3d/PrusaSlicer/issues/4768#issuecomment-829319195