### PR TITLE
<details> enclosing OpenGL extensions: add empty line after <summary>

### DIFF
--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -186,7 +186,7 @@ std::string OpenGLManager::GLInfo::to_string(bool for_github) const
 
         if (!extensions_list.empty()) {
             if (for_github)
-                out << "<details>\n<summary>Installed extensions:</summary>\n";
+                out << "<details>\n<summary>Installed extensions:</summary>\n\n";
             else
                 out << h2_start << "Installed extensions:" << h2_end << line_end;
 


### PR DESCRIPTION
:warning: I did not test the change. I just assume it's the correct solution.

In the implementation for #6830 a line break is missing.
See examples of Current Implementation and Fix adding an empty line.

```
<details>
<summary>Current Implementation:</summary>
GL_3DFX_texture_compression_FXT1
GL_ARB_ES2_compatibility
GL_ARB_ES3_compatibility
GL_ARB_arrays_of_arrays
GL_ARB_base_instance
...
</details>
```
<details>
<summary>Current Implementation:</summary>
GL_3DFX_texture_compression_FXT1
GL_ARB_ES2_compatibility
GL_ARB_ES3_compatibility
GL_ARB_arrays_of_arrays
GL_ARB_base_instance
...
</details>

```
<details>
<summary>Fix adding an empty line:</summary>

GL_3DFX_texture_compression_FXT1
GL_ARB_ES2_compatibility
GL_ARB_ES3_compatibility
GL_ARB_arrays_of_arrays
GL_ARB_base_instance
...
</details>
```
<details>
<summary>Fix adding an empty line:</summary>

GL_3DFX_texture_compression_FXT1
GL_ARB_ES2_compatibility
GL_ARB_ES3_compatibility
GL_ARB_arrays_of_arrays
GL_ARB_base_instance
...
</details>