### PR TITLE
Fix deadlock when canceling the slicing while gcode is creating thumbnails

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -886,9 +886,14 @@ namespace DoExport {
 	    // Write thumbnails using base64 encoding
 	    if (thumbnail_cb != nullptr)
 	    {
+            //Create the thumbnails
 	        const size_t max_row_length = 78;
 	        ThumbnailsList thumbnails;
-	        thumbnail_cb(thumbnails, sizes, true, true, true, true);
+            // note that it needs the gui thread, so can create deadlock if  job is canceled.
+	        bool can_create_thumbnail = thumbnail_cb(thumbnails, sizes, true, true, true, true);
+            throw_if_canceled();
+            if (!can_create_thumbnail) return;
+
 	        for (const ThumbnailData& data : thumbnails)
 	        {
 	            if (data.is_valid())

--- a/src/libslic3r/GCode/ThumbnailData.hpp
+++ b/src/libslic3r/GCode/ThumbnailData.hpp
@@ -20,7 +20,7 @@ struct ThumbnailData
 };
 
 typedef std::vector<ThumbnailData> ThumbnailsList;
-typedef std::function<void(ThumbnailsList & thumbnails, const Vec2ds & sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background)> ThumbnailsGeneratorCallback;
+typedef std::function<bool(ThumbnailsList & thumbnails, const Vec2ds & sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background)> ThumbnailsGeneratorCallback;
 
 } // namespace Slic3r
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1760,14 +1760,43 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     background_process.set_fff_print(&fff_print);
     background_process.set_sla_print(&sla_print);
     background_process.set_gcode_result(&gcode_result);
-    background_process.set_thumbnail_cb([this](ThumbnailsList& thumbnails, const Vec2ds& sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background)
+    background_process.set_thumbnail_cb([this](ThumbnailsList& thumbnails, const Vec2ds& sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background)->bool
         {
-            std::packaged_task<void(ThumbnailsList&, const Vec2ds&, bool, bool, bool, bool)> task([this](ThumbnailsList& thumbnails, const Vec2ds& sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background) {
+            auto task = std::make_shared<std::packaged_task<void(ThumbnailsList&, const Vec2ds&, bool, bool, bool, bool)>>([this](ThumbnailsList& thumbnails, const Vec2ds& sizes, bool printable_only, bool parts_only, bool show_bed, bool transparent_background) {
                 generate_thumbnails(thumbnails, sizes, printable_only, parts_only, show_bed, transparent_background);
                 });
-            std::future<void> result = task.get_future();
-            wxTheApp->CallAfter([&]() { task(thumbnails, sizes, printable_only, parts_only, show_bed, transparent_background); });
-            result.wait();
+
+            std::future<void> future_result = task->get_future();
+            std::shared_ptr<std::mutex> protect_bool = std::make_shared<std::mutex>();
+            std::shared_ptr<bool> is_started = std::make_shared<bool>(false);
+            std::shared_ptr<bool> cancel = std::make_shared<bool>(false);
+            wxTheApp->CallAfter([task, protect_bool, is_started, cancel, &thumbnails, &sizes, &printable_only, &parts_only, &show_bed, &transparent_background]()
+            { 
+                {
+                    std::lock_guard<std::mutex> lock(*protect_bool);
+                    if (*cancel)
+                        return;
+                    *is_started = true;
+                }
+                (*task)(thumbnails, sizes, printable_only, parts_only, show_bed, transparent_background); 
+            });
+            // can deadlock if background processing is cancelled / locked
+            // have to cancel the process if we're exiting here as the parameters will be deleted.
+            // if the process is already started, then we have to wait its end. and there is no deadlock with generate_thumbnails
+            // 2 seconds is plenty to 
+            std::future_status result = future_result.wait_for(std::chrono::seconds(2));
+            if (result == std::future_status::ready)
+                return true;
+            {
+                std::lock_guard<std::mutex> lock(*protect_bool);
+                if (*is_started) {
+                    future_result.wait();
+                    result = std::future_status::ready;
+                } else {
+                    *cancel = true;
+                }
+            }
+            return result == std::future_status::ready;
         });
     background_process.set_slicing_completed_event(EVT_SLICING_COMPLETED);
     background_process.set_finished_event(EVT_PROCESS_COMPLETED);


### PR DESCRIPTION
When creating thumbnail, it push a process on the gui thread and wait for it to finish.
But when cancelling, the gui thread switch the cancel flag and lock again (waiting for exception?)

So if we cancel just before the creation of thumbnails, then there is a deadlock.

Here is an extensive and complicated way to solve that problem.
The minimum is to throw_if_canceled(); just before sending & waiting for the thumbnail creation, that way the chance of this use occurring should be very small.