### PR TITLE
Fix Windows build after 677cb58

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3691,7 +3691,7 @@ void Plater::priv::create_simplify_notification(const std::vector<size_t>& obj_i
     std::vector<size_t> big_ids;
     big_ids.reserve(obj_ids.size());
     std::copy_if(obj_ids.begin(), obj_ids.end(), std::back_inserter(big_ids),
-                 [this](size_t object_id) {
+                 [&, this](size_t object_id) {
             if (object_id >= model.objects.size()) return false; // out of object index
             ModelVolumePtrs& volumes = model.objects[object_id]->volumes;
             if (volumes.size() != 1) return false; // not only one volume


### PR DESCRIPTION
VS needs a default capture mode to implicitly read uncaptured constants.

@lukasmatena, this is a minor Windows build fix to follow up your change. I didn't move `this` to default capture because I assumed there was a reason you kept it explicit.