### PR TITLE
Fix build on linux/clang 13

### DIFF
--- a/src/libslic3r/Geometry/Circle.cpp
+++ b/src/libslic3r/Geometry/Circle.cpp
@@ -2,6 +2,9 @@
 
 #include "../Polygon.hpp"
 
+#include <numeric>
+#include <boost/log/trivial.hpp>
+
 namespace Slic3r { namespace Geometry {
 
 Point circle_center_taubin_newton(const Points::const_iterator& input_begin, const Points::const_iterator& input_end, size_t cycles)

--- a/src/libslic3r/Geometry/Circle.hpp
+++ b/src/libslic3r/Geometry/Circle.hpp
@@ -1,6 +1,10 @@
 #ifndef slic3r_Geometry_Circle_hpp_
 #define slic3r_Geometry_Circle_hpp_
 
+#include "../Point.hpp"
+
+#include <Eigen/Geometry>
+
 namespace Slic3r { namespace Geometry {
 
 /// Find the center of the circle corresponding to the vector of Points as an arc.

--- a/src/libslic3r/Geometry/MedialAxis.cpp
+++ b/src/libslic3r/Geometry/MedialAxis.cpp
@@ -1,5 +1,7 @@
 #include "MedialAxis.hpp"
 
+#include "clipper.hpp"
+
 #ifdef SLIC3R_DEBUG
 namespace boost { namespace polygon {
 

--- a/src/libslic3r/Geometry/MedialAxis.hpp
+++ b/src/libslic3r/Geometry/MedialAxis.hpp
@@ -2,6 +2,7 @@
 #define slic3r_Geometry_MedialAxis_hpp_
 
 #include "Voronoi.hpp"
+#include "../ExPolygon.hpp"
 
 namespace Slic3r { namespace Geometry {
 

--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -1253,9 +1253,9 @@ namespace client
                 |   (kw["random"] > '(' > conditional_expression(_r1) [_val = _1] > ',' > conditional_expression(_r1) > ')') 
                                                                     [ px::bind(&MyContext::random<Iterator>, _r1, _val, _2) ]
                 |   (kw["digits"] > '(' > conditional_expression(_r1) [_val = _1] > ',' > conditional_expression(_r1) > optional_parameter(_r1))
-                                                                    [ px::bind(&expr<Iterator>::digits<false>, _val, _2, _3) ]
+                                                                    [ px::bind(&expr<Iterator>::template digits<false>, _val, _2, _3) ]
                 |   (kw["zdigits"] > '(' > conditional_expression(_r1) [_val = _1] > ',' > conditional_expression(_r1) > optional_parameter(_r1))
-                                                                    [ px::bind(&expr<Iterator>::digits<true>, _val, _2, _3) ]
+                                                                    [ px::bind(&expr<Iterator>::template digits<true>, _val, _2, _3) ]
                 |   (kw["int"]   > '(' > conditional_expression(_r1) > ')') [ px::bind(&FactorActions::to_int,  _1, _val) ]
                 |   (kw["round"] > '(' > conditional_expression(_r1) > ')') [ px::bind(&FactorActions::round,   _1, _val) ]
                 |   (strict_double > iter_pos)                      [ px::bind(&FactorActions::double_, _1, _2, _val) ]


### PR DESCRIPTION
Include a few missing headers required during the build under linux.

In src/libslic3r/PlaceholderParser.cpp:1256, disambiguate the nested template function with the "template" keyword to avoid an expression parsing failure (required at least for clang 13).
