### PR TITLE
Disable acceleration control if default_acceleration is zero

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2692,7 +2692,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     gcode += this->unretract();
 
     // adjust acceleration
-    {
+    if (m_config.default_acceleration.value > 0) {
         double acceleration;
         if (this->on_first_layer() && m_config.first_layer_acceleration.value > 0) {
             acceleration = m_config.first_layer_acceleration.value;


### PR DESCRIPTION
This is a one-line fix for #3409. It changes the code so that it will now skip applying the advanced acceleration values if `default_acceleration` is zero (or more accurately a non-positive value, but the UI forces negative values to 0).

This is consistent with what the UI already implies is happening (i.e. disabling the other fields when "Default" is 0, as pictured below). It also seems like the only logical solution, since `GCodeWriter::set_acceleration()` will ignore zero acceleration, meaning a 0 value `default_acceleration` prevents the acceleration from being reliably reset when changing between extrusion types, resulting in unexpected acceleration values being applied depending on the exact order of extrusion.

![image](https://user-images.githubusercontent.com/13139373/126802310-768c3cad-813f-431e-aa0c-8b1106365d6a.png)
