### PR TITLE
Fix file import/open bug in latest master branch

### DIFF
--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -55,7 +55,6 @@ enum FileType
     FT_OBJ,
     FT_AMF,
     FT_3MF,
-    FT_PRUSA,
     FT_GCODE,
     FT_MODEL,
     FT_PROJECT,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/301935/133289150-d0dfa98f-5934-4ea0-a14d-b805a4e50dd3.png)

I'm not able to import STL files after syncing this commit: 58d8ab3d
The cause is that `FT_PRUSA` file format is removed from `file_wildcards` function, while it's not remove in `FileType` enum.
Hence the order is miss-matched when we querying file_type strings in open-file dialogs.
