### PR TITLE
Replace OpenProcess with GetCurrentProcess where appropriate

### DIFF
--- a/src/libslic3r/BlacklistedLibraryCheck.cpp
+++ b/src/libslic3r/BlacklistedLibraryCheck.cpp
@@ -33,22 +33,20 @@ std::wstring BlacklistedLibraryCheck::get_blacklisted_string()
 
 bool BlacklistedLibraryCheck::perform_check()
 {   
-    // Get a handle to the process.
-    HANDLE  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, GetCurrentProcessId());
-    if (NULL == hProcess)
-        return false;
+    // Get the pseudo-handle for the current process.
+    HANDLE  hCurrentProcess = GetCurrentProcess();
 
     // Get a list of all the modules in this process.
     HMODULE hMods[1024];
     DWORD   cbNeeded;
-    if (EnumProcessModulesEx(hProcess, hMods, sizeof(hMods), &cbNeeded, LIST_MODULES_ALL))
+    if (EnumProcessModulesEx(hCurrentProcess, hMods, sizeof(hMods), &cbNeeded, LIST_MODULES_ALL))
     {
         //printf("Total Dlls: %d\n", cbNeeded / sizeof(HMODULE));
         for (unsigned int i = 0; i < cbNeeded / sizeof(HMODULE); ++ i)
         {
             wchar_t szModName[MAX_PATH];
             // Get the full path to the module's file.
-            if (GetModuleFileNameExW(hProcess, hMods[i], szModName, MAX_PATH))
+            if (GetModuleFileNameExW(hCurrentProcess, hMods[i], szModName, MAX_PATH))
             {
                 // Add to list if blacklisted
                 if (BlacklistedLibraryCheck::is_blacklisted(szModName)) {
@@ -61,7 +59,6 @@ bool BlacklistedLibraryCheck::perform_check()
         }
     }
 
-    CloseHandle(hProcess);
     //printf("\n");
     return !m_found.empty();
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -984,16 +984,11 @@ std::string log_memory_info(bool ignore_loglevel)
         } PROCESS_MEMORY_COUNTERS_EX, *PPROCESS_MEMORY_COUNTERS_EX;
     #endif /* PROCESS_MEMORY_COUNTERS_EX */
 
-
-        HANDLE hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, ::GetCurrentProcessId());
-        if (hProcess != nullptr) {
-            PROCESS_MEMORY_COUNTERS_EX pmc;
-            if (GetProcessMemoryInfo(hProcess, (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc)))
-                out = " WorkingSet: " + format_memsize_MB(pmc.WorkingSetSize) + "; PrivateBytes: " + format_memsize_MB(pmc.PrivateUsage) + "; Pagefile(peak): " + format_memsize_MB(pmc.PagefileUsage) + "(" + format_memsize_MB(pmc.PeakPagefileUsage) + ")";
-            else
-                out += " Used memory: N/A";
-            CloseHandle(hProcess);
-        }
+        PROCESS_MEMORY_COUNTERS_EX pmc;
+        if (GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc)))
+            out = " WorkingSet: " + format_memsize_MB(pmc.WorkingSetSize) + "; PrivateBytes: " + format_memsize_MB(pmc.PrivateUsage) + "; Pagefile(peak): " + format_memsize_MB(pmc.PagefileUsage) + "(" + format_memsize_MB(pmc.PeakPagefileUsage) + ")";
+        else
+            out += " Used memory: N/A";
 #elif defined(__linux__) or defined(__APPLE__)
         // Get current memory usage.
     #ifdef __APPLE__


### PR DESCRIPTION
`GetCurrentProcess` is the correct call when we're dealing with the current process, because it avoids all the overhead associated with invoking the object manager and creating additional handle contexts. This should also resolve the spurious AV warnings identified in #6878, as there are various reasons why "security" software generally doesn't interfere with operations on the current process pseudo-handle. (Giant caveat: I wrote "should" because I can't make any guarantees about what invasive things AV software will do.)

Also note that I removed the `CloseHandle` calls, because you can't close the pseudo-handle for the current process; the call would succeed, but it doesn't do anything.

@bubnikv, the only two occurences of `OpenProcess` are using the current process, so this seems like an obvious solution for reducing spurious AV alerts.