### PR TITLE
Fix build with Boost 1.77 (missing include)

### DIFF
--- a/src/libslic3r/SLA/Clustering.cpp
+++ b/src/libslic3r/SLA/Clustering.cpp
@@ -1,4 +1,5 @@
 #include "Clustering.hpp"
+#include "boost/geometry.hpp"
 #include "boost/geometry/index/rtree.hpp"
 
 #include <libslic3r/SLA/SpatIndex.hpp>


### PR DESCRIPTION
We're relying on boost::geometry so we need to include the "main"
header for it.

Fixes errors like:
error: ‘boost::geometry::strategy::disjoint’ has not been declared

Bug: https://bugs.gentoo.org/808771