### PR TITLE
Only check printable instances BBs when auto-centering on the bed

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -341,7 +341,8 @@ bool Model::center_instances_around_point(const Vec2d &point)
     BoundingBoxf3 bb;
     for (ModelObject *o : this->objects)
         for (size_t i = 0; i < o->instances.size(); ++ i)
-            bb.merge(o->instance_bounding_box(i, false));
+            if (o->instances[i]->is_printable())
+                bb.merge(o->instance_bounding_box(i, false));
 
     Vec2d shift2 = point - to_2d(bb.center());
 	if (std::abs(shift2(0)) < EPSILON && std::abs(shift2(1)) < EPSILON)


### PR DESCRIPTION
I use the autocenter feature together with arrange - arrange is great but sometimes it still keeps the objects too far away and without autocenter I have to move almost all of them when I only need to nudge one or two.
But this combo does not play well with some instances being set as non-printable, because arrange positions them outside the bed and then autocenter centers everything, pushing at least half the plate out of bounds.

So I implemented this simple fix where autocenter ignores the bounding boxes of non-printable instances of objects when computing the needed move.

Currently it uses the `is_printable()` method so it ignores when a non-printable->printable switch is done with the object outside the plate - you have to either use arrange or manually drag the object to the plate for the autocenter to start taking it into account again. I tested both `is_prinable()` and just the `printable` property and prefer this, because when just `printable` itself is checked, the autocenter kicks in right after the printability change, which will mean everything currently positioned on the plate will jump to the other side instead.