### PR TITLE
For review - Remove trailing zeros from gcode feed rates.

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -10,7 +10,9 @@
 #define FLAVOR_IS_NOT(val) this->config.gcode_flavor != val
 #define COMMENT(comment) if (this->config.gcode_comments && !comment.empty()) gcode << " ; " << comment;
 #define PRECISION(val, precision) std::fixed << std::setprecision(precision) << (val)
-#define XYZF_NUM(val) PRECISION(val, 3)
+#define FLOAT_PRECISION(val, precision) std::defaultfloat << std::setprecision(precision) << (val)
+#define XYZ_NUM(val) PRECISION(val, 3)
+#define F_NUM(val) FLOAT_PRECISION(val, 8)
 #define E_NUM(val) PRECISION(val, 5)
 
 namespace Slic3r {
@@ -293,7 +295,7 @@ std::string GCodeWriter::set_speed(double F, const std::string &comment, const s
     assert(F > 0.);
     assert(F < 100000.);
     std::ostringstream gcode;
-    gcode << "G1 F" << XYZF_NUM(F);
+    gcode << "G1 F" << F_NUM(F);
     COMMENT(comment);
     gcode << cooling_marker;
     gcode << "\n";
@@ -306,9 +308,9 @@ std::string GCodeWriter::travel_to_xy(const Vec2d &point, const std::string &com
     m_pos(1) = point(1);
     
     std::ostringstream gcode;
-    gcode << "G1 X" << XYZF_NUM(point(0))
-          <<   " Y" << XYZF_NUM(point(1))
-          <<   " F" << XYZF_NUM(this->config.travel_speed.value * 60.0);
+    gcode << "G1 X" << XYZ_NUM(point(0))
+          <<   " Y" << XYZ_NUM(point(1))
+          <<   " F" << F_NUM(this->config.travel_speed.value * 60.0);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();
@@ -341,10 +343,10 @@ std::string GCodeWriter::travel_to_xyz(const Vec3d &point, const std::string &co
     m_pos = point;
     
     std::ostringstream gcode;
-    gcode << "G1 X" << XYZF_NUM(point(0))
-          <<   " Y" << XYZF_NUM(point(1))
-          <<   " Z" << XYZF_NUM(point(2))
-          <<   " F" << XYZF_NUM(this->config.travel_speed.value * 60.0);
+    gcode << "G1 X" << XYZ_NUM(point(0))
+          <<   " Y" << XYZ_NUM(point(1))
+          <<   " Z" << XYZ_NUM(point(2))
+          <<   " F" << F_NUM(this->config.travel_speed.value * 60.0);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();
@@ -376,10 +378,10 @@ std::string GCodeWriter::_travel_to_z(double z, const std::string &comment)
     double speed = this->config.travel_speed_z.value;
     if (speed == 0.)
         speed = this->config.travel_speed.value;
-    
+
     std::ostringstream gcode;
     gcode << "G1 Z" << XYZF_NUM(z)
-          <<   " F" << XYZF_NUM(speed * 60.0);
+          <<   " F" << F_NUM(speed * 60.0);
     COMMENT(comment);
     gcode << "\n";
     return gcode.str();
@@ -404,8 +406,8 @@ std::string GCodeWriter::extrude_to_xy(const Vec2d &point, double dE, const std:
     m_extruder->extrude(dE);
     
     std::ostringstream gcode;
-    gcode << "G1 X" << XYZF_NUM(point(0))
-          <<   " Y" << XYZF_NUM(point(1))
+    gcode << "G1 X" << XYZ_NUM(point(0))
+          <<   " Y" << XYZ_NUM(point(1))
           <<    " " << m_extrusion_axis << E_NUM(m_extruder->E());
     COMMENT(comment);
     gcode << "\n";
@@ -419,9 +421,9 @@ std::string GCodeWriter::extrude_to_xyz(const Vec3d &point, double dE, const std
     m_extruder->extrude(dE);
     
     std::ostringstream gcode;
-    gcode << "G1 X" << XYZF_NUM(point(0))
-          <<   " Y" << XYZF_NUM(point(1))
-          <<   " Z" << XYZF_NUM(point(2))
+    gcode << "G1 X" << XYZ_NUM(point(0))
+          <<   " Y" << XYZ_NUM(point(1))
+          <<   " Z" << XYZ_NUM(point(2))
           <<    " " << m_extrusion_axis << E_NUM(m_extruder->E());
     COMMENT(comment);
     gcode << "\n";
@@ -476,7 +478,7 @@ std::string GCodeWriter::_retract(double length, double restart_extra, const std
                 gcode << "G10 ; retract\n";
         } else {
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_extruder->E())
-                           << " F" << XYZF_NUM(m_extruder->retract_speed() * 60.);
+                           << " F" << F_NUM(m_extruder->retract_speed() * 60.);
             COMMENT(comment);
             gcode << "\n";
         }
@@ -506,7 +508,7 @@ std::string GCodeWriter::unretract()
         } else {
             // use G1 instead of G0 because G0 will blend the restart with the previous travel move
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_extruder->E())
-                           << " F" << XYZF_NUM(m_extruder->deretract_speed() * 60.);
+                           << " F" << F_NUM(m_extruder->deretract_speed() * 60.);
             if (this->config.gcode_comments) gcode << " ; unretract";
             gcode << "\n";
         }

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -68,28 +68,28 @@ SCENARIO("lift() is not ignored after unlift() at normal values of Z", "[GCodeWr
     }
 }
 
-SCENARIO("set_speed emits values with fixed-point output.", "[GCodeWriter]") {
+SCENARIO("set_speed emits values with floating-point output, 8 significant digits.", "[GCodeWriter]") {
 
     GIVEN("GCodeWriter instance") {
         GCodeWriter writer;
-        WHEN("set_speed is called to set speed to 99999.123") {
-            THEN("Output string is G1 F99999.123") {
-                REQUIRE_THAT(writer.set_speed(99999.123), Catch::Equals("G1 F99999.123\n"));
+        WHEN("set_speed is called to set speed to 12345.678") {
+            THEN("Output string is G1 F12345.678") {
+                REQUIRE_THAT(writer.set_speed(12345.678), Catch::Equals("G1 F12345.678\n"));
             }
         }
         WHEN("set_speed is called to set speed to 1") {
-            THEN("Output string is G1 F1.000") {
-                REQUIRE_THAT(writer.set_speed(1.0), Catch::Equals("G1 F1.000\n"));
+            THEN("Output string is G1 F1") {
+                REQUIRE_THAT(writer.set_speed(1.0), Catch::Equals("G1 F1\n"));
             }
         }
-        WHEN("set_speed is called to set speed to 203.200022") {
-            THEN("Output string is G1 F203.200") {
-                REQUIRE_THAT(writer.set_speed(203.200022), Catch::Equals("G1 F203.200\n"));
+        WHEN("set_speed is called to set speed to 203.2000022") {
+            THEN("Output string is G1 F203.2") {
+                REQUIRE_THAT(writer.set_speed(203.2000022), Catch::Equals("G1 F203.2\n"));
             }
         }
-        WHEN("set_speed is called to set speed to 203.200522") {
-            THEN("Output string is G1 F203.201") {
-                REQUIRE_THAT(writer.set_speed(203.200522), Catch::Equals("G1 F203.201\n"));
+        WHEN("set_speed is called to set speed to 12345.200522") {
+            THEN("Output string is G1 F12345.201") {
+                REQUIRE_THAT(writer.set_speed(203.200522), Catch::Equals("G1 F12345.201\n"));
             }
         }
     }


### PR DESCRIPTION
Changed the format of feed rates from fixed point with 3 decimal places to floating point with 8 digits of precision. This means the decimal places are retained when necessary and omitted when not required. So

`G1 X16.288 Y28.463 F3600.000` is written out as `G1 X16.288 Y28.463 F3600`

whereas

`G1 X16.288 Y28.463 F3600.123` is written out as `G1 X16.288 Y28.463 F3600.123`

This makes the GCODE more readable and results in a small saving in GCODE file size (about 1%, or 20KB in a 2MB file).
