### PR TITLE
Fix missing `wx/timer.h` header compile issue

### DIFF
--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -5,6 +5,7 @@
 #include "GUI_Utils.hpp"
 
 #include <wx/dialog.h>
+#include <wx/timer.h>
 #include <map>
 
 class wxColourPickerCtrl;


### PR DESCRIPTION
Tried to compile the latest git version on my system and got an error that wxTimer could not be found. Fixed it by adding in the header.

cc @kocikdav