### PR TITLE
Replace "Rear" seam option with adjustable "Direction"

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2756,7 +2756,7 @@ std::string GCode::extrude_perimeters(const Print &print, const std::vector<Obje
                 lower_layer_edge_grid = calculate_layer_edge_grid(*m_layer->lower_layer);
 
             m_seam_placer.plan_perimeters(std::vector<const ExtrusionEntity*>(region.perimeters.begin(), region.perimeters.end()),
-                *m_layer, m_config.seam_position, this->last_pos(), EXTRUDER_CONFIG(nozzle_diameter),
+                *m_layer, m_config.seam_position, m_config.seam_preferred_direction, this->last_pos(), EXTRUDER_CONFIG(nozzle_diameter),
                 (m_layer == NULL ? nullptr : m_layer->object()),
                 (lower_layer_edge_grid ? lower_layer_edge_grid.get() : nullptr));
 

--- a/src/libslic3r/GCode/SeamPlacer.hpp
+++ b/src/libslic3r/GCode/SeamPlacer.hpp
@@ -49,21 +49,20 @@ public:
 
 
     void plan_perimeters(const std::vector<const ExtrusionEntity*> perimeters,
-        const Layer& layer, SeamPosition seam_position,
+        const Layer& layer, SeamPosition seam_position, float seam_preferred_direction,
         Point last_pos, coordf_t nozzle_dmr, const PrintObject* po,
         const EdgeGrid::Grid* lower_layer_edge_grid);
 
     void place_seam(ExtrusionLoop& loop, const Point& last_pos, bool external_first, double nozzle_diameter,
                     const EdgeGrid::Grid* lower_layer_edge_grid);
     
-
     using TreeType = AABBTreeIndirect::Tree<2, coord_t>;
     using AlignedBoxType = Eigen::AlignedBox<TreeType::CoordType, TreeType::NumDimensions>;
 
 private:
 
     // When given an external perimeter (!), returns the seam.
-    Point calculate_seam(const Layer& layer, const SeamPosition seam_position,
+    Point calculate_seam(const Layer& layer, const SeamPosition seam_position, const float seam_preferred_direction,
         const ExtrusionLoop& loop, coordf_t nozzle_dmr, const PrintObject* po,
         const EdgeGrid::Grid* lower_layer_edge_grid, Point last_pos, bool prefer_nearest);
 
@@ -83,6 +82,7 @@ private:
         bool external = false;
         const Layer* layer = nullptr;
         SeamPosition seam_position;
+        float seam_preferred_direction;
         const PrintObject* po = nullptr;
     };
     std::vector<SeamPoint> m_plan;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -419,7 +419,7 @@ static std::vector<std::string> s_Preset_print_options {
     "layer_height", "first_layer_height", "perimeters", "spiral_vase", "slice_closing_radius", "slicing_mode",
     "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
     "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs",
-    "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
+    "seam_position", "seam_preferred_direction", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
     "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
     "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first",
     "ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -152,7 +152,7 @@ static t_config_enum_values s_keys_map_SeamPosition {
     { "random",         spRandom },
     { "nearest",        spNearest },
     { "aligned",        spAligned },
-    { "rear",           spRear }
+    { "direction",      spDirection }
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SeamPosition)
 
@@ -2217,35 +2217,21 @@ void PrintConfigDef::init_fff_params()
     def->enum_values.push_back("random");
     def->enum_values.push_back("nearest");
     def->enum_values.push_back("aligned");
-    def->enum_values.push_back("rear");
+    def->enum_values.push_back("direction");
     def->enum_labels.push_back(L("Random"));
     def->enum_labels.push_back(L("Nearest"));
     def->enum_labels.push_back(L("Aligned"));
-    def->enum_labels.push_back(L("Rear"));
+    def->enum_labels.push_back(L("Direction"));
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionEnum<SeamPosition>(spAligned));
 
-#if 0
     def = this->add("seam_preferred_direction", coFloat);
-//    def->gui_type = ConfigOptionDef::GUIType::slider;
-    def->label = L("Direction");
+    def->label = L("Seam position - Preferred direction");
     def->sidetext = L("°");
-    def->full_label = L("Preferred direction of the seam");
-    def->tooltip = L("Seam preferred direction");
+    def->tooltip = L("Preferred direction of seam location.");
     def->min = 0;
     def->max = 360;
     def->set_default_value(new ConfigOptionFloat(0));
-
-    def = this->add("seam_preferred_direction_jitter", coFloat);
-//    def->gui_type = ConfigOptionDef::GUIType::slider;
-    def->label = L("Jitter");
-    def->sidetext = L("°");
-    def->full_label = L("Seam preferred direction jitter");
-    def->tooltip = L("Preferred direction of the seam - jitter");
-    def->min = 0;
-    def->max = 360;
-    def->set_default_value(new ConfigOptionFloat(30));
-#endif
 
     def = this->add("skirt_distance", coFloat);
     def->label = L("Distance from brim/object");
@@ -3846,6 +3832,8 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
         opt_key = "printhost_apikey";
     } else if (opt_key == "preset_name") {
         opt_key = "preset_names";
+    } else if (opt_key == "seam_position" && value == "rear") {
+        value = "direction";
     } /*else if (opt_key == "material_correction" || opt_key == "relative_correction") {
         ConfigOptionFloats p;
         p.deserialize(value);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -98,7 +98,7 @@ enum SupportMaterialInterfacePattern {
 };
 
 enum SeamPosition {
-    spRandom, spNearest, spAligned, spRear
+    spRandom, spNearest, spAligned, spDirection
 };
 
 enum SLAMaterial {
@@ -477,8 +477,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               raft_first_layer_expansion))
     ((ConfigOptionInt,                 raft_layers))
     ((ConfigOptionEnum<SeamPosition>,  seam_position))
-//  ((ConfigOptionFloat,               seam_preferred_direction))
-//  ((ConfigOptionFloat,               seam_preferred_direction_jitter))
+    ((ConfigOptionFloat,               seam_preferred_direction))
     ((ConfigOptionFloat,               slice_closing_radius))
     ((ConfigOptionEnum<SlicingMode>,   slicing_mode))
     ((ConfigOptionBool,                support_material))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -650,7 +650,6 @@ bool PrintObject::invalidate_state_by_config_options(
         } else if (
                opt_key == "seam_position"
             || opt_key == "seam_preferred_direction"
-            || opt_key == "seam_preferred_direction_jitter"
             || opt_key == "support_material_speed"
             || opt_key == "support_material_interface_speed"
             || opt_key == "bridge_speed"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -220,7 +220,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     bool have_perimeters = config->opt_int("perimeters") > 0;
     for (auto el : { "extra_perimeters", "ensure_vertical_shell_thickness", "thin_walls", "overhangs",
                     "seam_position", "external_perimeters_first", "external_perimeter_extrusion_width",
-                    "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed" })
+                    "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed",
+                    "seam_preferred_direction"})
         toggle_field(el, have_perimeters);
 
     bool have_infill = config->option<ConfigOptionPercent>("fill_density")->value > 0;
@@ -317,6 +318,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_avoid_crossing_perimeters = config->opt_bool("avoid_crossing_perimeters");
     toggle_field("avoid_crossing_perimeters_max_detour", have_avoid_crossing_perimeters);
+
+    toggle_field("seam_preferred_direction", config->opt_enum<SeamPosition>("seam_position") == spDirection);
 }
 
 void ConfigManipulation::update_print_sla_config(DynamicPrintConfig* config, const bool is_global_config/* = false*/)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1494,6 +1494,7 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Advanced"));
         optgroup->append_single_option_line("seam_position", category_path + "seam-position");
+        optgroup->append_single_option_line("seam_preferred_direction", category_path + "seam-preferred-direction");
         optgroup->append_single_option_line("external_perimeters_first", category_path + "external-perimeters-first");
         optgroup->append_single_option_line("gap_fill_enabled", category_path + "fill-gaps");
 


### PR DESCRIPTION
This replaces the "Rear" seam option with a preferred seam direction in counterclockwise degrees from 0° to 360° (pictured below). It uses exactly the same logic as the "Rear" seam, such that a direction of 0° is the default and behaves identically to "Rear" (and the `rear` option in legacy configs gets converted to the default `direction` of 0°).

![image](https://user-images.githubusercontent.com/13139373/126193612-0f017123-2240-42c9-9d6e-28e839471fd6.png)

I tried to make this patch as unobtrusive as possible. It uses the existing, nonfunctional `seam_preferred_direction` config option. I also split out the commit that removes the nonfunctional `seam_preferred_direction_jitter` (in case there's a reason to keep it, although both nonfunctional options appear untouched for +4 years).

I did look at keeping the "Rear" option and just expanding the position options to the full set of octants (e.g. rear, rear left, left, front left...), but that felt like it made the dropdown UI too busy and generally just seemed more confusing.

# Rationale for This Change

I keep encountering situations where I want the equivalent of the "Rear" seam behavior, but I can't rotate the model to get the correct spot to the rear because either it's too large or I want to pack the build plate with as many instances as I can (see picture below, where rotating 45° lets me pack several more instances on the plate).

I could of course solve this with seam painting, but that's just a lot more work for cases where a simple direction option will suffice (e.g. in the picture below I'd have to paint the back, legs, claws, hair tufts, ears, etc. for each material) and I have to redo that work any time I reload the object from disk. I'd also note that the current implementation of seam painting isn't great for things like straight lines (but a future update could certainly address that).

![stitch_full_plate_45_degree_seam](https://user-images.githubusercontent.com/13139373/126194444-9255d9da-d200-4b43-9ca8-f77563e8679b.png)
