### PR TITLE
Fix for #5620

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6030,9 +6030,14 @@ void Plater::force_print_bed_update()
 
 void Plater::on_activate()
 {
-#if defined(__linux__) || defined(_WIN32)
     // Activating the main frame, and no window has keyboard focus.
     // Set the keyboard focus to the visible Canvas3D.
+#if defined(__linux__)
+    if (this->p->view3D->IsShown() && wxWindow::FindFocus() != this->p->view3D->get_wxglcanvas())
+        this->p->view3D->get_wxglcanvas()->SetFocus();
+    else if (this->p->preview->IsShown() && wxWindow::FindFocus() != this->p->view3D->get_wxglcanvas())
+        this->p->preview->get_wxglcanvas()->SetFocus();
+#elif defined(_WIN32)
     if (this->p->view3D->IsShown() && wxWindow::FindFocus() != this->p->view3D->get_wxglcanvas())
         CallAfter([this]() { this->p->view3D->get_wxglcanvas()->SetFocus(); });
     else if (this->p->preview->IsShown() && wxWindow::FindFocus() != this->p->view3D->get_wxglcanvas())


### PR DESCRIPTION
The CallAfter() on Linux causes weird window focus issues.

For me, using ALT-Tab to switch away from PrusaSlicer would cause
PrusaSlicer to take back focus after about one second.  Stranger
things reportedly occur with focus-follows-mouse.

The #ifdef is there because it is assumed the CallAfter() was added
in 20f5b7a for a good reason.