### PR TITLE
Update Anycubic i3 Mega (S) profile

### DIFF
--- a/resources/profiles/Anycubic.ini
+++ b/resources/profiles/Anycubic.ini
@@ -828,34 +828,35 @@ end_gcode = M117 Cooling down...\nM104 S0 ; turn off extruder\nM107 ; Fan off\nM
 bottom_solid_min_thickness = 0.5
 bridge_acceleration = 1000
 bridge_flow_ratio = 0.95
-bridge_speed = 30
+bridge_speed = 25
 compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_ANYCUBIC.*/ and printer_notes=~/.*PRINTER_MODEL_I3_MEGA.*/  and nozzle_diameter[0]==0.4
 default_acceleration = 1000
 ensure_vertical_shell_thickness = 1
 external_perimeter_extrusion_width = 0.45
-external_perimeter_speed = 25
+external_perimeter_speed = 40
 extruder_clearance_height = 35
 extruder_clearance_radius = 60
 extrusion_width = 0.45
 fill_density = 15%
 fill_pattern = gyroid
-first_layer_acceleration = 1000
+first_layer_acceleration = 800
 first_layer_extrusion_width = 0.42
 first_layer_height = 0.2
 first_layer_speed = 20
 gap_fill_speed = 40
-gcode_comments = 1
+gcode_comments = 0
+gcode_label_objects = 1
 infill_acceleration = 1000
 infill_anchor = 2.5
 infill_anchor_max = 12
 infill_extrusion_width = 0.45
-max_print_speed = 200
+max_print_speed = 100
 min_skirt_length = 4
 only_retract_when_crossing_perimeters = 0
 output_filename_format = {input_filename_base}_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode
 perimeter_acceleration = 800
 perimeter_extrusion_width = 0.45
-perimeter_speed = 45
+perimeter_speed = 50
 perimeters = 2
 seam_position = nearest
 skirt_distance = 2
@@ -864,24 +865,23 @@ skirts = 1
 small_perimeter_speed = 25
 solid_infill_below_area = 0
 solid_infill_extrusion_width = 0.45
-solid_infill_speed = 80
-support_material_buildplate_only = 1
+solid_infill_speed = 50
+support_material = 0
+support_material_buildplate_only = 0
 support_material_contact_distance = 0.1
 support_material_extrusion_width = 0.35
 support_material_interface_layers = 2
 support_material_interface_spacing = 0.2
+support_material_interface_speed = 80%
 support_material_spacing = 2
 support_material_speed = 50
-support_material_threshold = 55
+support_material_threshold = 50
+support_material_xy_spacing = 60%
 thin_walls = 0
 top_infill_extrusion_width = 0.4
 top_solid_infill_speed = 40
-top_solid_layers = 5
-top_solid_min_thickness = 0.6
+top_solid_min_thickness = 0.7
 travel_speed = 180
-
-[print:*supported_mega*]
-support_material = 1
 
 # XXXXXXXXXXXXXXXXXXXX
 # XXX--- 0.15mm ---XXX
@@ -890,14 +890,13 @@ support_material = 1
 [print:*0.15mm_mega*]
 inherits = *common_mega*
 bottom_solid_layers = 5
+bridge_flow_ratio = 1
+infill_speed = 60
 layer_height = 0.15
 top_solid_layers = 7
 
 [print:0.15mm QUALITY @MEGA]
 inherits = *0.15mm_mega*
-
-[print:0.15mm QUALITY SUPPORTED @MEGA]
-inherits = *0.15mm_mega*;*supported_mega*
 
 # XXXXXXXXXXXXXXXXXXXX
 # XXX--- 0.20mm ---XXX
@@ -906,14 +905,12 @@ inherits = *0.15mm_mega*;*supported_mega*
 [print:*0.20mm_mega*]
 inherits = *common_mega*
 bottom_solid_layers = 4
+infill_speed = 60
 layer_height = 0.2
 top_solid_layers = 5
 
 [print:0.20mm QUALITY @MEGA]
 inherits = *0.20mm_mega*
-
-[print:0.20mm QUALITY SUPPORTED @MEGA]
-inherits = *0.20mm_mega*;*supported_mega*
 
 # XXXXXXXXXXXXXXXXXXXX
 # XXX--- 0.30mm ---XXX
@@ -925,12 +922,11 @@ bottom_solid_layers = 4
 external_perimeter_extrusion_width = 0.6
 external_perimeter_speed = 35
 extrusion_width = 0.5
-fill_pattern = grid
+fill_pattern = cubic
 infill_extrusion_width = 0.5
 infill_speed = 85
 layer_height = 0.3
 perimeter_extrusion_width = 0.5
-perimeter_speed = 50
 small_perimeter_speed = 30
 solid_infill_extrusion_width = 0.5
 support_material_extrusion_width = 0.38
@@ -939,9 +935,6 @@ top_solid_layers = 4
 
 [print:0.30mm DRAFT @MEGA]
 inherits = *0.30mm_mega*
-
-[print:0.30mm DRAFT SUPPORTED @MEGA]
-inherits = *0.30mm_mega*;*supported_mega*
 
 # XXXXXXXXXXXXXXXXXXXXXX
 # XXX--- filament ---XXX
@@ -1092,6 +1085,14 @@ first_layer_temperature = 215
 min_fan_speed = 100
 temperature = 210
 
+[filament:DAS FILAMENT PETG @MEGA]
+inherits = *PETG_mega*
+filament_vendor = DAS FILAMENT
+bed_temperature = 75
+first_layer_bed_temperature = 75
+first_layer_temperature = 220
+temperature = 225
+
 [filament:*PLA_mega*]
 inherits = *common_mega*
 bed_temperature = 60
@@ -1166,7 +1167,7 @@ bed_shape = 0x0,210x0,210x210,0x210
 before_layer_gcode = ;BEFORE_LAYER_CHANGE\nG92 E0.0\n;[layer_z]
 default_filament_profile = Generic PLA @MEGA
 default_print_profile = 0.15mm QUALITY @MEGA
-deretract_speed = 40
+deretract_speed = 50
 end_gcode = G1 E-1.0 F2100 ; retract\nG92 E0.0\nG1{if max_layer_z < max_print_height} Z{z_offset+min(max_layer_z+30, max_print_height)}{endif} E-34.0 F720 ; move print head up & retract filament\nG4 ; wait\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y105 F3000 ; park print head\nM84 ; disable motors
 extruder_colour = #808080
 gcode_flavor = marlin
@@ -1177,10 +1178,10 @@ remaining_times = 1
 retract_before_travel = 1.5
 retract_before_wipe = 60%
 retract_layer_change = 1
-retract_length = 3.2
-retract_lift = 0.2
+retract_length = 6
+retract_lift = 0.075
 retract_lift_below = 204
-retract_speed = 70
+retract_speed = 40
 silent_mode = 0
 start_gcode = G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM204 S[machine_max_acceleration_extruding] T[machine_max_acceleration_retracting]\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nG28 ; home all\nG1 Y1.0 Z0.3 F1000 ; move print head up\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG92 E0.0\n; initial load\nG1 X205.0 E19 F1000\nG1 Y1.6\nG1 X5.0 E19 F1000\nG92 E0.0\n; intro line\nG1 Y2.0 Z0.2 F1000\nG1 X65.0 E9.0 F1000\nG1 X105.0 E12.5 F1000\nG92 E0.0
 thumbnails = 16x16,220x124


### PR DESCRIPTION
- revert retraction settings as previous change causes issues with stringing.
  See also the discussion at https://github.com/prusa3d/PrusaSlicer-settings/pull/131#issuecomment-862191690
- sync many settings with Prusa MK2 profile and some with Prusa MK3 profile.
- remove no longer needed SUPPORTED print settings. Support settings can now be selected directly in the PrusaSlicer menu.
- add DAS FILAMENT PETG profile.

I tested these changes with good results on our printer. @Igami, feel free to test and please let me know if you see any issues with these changes.