### PR TITLE
Fix float accuracy issue that can turn all solid layers above a bridge into bridge flow

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1447,7 +1447,7 @@ void PrintObject::bridge_over_infill()
                 Polygons to_bridge_pp = internal_solid;
                 
                 // iterate through lower layers spanned by bridge_flow
-                double bottom_z = layer->print_z - bridge_flow.height();
+                double bottom_z = layer->print_z - bridge_flow.height() - EPSILON;
                 for (int i = int(layer_it - m_layers.begin()) - 1; i >= 0; --i) {
                     const Layer* lower_layer = m_layers[i];
                     


### PR DESCRIPTION
This is a tiny fix for a floating point accuracy issue that sometimes causes all internal solid infill layers above a bridge layer to use bridging flow. I've attached [bridge_infill_test.zip](https://github.com/prusa3d/PrusaSlicer/files/7173336/bridge_infill_test.zip) (containing bridge_infill_test.3mf) as a reduced test case demonstrating the issue at 0.12mm layer height on a small cylinder with five top layers. If you cycle through the layers you'll find that the three solid layers between the bridge layer and the top layer all use bridging flow, even though they should not.

The bug is in this code:

```
1450                double bottom_z = layer->print_z - bridge_flow.height();
1451                for (int i = int(layer_it - m_layers.begin()) - 1; i >= 0; --i) {
1452                    const Layer* lower_layer = m_layers[i];
1453
1454                    // stop iterating if layer is lower than bottom_z
1455                    if (lower_layer->print_z < bottom_z) break;
```

The problem is that at certain lower layer heights you'll hit a floating point accuracy issue when calculating `bottom_z`, such that it will always be infinitesimally larger than `lower_layer->print_z`, meaning the code will always break out of the loop early and wind up flagging all solid layers above a bridge as bridging flow, up until the top layer.

This PR just subtracts an additional EPSILON from bottom_z, which seems like the norm in nearby code. Also, it doesn't appear that this can be hit with the old style thick bridges, because the larger magnitude of the thick_bridge height will prevent it.

Here's a picture of the print that caused me to discover this bug. It's a special purpose model that had 15 top layers at .12mm, so the excessive cooling caused the layers to curl up and create that bumpy mess over the voids in the hexagonal infill. It was a small, fast print, so no real loss, but it did send me down the rabbit hole of debugging this one.

@bubnikv, I figured it made sense to ask about this one since it's a bug in a new feature for the upcoming release.

![image](https://user-images.githubusercontent.com/13139373/133514897-a16f2a5a-a4f0-42cb-ad49-f8834664049f.png)
