### PR TITLE
Fixes Linux (and probably MacOS) build: wx/msw/registry.h is only ava…

### DIFF
--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -8,6 +8,7 @@
 #include <Windows.h>
 #include "GUI_App.hpp"
 #include "libslic3r/AppConfig.hpp"
+#include <wx/msw/registry.h>
 #endif
 
 #include <wx/toplevel.h>
@@ -16,7 +17,6 @@
 #include <wx/dcclient.h>
 #include <wx/font.h>
 #include <wx/fontutil.h>
-#include <wx/msw/registry.h>
 
 #include "libslic3r/Config.hpp"
 


### PR DESCRIPTION
…ilable on Windows.

Note that while this fixes the Linux build, I have no way to verify the build on Windows (the order of includes has changed)
