### PR TITLE
Add support for reading the SML model format

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -82,6 +82,8 @@ add_library(libslic3r STATIC
     Format/STL.hpp
     Format/SL1.hpp
     Format/SL1.cpp
+    Format/SML.hpp
+    Format/SML.cpp
     GCode/ThumbnailData.cpp
     GCode/ThumbnailData.hpp
     GCode/CoolingBuffer.cpp

--- a/src/libslic3r/Format/SML.cpp
+++ b/src/libslic3r/Format/SML.cpp
@@ -1,0 +1,199 @@
+#include "../libslic3r.h"
+#include "../Model.hpp"
+#include "../TriangleMesh.hpp"
+
+#include "SML.hpp"
+
+#include <string>
+
+#include <boost/log/trivial.hpp>
+
+#ifdef _WIN32
+#define DIR_SEPARATOR '\\'
+#else
+#define DIR_SEPARATOR '/'
+#endif
+
+namespace Slic3r {
+
+bool load_sml(const char *path, TriangleMesh *meshptr)
+{
+    if (meshptr == nullptr)
+        return false;
+
+
+    FILE *pFile = boost::nowide::fopen(path, "rb");
+    if (pFile == 0)
+        return false;
+
+    char header[4];
+    if (::fread(header, 4, 1, pFile) != 1) {
+        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Could not read the header.";
+        return false;
+    }
+    if (memcmp(header, "SML1", 4)) {
+        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". The header was invalid.";
+        return false;
+    }
+
+    uint32_t crc;
+    if (::fread(&crc, 4, 1, pFile) != 1) {
+        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Could not read the header.";
+        return false;
+    }
+    // FIXME Should actually check if the file matches the CRC.
+
+    indexed_triangle_set its;
+
+    uint8_t type;
+    uint32_t length;
+    while (::fread(&type, 1, 1, pFile) == 1) {
+        if (::fread(&length, 4, 1, pFile) != 1) {
+            BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+            return false;
+        }
+
+        switch (type) {
+            default: // Unsupported segment type
+            case 0: // Comment
+                ::fseek(pFile, length, SEEK_CUR);
+                break;
+
+            case 1: { // Float vertex list
+                uint32_t num_vertices = length / 12; // 3x4 bytes per vertex
+                its.vertices.reserve(its.vertices.size() + num_vertices);
+
+                float coords[3];
+
+                for (uint32_t i = 0; i < num_vertices; ++ i) {
+                    if (::fread(coords, 4, 3, pFile) != 3) {
+                        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                        return false;
+                    }
+                    its.vertices.emplace_back(coords[0], coords[1], coords[2]);
+                }
+            } break;
+
+            case 2: { // Double vertex list
+                uint32_t num_vertices = length / 24; // 3x8 bytes per vertex
+                its.vertices.reserve(its.vertices.size() + num_vertices);
+
+                double coords[3];
+
+                for (uint32_t i = 0; i < num_vertices; ++ i) {
+                    if (::fread(coords, 8, 3, pFile) != 3) {
+                        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                        return false;
+                    }
+                    its.vertices.emplace_back(coords[0], coords[1], coords[2]);
+                }
+            } break;
+
+            case 3: { // Triangle list
+                uint32_t num_faces = length / 12; // 3x4 bytes per triangle
+                its.indices.reserve(its.indices.size() + num_faces);
+
+                uint32_t indices[3];
+
+                for (uint32_t i = 0; i < num_faces; ++ i) {
+                    if (::fread(indices, 4, 3, pFile) != 3) {
+                        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                        return false;
+                    }
+                    its.indices.emplace_back(indices[0], indices[1], indices[2]);
+                }
+            } break;
+            case 4: { // Quad list
+                uint32_t num_faces = length / 16; // 4x4 bytes per triangle
+                its.indices.reserve(its.indices.size() + num_faces);
+
+                uint32_t indices[4];
+
+                for (uint32_t i = 0; i < num_faces; ++ i) {
+                    if (::fread(indices, 4, 4, pFile) != 4) {
+                        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                        return false;
+                    }
+                    its.indices.emplace_back(indices[0], indices[1], indices[2]);
+                    its.indices.emplace_back(indices[0], indices[2], indices[3]);
+                }
+            } break;
+
+            case 5: { // Triangle strip
+                uint32_t num_points = length / 4;
+                // In testing it turned out to be vastly faster to NOT reserve space, and let libstdc++'s algorithms do it.
+                //uint32_t num_faces = (num_points - 2) * 3;
+                //its.indices.reserve(its.indices.size() + num_faces);
+
+                uint32_t indices[3];
+                if (::fread(indices, 4, 3, pFile) != 3) {
+                    BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                    return false;
+                }
+                its.indices.emplace_back(indices[0], indices[1], indices[2]);
+
+                for (uint32_t i = 3; i < num_points; ++ i) {
+                    indices[i & 1] = indices[2];
+
+                    if (::fread(&indices[2], 4, 1, pFile) != 1) {
+                        BOOST_LOG_TRIVIAL(error) << "load_sml: failed to parse " << path << ". Truncated segment.";
+                        return false;
+                    }
+
+                    its.indices.emplace_back(indices[0], indices[1], indices[2]);
+                }
+            } break;
+        }
+    }
+
+    ::fclose(pFile);
+
+    *meshptr = TriangleMesh(std::move(its));
+    if (meshptr->empty()) {
+        BOOST_LOG_TRIVIAL(error) << "load_sml: This SML file couldn't be read because it's empty. " << path;
+        return false;
+    }
+    if (meshptr->volume() < 0)
+        meshptr->flip_triangles();
+    return true;
+}
+
+bool load_sml(const char *path, Model *model, const char *object_name_in)
+{
+    TriangleMesh mesh;
+
+    bool ret = load_sml(path, &mesh);
+
+    if (ret) {
+        std::string  object_name;
+        if (object_name_in == nullptr) {
+            const char *last_slash = strrchr(path, DIR_SEPARATOR);
+            object_name.assign((last_slash == nullptr) ? path : last_slash + 1);
+        } else
+           object_name.assign(object_name_in);
+
+        model->add_object(object_name.c_str(), path, std::move(mesh));
+    }
+
+    return ret;
+}
+
+bool store_sml(const char *path, TriangleMesh *mesh)
+{
+    // FIXME Implement this.
+    return true;
+}
+
+bool store_sml(const char *path, ModelObject *model_object)
+{
+    // FIXME Implement this.
+    return true;
+}
+
+bool store_sml(const char *path, Model *model)
+{
+    // FIXME Implement this.
+    return true;
+}
+
+}; // namespace Slic3r

--- a/src/libslic3r/Format/SML.hpp
+++ b/src/libslic3r/Format/SML.hpp
@@ -1,0 +1,20 @@
+#ifndef slic3r_Format_SML_hpp_
+#define slic3r_Format_SML_hpp_
+
+namespace Slic3r {
+
+class TriangleMesh;
+class Model;
+class ModelObject;
+
+// Load an OBJ file into a provided model.
+extern bool load_sml(const char *path, TriangleMesh *mesh);
+extern bool load_sml(const char *path, Model *model, const char *object_name = nullptr);
+
+extern bool store_sml(const char *path, TriangleMesh *mesh);
+extern bool store_sml(const char *path, ModelObject *model);
+extern bool store_sml(const char *path, Model *model);
+
+}; // namespace Slic3r
+
+#endif /* slic3r_Format_SML_hpp_ */

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -11,6 +11,7 @@
 #include "Format/OBJ.hpp"
 #include "Format/STL.hpp"
 #include "Format/3mf.hpp"
+#include "Format/SML.hpp"
 
 #include <float.h>
 
@@ -149,8 +150,10 @@ Model Model::read_from_file(const std::string& input_file, DynamicPrintConfig* c
     else if (boost::algorithm::iends_with(input_file, ".3mf"))
         //FIXME options & LoadAttribute::CheckVersion ? 
         result = load_3mf(input_file.c_str(), *config, *config_substitutions, &model, false);
+	else if (boost::algorithm::iends_with(input_file, ".sml"))
+		result = load_sml(input_file.c_str(), &model);
     else
-        throw Slic3r::RuntimeError("Unknown file format. Input file must have .stl, .obj, .amf(.xml) or .prusa extension.");
+        throw Slic3r::RuntimeError("Unknown file format. Input file must have .stl, .obj, .amf(.xml), .sml or .prusa extension.");
 
     if (! result)
         throw Slic3r::RuntimeError("Loading of a model file failed.");

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -150,8 +150,8 @@ Model Model::read_from_file(const std::string& input_file, DynamicPrintConfig* c
     else if (boost::algorithm::iends_with(input_file, ".3mf"))
         //FIXME options & LoadAttribute::CheckVersion ? 
         result = load_3mf(input_file.c_str(), *config, *config_substitutions, &model, false);
-	else if (boost::algorithm::iends_with(input_file, ".sml"))
-		result = load_sml(input_file.c_str(), &model);
+    else if (boost::algorithm::iends_with(input_file, ".sml"))
+        result = load_sml(input_file.c_str(), &model);
     else
         throw Slic3r::RuntimeError("Unknown file format. Input file must have .stl, .obj, .amf(.xml), .sml or .prusa extension.");
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -431,8 +431,9 @@ wxString file_wildcards(FileType file_type, const std::string &custom_extension)
         /* FT_OBJ */     "OBJ files (*.obj)|*.obj;*.OBJ",
         /* FT_AMF */     "AMF files (*.amf)|*.zip.amf;*.amf;*.AMF;*.xml;*.XML",
         /* FT_3MF */     "3MF files (*.3mf)|*.3mf;*.3MF;",
+        /* FT_SML */     "SML files (*.sml)|*.sml;*.SML;",
         /* FT_GCODE */   "G-code files (*.gcode, *.gco, *.g, *.ngc)|*.gcode;*.GCODE;*.gco;*.GCO;*.g;*.G;*.ngc;*.NGC",
-        /* FT_MODEL */   "Known files (*.stl, *.obj, *.amf, *.xml, *.3mf, *.prusa)|*.stl;*.STL;*.obj;*.OBJ;*.amf;*.AMF;*.xml;*.XML;*.3mf;*.3MF",
+        /* FT_MODEL */   "Known files (*.stl, *.obj, *.amf, *.xml, *.3mf, *.sml, *.prusa)|*.stl;*.STL;*.obj;*.OBJ;*.amf;*.AMF;*.xml;*.XML;*.3mf;*.3MF;*.sml;*.SML",
         /* FT_PROJECT */ "Project files (*.3mf, *.amf)|*.3mf;*.3MF;*.amf;*.AMF",
         /* FT_GALLERY */ "Known files (*.stl, *.obj)|*.stl;*.STL;*.obj;*.OBJ",
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -55,6 +55,7 @@ enum FileType
     FT_OBJ,
     FT_AMF,
     FT_3MF,
+    FT_SML,
     FT_GCODE,
     FT_MODEL,
     FT_PROJECT,

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -75,12 +75,12 @@ void KBShortcutsDialog::fill_shortcuts()
         Shortcuts commands_shortcuts = {
             // File
             { ctrl + "N", L("New project, clear plater") },
-            { ctrl + "O", L("Open project STL/OBJ/AMF/3MF with config, clear plater") },
+            { ctrl + "O", L("Open project STL/OBJ/AMF/3MF/SML with config, clear plater") },
             { ctrl + "S", L("Save project (3mf)") },
             { ctrl + alt + "S", L("Save project as (3mf)") },
             { ctrl + "R", L("(Re)slice") },
             // File>Import
-            { ctrl + "I", L("Import STL/OBJ/AMF/3MF without config, keep plater") },
+            { ctrl + "I", L("Import STL/OBJ/AMF/3MF/SML without config, keep plater") },
             { ctrl + "L", L("Import Config from ini/amf/3mf/gcode") },
             { ctrl + alt + "L", L("Load Config from ini/amf/3mf/gcode and merge") },
             // File>Export

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1204,7 +1204,7 @@ void MainFrame::init_menubar_as_editor()
         fileMenu->AppendSeparator();
 
         wxMenu* import_menu = new wxMenu();
-        append_menu_item(import_menu, wxID_ANY, _L("Import STL/OBJ/AM&F/3MF") + dots + "\tCtrl+I", _L("Load a model"),
+        append_menu_item(import_menu, wxID_ANY, _L("Import STL/OBJ/AM&F/3MF/SML") + dots + "\tCtrl+I", _L("Load a model"),
             [this](wxCommandEvent&) { if (m_plater) m_plater->add_model(); }, "import_plater", nullptr,
             [this](){return m_plater != nullptr; }, this);
         

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5294,7 +5294,7 @@ void ProjectDropDialog::on_dpi_changed(const wxRect& suggested_rect)
 
 bool Plater::load_files(const wxArrayString& filenames)
 {
-    const std::regex pattern_drop(".*[.](stl|obj|amf|3mf|prusa)", std::regex::icase);
+    const std::regex pattern_drop(".*[.](stl|obj|amf|3mf|sml|prusa)", std::regex::icase);
     const std::regex pattern_gcode_drop(".*[.](gcode|g)", std::regex::icase);
 
     std::vector<fs::path> paths;


### PR DESCRIPTION
The growing size of STL files in the 3D printing community has started to become a problem. The SML file format is designed to be significantly smaller while containing the same functional data -- in the area of 1/3 to 1/4 of the original size in my tests -- while remaining compressible and easily-implemented.

While this is a new format without significant support, I figured I have to start somewhere, and contributing code to my favourite slicer seemed like a good place.

If you're interested in this, I can write and contribute exporting code as well.