### PR TITLE
Fix bucket/seed fill tooltips

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -346,7 +346,7 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(max_tooltip_width);
-        ImGui::TextUnformatted(_L("Paints neighboring facets whose relative angle is less or equal to set angle.").ToUTF8().data());
+        ImGui::TextUnformatted(_L("Paints neighboring facets that have the same color.").ToUTF8().data());
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
@@ -364,7 +364,7 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(max_tooltip_width);
-        ImGui::TextUnformatted(_L("Paints neighboring that have the same color.").ToUTF8().data());
+        ImGui::TextUnformatted(_L("Paints neighboring facets whose relative angle is less or equal to set angle.").ToUTF8().data());
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }


### PR DESCRIPTION
@hejllukas, it looks like the tooltips for seed and bucket fills are flipped, so here's a tiny patch to fix the text.

Awesome enhancement to the painting feature BTW. It would have saved me some time with this Stitch model I painted a few weeks ago, where I had to repaint the claws and nose after realizing they should dark blue rather than black.

![image](https://user-images.githubusercontent.com/13139373/125972762-af2032ee-2b92-4679-bea9-173c3a4af87e.png)

