### PR TITLE
Add solid_infill_specific_layer expert option

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -420,7 +420,7 @@ const std::vector<std::string>& Preset::print_options()
         "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
         "extra_perimeters", "ensure_vertical_shell_thickness", "avoid_crossing_perimeters", "thin_walls", "overhangs",
         "seam_position", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
-        "infill_every_layers", "infill_only_where_needed", "solid_infill_every_layers", "fill_angle", "bridge_angle",
+        "infill_every_layers", "infill_only_where_needed", "solid_infill_specific_layer", "solid_infill_every_layers", "fill_angle", "bridge_angle",
         "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first",
     	"ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
         "max_print_speed", "max_volumetric_speed", "avoid_crossing_perimeters_max_detour",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2239,6 +2239,17 @@ void PrintConfigDef::init_fff_params()
     def->min = 1;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(1));
+    
+    def = this->add("solid_infill_specific_layer", coInt);
+    def->label = L("Solid infill on specific layer");
+    def->category = L("Infill");
+    def->tooltip = L("This feature allows to force a solid layer on a specific layer number. "
+                   "This is usefull when printing large objects with low infill rate."
+                   "Which avoids printing infill on the gaps between infill");
+    def->sidetext = L("layers");
+    def->min = 0;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionInt(0));
 
     def = this->add("solid_infill_every_layers", coInt);
     def->label = L("Solid infill every");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -555,6 +555,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                solid_infill_below_area))
     ((ConfigOptionInt,                  solid_infill_extruder))
     ((ConfigOptionFloatOrPercent,       solid_infill_extrusion_width))
+    ((ConfigOptionInt,                  solid_infill_specific_layer))
     ((ConfigOptionInt,                  solid_infill_every_layers))
     ((ConfigOptionFloatOrPercent,       solid_infill_speed))
     // Detect thin walls.

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -579,6 +579,7 @@ bool PrintObject::invalidate_state_by_config_options(
                opt_key == "interface_shells"
             || opt_key == "infill_only_where_needed"
             || opt_key == "infill_every_layers"
+            || opt_key == "solid_infill_specific_layer"
             || opt_key == "solid_infill_every_layers"
             || opt_key == "bottom_solid_min_thickness"
             || opt_key == "top_solid_layers"
@@ -1782,8 +1783,9 @@ void PrintObject::discover_horizontal_shells()
             Layer 					*layer  = m_layers[i];
             LayerRegion             *layerm = layer->regions()[region_id];
             const PrintRegionConfig &region_config = layerm->region().config();
-            if (region_config.solid_infill_every_layers.value > 0 && region_config.fill_density.value > 0 &&
-                (i % region_config.solid_infill_every_layers) == 0) {
+            if ((region_config.solid_infill_every_layers.value > 0 && region_config.fill_density.value > 0 &&
+                (i % region_config.solid_infill_every_layers) == 0) || 
+                (region_config.solid_infill_specific_layer.value > 0 && (region_config.solid_infill_specific_layer.value - 1) == i)) {
                 // Insert a solid internal layer. Mark stInternal surfaces as stInternalSolid or stInternalBridge.
                 SurfaceType type = (region_config.fill_density == 100) ? stInternalSolid : stInternalBridge;
                 for (Surface &surface : layerm->fill_surfaces.surfaces)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -241,7 +241,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_infill = config->option<ConfigOptionPercent>("fill_density")->value > 0;
     // infill_extruder uses the same logic as in Print::extruders()
-    for (auto el : { "fill_pattern", "infill_every_layers", "infill_only_where_needed",
+    for (auto el : { "fill_pattern", "infill_every_layers", "infill_only_where_needed", "solid_infill_specific_layer",
                     "solid_infill_every_layers", "solid_infill_below_area", "infill_extruder", "infill_anchor_max" })
         toggle_field(el, have_infill);
     // Only allow configuration of open anchors if the anchoring is enabled.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1490,6 +1490,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("infill_only_where_needed", category_path + "only-infill-where-needed");
 
         optgroup = page->new_optgroup(L("Advanced"));
+        optgroup->append_single_option_line("solid_infill_specific_layer", category_path + "solid-infill-specific-layer");
         optgroup->append_single_option_line("solid_infill_every_layers", category_path + "solid-infill-every-x-layers");
         optgroup->append_single_option_line("fill_angle", category_path + "fill-angle");
         optgroup->append_single_option_line("solid_infill_below_area", category_path + "solid-infill-threshold-area");


### PR DESCRIPTION
When printing big objects with low infill rate (< 10%) the gaps between the infill can to big to do a nice transition. This results in 2 problems, either there's a gap in your print, or it curls upwards and the extruder bumps into it which also degrades print quality.

This PR adds the solid_infill_specific_layer expert option where an user can specify a specific layer to force solid infill from perimeter to perimeter which avoid creating holes, whilst minimizing printing time and material usage.