### PR TITLE
Docs update and minor improvements/fixes for build_win.bat

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -163,7 +163,7 @@ IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY deps\build "%PS_DEPS_
 cd deps\build || GOTO :END
 cmake.exe .. -DDESTDIR="%PS_DESTDIR%" || GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE%"
-msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% || GOTO :END
+msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG%  /v:quiet || GOTO :END
 cd ..\..
 IF /I "%PS_STEPS:~0,4%" EQU "deps" GOTO :RUN_APP
 
@@ -183,7 +183,7 @@ FOR /F "tokens=2 delims=," %%I in (
 ) do SET PS_PROJECT_IS_OPEN=%%~I
 cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% || GOTO :END
 REM Skip the build step if we're using the undocumented app-cmake to regenerate the full config from inside devenv
-IF "%PS_STEPS%" NEQ "app-cmake" msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% || GOTO :END
+IF "%PS_STEPS%" NEQ "app-cmake" msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% /v:quiet || GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE_FOR_CONFIG%"
 
 REM Run app

--- a/build_win.bat
+++ b/build_win.bat
@@ -159,7 +159,7 @@ REM Build deps
 :BUILD_DEPS
 SET EXIT_STATUS=3
 SET PS_CURRENT_STEP=deps
-IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY deps\build "%PS_DEPS_PATH_FILE_NAME%"
+IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY deps\build "%PS_DEPS_PATH_FILE_NAME%" .vs
 cd deps\build || GOTO :END
 cmake.exe .. -DDESTDIR="%PS_DESTDIR%" || GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE%"
@@ -171,7 +171,7 @@ REM Build app
 :BUILD_APP
 SET EXIT_STATUS=4
 SET PS_CURRENT_STEP=app
-IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY build "%PS_CUSTOM_RUN_FILE%"
+IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY build "%PS_CUSTOM_RUN_FILE%" .vs
 cd build || GOTO :END
 REM Make sure we have a custom batch file skeleton for the run stage
 set PS_CUSTOM_BAT=%PS_CUSTOM_RUN_FILE%
@@ -262,8 +262,11 @@ REM Functions and stubs start here.
 
 :RESOLVE_DESTDIR_CACHE
 @REM Resolves all DESTDIR cache values and sets PS_STEPS_DEFAULT
-@REM Note: This just sets global variableq, so it doesn't use setlocal.
-SET PS_DEPS_PATH_FILE_FOR_CONFIG=%~dp0build\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%
+@REM Note: This just sets global variables, so it doesn't use setlocal.
+SET PS_DEPS_PATH_FILE_FOR_CONFIG=%~dp0build\.vs\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%
+mkdir "%~dp0build\.vs\%PS_ARCH%\%PS_CONFIG%" > nul 2> nul
+REM Copy a legacy file if we don't have one in the proper location.
+echo f|xcopy /D "%~dp0build\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%" "%PS_DEPS_PATH_FILE_FOR_CONFIG%"
 CALL :CANONICALIZE_PATH PS_DEPS_PATH_FILE_FOR_CONFIG
 IF EXIST "%PS_DEPS_PATH_FILE_FOR_CONFIG%" (
     FOR /F "tokens=* USEBACKQ" %%I IN ("%PS_DEPS_PATH_FILE_FOR_CONFIG%") DO (

--- a/build_win.bat
+++ b/build_win.bat
@@ -65,6 +65,7 @@ SET PS_DESTDIR=
 CALL :RESOLVE_DESTDIR_CACHE
 
 REM Set up parameters used by help menu
+SET EXIT_STATUS=0
 SET PS_CONFIG_DEFAULT=%PS_CONFIG%
 SET PS_ARCH_HOST=%PS_ARCH%
 (echo " -help /help -h /h -? /? ")| findstr /I /C:" %~1 ">nul && GOTO :HELP

--- a/build_win.bat
+++ b/build_win.bat
@@ -161,7 +161,10 @@ SET EXIT_STATUS=3
 SET PS_CURRENT_STEP=deps
 IF "%PS_STEPS_DIRTY%" EQU "" CALL :MAKE_OR_CLEAN_DIRECTORY deps\build "%PS_DEPS_PATH_FILE_NAME%" .vs
 cd deps\build || GOTO :END
-cmake.exe .. -DDESTDIR="%PS_DESTDIR%" || GOTO :END
+cmake.exe .. -DDESTDIR="%PS_DESTDIR%"
+IF %ERRORLEVEL% NEQ 0 IF "%PS_STEPS_DIRTY%" NEQ "" (
+    (del CMakeCache.txt && cmake.exe .. -DDESTDIR="%PS_DESTDIR%") || GOTO :END
+) ELSE GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE%"
 msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG%  /v:quiet || GOTO :END
 cd ..\..
@@ -181,7 +184,10 @@ SET PS_PROJECT_IS_OPEN=
 FOR /F "tokens=2 delims=," %%I in (
     'tasklist /V /FI "IMAGENAME eq devenv.exe " /NH /FO CSV ^| find "%PS_SOLUTION_NAME%"'
 ) do SET PS_PROJECT_IS_OPEN=%%~I
-cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% || GOTO :END
+cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST%
+IF %ERRORLEVEL% NEQ 0 IF "%PS_STEPS_DIRTY%" NEQ "" (
+    (del CMakeCache.txt && cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST%) || GOTO :END
+) ELSE GOTO :END
 REM Skip the build step if we're using the undocumented app-cmake to regenerate the full config from inside devenv
 IF "%PS_STEPS%" NEQ "app-cmake" msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% /v:quiet || GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE_FOR_CONFIG%"

--- a/doc/How to build - Windows.md
+++ b/doc/How to build - Windows.md
@@ -3,7 +3,7 @@
 ### Install the tools
 
 Install Visual Studio Community 2019 from [visualstudio.microsoft.com/vs/](https://visualstudio.microsoft.com/vs/). Older versions are not supported as PrusaSlicer requires support for C++17.
-Select all workload options for C++ 
+Select all workload options for C++ and make sure to launch Visual Studio after install (to ensure that the full setup completes).
 
 Install git for Windows from [gitforwindows.org](https://gitforwindows.org/)
 Download and run the exe accepting all defaults
@@ -16,6 +16,42 @@ c:> mkdir src
 c:> cd src
 c:\src> git clone https://github.com/prusa3d/PrusaSlicer.git
 ```
+
+### Run the automatic build script
+
+The script `build_win.bat` will automatically find the default Visual Studio installation, set up the build environment, and then run both CMake and MSBuild to generate the dependencies and application as needed. If you'd rather do these steps manually, you can skip to the [Manual Build Instructions](#manual-build-instructions) in the next section. Otherwise, just run the following command to get everything going with the default configs:
+
+```
+c:\src>cd c:\src\PrusaSlicer
+c:\src\PrusaSlicer>build_win.bat -d=..\PrusaSlicer-deps -r=console
+```
+
+The build script will run for a while (over an hour, depending on your machine) and automatically perform the following steps:
+1. Configure and build [deps](#compile-the-dependencies) as RelWithDebInfo with `c:\src\PrusaSlicer-deps` as the destination directory
+2. Configure and build all [application targets](#compile-prusaslicer) as RelWithDebInfo
+3. Launch the resulting `prusa-slicer-console.exe` binary
+
+You can change the above command line options to do things like:
+* Change the destination for the dependencies by pointing `-d` to a different directory such as: `build_win.bat -d=s:\PrusaSlicerDeps`
+* Open the solution in Visual Studio after the build completes by changing the `-r` switch to `-r=ide`
+* Generate a release build without debug info by adding `-c=Release` or a full debug build with `-c=Debug`
+* Perform an incremental application build (the default) with: `build_win.bat -s=app-dirty`
+* Clean and rebuild the application: `build_win.bat -s=app`
+* Clean and rebuild the dependencies: `build_win.bat -s=deps`
+* Clean and rebuild everything (app and deps): `build_win.bat -s=all`
+* _The full list of build script options can be listed by running:_ `build_win.bat -?`
+
+### Troubleshooting
+
+You're best off initiating builds from within Visual Studio for day-to-day development. However, the `build_win.bat` script can be very helpful if you run into build failures after updating your source tree. Here are some tips to keep in mind:
+* The last several lines of output from `build_win.bat` will usually have the most helpful error messages.
+* If CMake complains about missing binaries or paths (e.g. after updating Visual Studio), building with `build_win.bat` will force CMake to regenerate its cache on an error.
+* After a deps change, you may just need to rebuild everything with the `-s=all` switch.
+* Reading through the instructions in the next section may help diagnose more complex issues.
+
+# Manual Build Instructions
+
+_Follow the steps below if you want to understand how to perform a manual build, or if you're troubleshooting issues with the automatic build script._
 
 ### Compile the dependencies.
 Dependencies are updated seldomly, thus they are compiled out of the PrusaSlicer source tree.


### PR DESCRIPTION
- Don't delete preferences on clean build
- Reduce msbuild verbosity
- Retry on cmake cache failure
- Don't report an error on help switch
- Update Windows build docs
