### PR TITLE
Fix non-MSW Windows build

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1365,7 +1365,7 @@ void fatal_error(wxWindow* parent)
     //     exit 1; // #ys_FIXME
 }
 
-#ifdef _WIN32
+#ifdef _MSW_DARK_MODE
 void GUI_App::force_colors_update()
 {
     NppDarkMode::SetDarkMode(app_config->get("dark_color_mode") == "1");


### PR DESCRIPTION
@YuSanka, this fixes a broken build after 4652733201f446f062e37574d4a44f80c1541592. The error is a missing definition for `NppDarkMode::SetDarkMode`. Since the only caller of `GUI_App::force_colors_update()` is behind an _MSW_DARK_MODE guard, I assume the same guard should apply to the definition?