### PR TITLE
Add variables for individual extruders to be included in filename

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -631,8 +631,16 @@ namespace DoExport {
         double total_used_filament   = 0.0;
         double total_weight          = 0.0;
         double total_cost            = 0.0;
+        
+        /* filament statistics per extruder */
+        std::vector<double> individual_extruded_volume(12, 0.0);
+        std::vector<double> individual_used_filament(12, 0.0);
+        std::vector<double> individual_weight(12, 0.0);
+        std::vector<double> individual_cost(12, 0.0);
+        
         for (auto volume : result.print_statistics.volumes_per_extruder) {
             total_extruded_volume += volume.second;
+            
 
             size_t extruder_id = volume.first;
             auto extruder = std::find_if(extruders.begin(), extruders.end(), [extruder_id](const Extruder& extr) { return extr.id() == extruder_id; });
@@ -644,12 +652,22 @@ namespace DoExport {
             total_used_filament += volume.second/s;
             total_weight        += weight;
             total_cost          += weight * extruder->filament_cost() * 0.001;
+            
+            individual_extruded_volume.at(extruder_id) = volume.second;
+            individual_used_filament.at(extruder_id) = volume.second/s;
+            individual_weight.at(extruder_id) = weight;
+            individual_cost.at(extruder_id) = (weight * extruder->filament_cost() * 0.001);
         }
 
         print_statistics.total_extruded_volume = total_extruded_volume;
         print_statistics.total_used_filament   = total_used_filament;
         print_statistics.total_weight          = total_weight;
         print_statistics.total_cost            = total_cost;
+        
+        print_statistics.individual_extruded_volume = individual_extruded_volume;
+        print_statistics.individual_used_filament = individual_used_filament;
+        print_statistics.individual_weight = individual_weight;
+        print_statistics.individual_cost = individual_cost;
 
         print_statistics.filament_stats = result.print_statistics.volumes_per_extruder;
     }

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1251,6 +1251,10 @@ DynamicConfig PrintStatistics::config() const
     config.set_key_value("total_weight",              new ConfigOptionFloat(this->total_weight));
     config.set_key_value("total_wipe_tower_cost",     new ConfigOptionFloat(this->total_wipe_tower_cost));
     config.set_key_value("total_wipe_tower_filament", new ConfigOptionFloat(this->total_wipe_tower_filament));
+    config.set_key_value("individual_extruded_volume",  new ConfigOptionFloats(this->individual_extruded_volume));
+    config.set_key_value("individual_used_filament",    new ConfigOptionFloats(this->individual_used_filament));
+    config.set_key_value("individual_weight",           new ConfigOptionFloats(this->individual_weight));
+    config.set_key_value("individual_cost",             new ConfigOptionFloats(this->individual_cost));
     return config;
 }
 
@@ -1260,6 +1264,7 @@ DynamicConfig PrintStatistics::placeholders()
     for (const std::string &key : { 
         "print_time", "normal_print_time", "silent_print_time", 
         "used_filament", "extruded_volume", "total_cost", "total_weight", 
+        "individual_extruded_volume", "individual_used_filament", "individual_weight", "individual_cost",
         "total_toolchanges", "total_wipe_tower_cost", "total_wipe_tower_filament"})
         config.set_key_value(key, new ConfigOptionString(std::string("{") + key + "}"));
     return config;

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -403,6 +403,10 @@ struct PrintStatistics
     double                          total_used_filament;
     double                          total_extruded_volume;
     double                          total_cost;
+    std::vector<double>             individual_extruded_volume;
+    std::vector<double>             individual_used_filament;
+    std::vector<double>             individual_weight;
+    std::vector<double>             individual_cost;
     int                             total_toolchanges;
     double                          total_weight;
     double                          total_wipe_tower_cost;


### PR DESCRIPTION
This patch allows to get statistics for individual extruders in the filename.

Variables added, mirroring the existing total_* values
individual_extruded_volume
individual_used_filament 
individual_weight 
individual_cost 

One example is to use it with if to generate infos about the used extruders and the material presets in the name:

```
{if individual_extruded_volume[0] > 0}_T0-{filament_type[0]}
_T0-PLA
```


```
Setting:
{input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm__{printer_model}_{print_time}{if individual_extruded_volume[0] > 0}_T0-{filament_type[0]}{endif}{if individual_extruded_volume[1] > 0}_T1-{filament_type[1]}{endif}{if individual_extruded_volume[2] > 0}_T2-{filament_type[2]}{endif}{if individual_extruded_volume[3] > 0}_T3-{filament_type[3]}{endif}{if individual_extruded_volume[4] > 0}_T4-{filament_type[4]}{endif}.gcode

Output with E2 and E3 used (T1 and T2)
Gelander Halter v11_0.6n_0.3mm__MK3SMMU2S_1h30m_T1-PETG_T2-PLA.gcode
```

This may need a small change to replace 12 with the configured number of extruders - I didn't find out where to get that from.

