### PR TITLE
Avoid exclusion zones in custom bed texture during Arrange (fixes #3866)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ local-lib
 /.vscode/
 build-linux/*
 deps/build-linux/*
+deps/build
+TAGS

--- a/src/libslic3r/BoundingBox.hpp
+++ b/src/libslic3r/BoundingBox.hpp
@@ -68,8 +68,8 @@ public:
         return ! (this->max(0) < other.min(0) || this->min(0) > other.max(0) ||
                   this->max(1) < other.min(1) || this->min(1) > other.max(1));
     }
-    bool operator==(const BoundingBoxBase<PointClass> &rhs) { return this->min == rhs.min && this->max == rhs.max; }
-    bool operator!=(const BoundingBoxBase<PointClass> &rhs) { return ! (*this == rhs); }
+    bool operator==(const BoundingBoxBase<PointClass> &rhs) const { return this->min == rhs.min && this->max == rhs.max; }
+    bool operator!=(const BoundingBoxBase<PointClass> &rhs) const { return ! (*this == rhs); }
 };
 
 template <class PointClass>

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -215,6 +215,29 @@ std::string escape_ampersand(const std::string& str)
     return std::string(out.data(), outptr - out.data());
 }
 
+std::string serializeBoundingBox(const BoundingBox& bb)
+{
+    std::ostringstream ss;
+    ss << bb.min.x() << "x" << bb.min.y() << "," << bb.max.x() << "x" << bb.max.y();
+    return ss.str();
+}
+    
+bool deserializeBoundingBox(const std::string &str, BoundingBox* dest)
+{
+    std::istringstream is(str);
+    for (auto& target : {&(dest->min), &(dest->max)}) {
+        std::string point_str;
+        if (!std::getline(is, point_str, ',')) return false;
+        std::istringstream iss(point_str);
+        std::string coord_str;
+        if (!std::getline(iss, coord_str, 'x')) return false;
+        std::istringstream(coord_str) >> target->x();
+        if (!std::getline(iss, coord_str, 'x')) return false;
+        std::istringstream(coord_str) >> target->y();
+    }
+    return true;
+}
+
 void ConfigOptionDeleter::operator()(ConfigOption* p) {
     delete p;
 }
@@ -269,6 +292,8 @@ ConfigOption* ConfigOptionDef::create_empty_option() const
 	    case coBool:            return new ConfigOptionBool();
 	    case coBools:           return new ConfigOptionBools();
 	    case coEnum:            return new ConfigOptionEnumGeneric(this->enum_keys_map);
+	    case coBoundingBox:     return new ConfigOptionBoundingBox();
+	    case coBoundingBoxes:   return new ConfigOptionBoundingBoxes();
 	    default:                throw ConfigurationError(std::string("Unknown option type for option ") + this->label);
 	    }
 	}
@@ -1301,6 +1326,8 @@ CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBool)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBools)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBoolsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionEnumGeneric)
+CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBoundingBox)
+CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBoundingBoxes)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigBase)
 CEREAL_REGISTER_TYPE(Slic3r::DynamicConfig)
 
@@ -1337,4 +1364,6 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<bool>, Slic3r::C
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<unsigned char>, Slic3r::ConfigOptionBools)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<unsigned char>, Slic3r::ConfigOptionBoolsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionInt, Slic3r::ConfigOptionEnumGeneric)
+CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<Slic3r::BoundingBox>, Slic3r::ConfigOptionBoundingBox)
+CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<Slic3r::BoundingBox>, Slic3r::ConfigOptionBoundingBoxes)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigBase, Slic3r::DynamicConfig)

--- a/src/libslic3r/Polygon.hpp
+++ b/src/libslic3r/Polygon.hpp
@@ -77,6 +77,7 @@ public:
 
 inline bool operator==(const Polygon &lhs, const Polygon &rhs) { return lhs.points == rhs.points; }
 inline bool operator!=(const Polygon &lhs, const Polygon &rhs) { return lhs.points != rhs.points; }
+inline bool operator<(const Polygon &l, const Polygon &r) { return l.points < r.points; }
 
 BoundingBox get_extents(const Polygon &poly);
 BoundingBox get_extents(const Polygons &polygons);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -472,7 +472,8 @@ static std::vector<std::string> s_Preset_machine_limits_options {
 
 static std::vector<std::string> s_Preset_printer_options {
     "printer_technology",
-    "bed_shape", "bed_custom_texture", "bed_custom_model", "z_offset", "gcode_flavor", "use_relative_e_distances",
+    "bed_shape", "bed_custom_texture", "bed_custom_model", "bed_avoid_boundingboxes", "bed_avoid_boundingboxes_color", "bed_enable_avoid_boundingboxes",
+    "z_offset", "gcode_flavor", "use_relative_e_distances",
     "use_firmware_retraction", "use_volumetric_e", "variable_layer_height",
     //FIXME the print host keys are left here just for conversion from the Printer preset to Physical Printer preset.
     "host_type", "print_host", "printhost_apikey", "printhost_cafile",
@@ -553,7 +554,8 @@ static std::vector<std::string> s_Preset_sla_material_options {
 
 static std::vector<std::string> s_Preset_sla_printer_options {
     "printer_technology",
-    "bed_shape", "bed_custom_texture", "bed_custom_model", "max_print_height",
+    "bed_shape", "bed_custom_texture", "bed_custom_model", "bed_avoid_boundingboxes", "bed_avoid_boundingboxes_color", "bed_enable_avoid_boundingboxes",
+    "max_print_height",
     "display_width", "display_height", "display_pixels_x", "display_pixels_y",
     "display_mirror_x", "display_mirror_y",
     "display_orientation",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -232,6 +232,20 @@ void PrintConfigDef::init_common_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
 
+    def = this->add("bed_avoid_boundingboxes", coBoundingBoxes);
+    def->label = L("Bed avoid boundingboxes");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBoundingBoxes());
+
+    def = this->add("bed_enable_avoid_boundingboxes", coBool);
+    def->label = L("Bed should avoid boundingboxes whose stroke color matches bed_avoid_boundingboxes_color");
+    def->set_default_value(new ConfigOptionBool { false });
+
+    def = this->add("bed_avoid_boundingboxes_color", coString);
+    def->label = L("Bed stroke avoid color");
+    def->tooltip = L("The RGB stroke color of polygons to avoid in the bed's texture (only works with SVG). Empty means unset.");
+    def->set_default_value(new ConfigOptionString("#FF0000"));
+
     def = this->add("elefant_foot_compensation", coFloat);
     def->label = L("Elephant foot compensation");
     def->category = L("Advanced");

--- a/src/slic3r/GUI/BedShapeDialog.hpp
+++ b/src/slic3r/GUI/BedShapeDialog.hpp
@@ -1,7 +1,7 @@
 #ifndef slic3r_BedShapeDialog_hpp_
 #define slic3r_BedShapeDialog_hpp_
 // The bed shape dialog.
-// The dialog opens from Print Settins tab->Bed Shape : Set...
+// The dialog opens from Printer Settings tab->Bed Shape : Set...
 
 #include "GUI_Utils.hpp"
 #include "2DBed.hpp"
@@ -79,16 +79,22 @@ class BedShapePanel : public wxPanel
     std::vector<Vec2d> m_loaded_shape;
     std::string        m_custom_texture;
     std::string        m_custom_model;
+    std::vector<BoundingBox> m_avoid_boundingboxes;
+    bool m_enable_avoid_boundingboxes;
+    std::string m_avoid_boundingboxes_color;
 
 public:
-    BedShapePanel(wxWindow* parent) : wxPanel(parent, wxID_ANY), m_custom_texture(NONE), m_custom_model(NONE) {}
+    BedShapePanel(wxWindow* parent) : wxPanel(parent, wxID_ANY), m_custom_texture(NONE), m_custom_model(NONE), m_enable_avoid_boundingboxes(false), m_avoid_boundingboxes_color("") {}
 
-    void build_panel(const ConfigOptionPoints& default_pt, const ConfigOptionString& custom_texture, const ConfigOptionString& custom_model);
+    void build_panel(const ConfigOptionPoints& default_pt, const ConfigOptionString& custom_texture, const ConfigOptionString& custom_model, const ConfigOptionBoundingBoxes& avoid_boundingboxes, const ConfigOptionBool& enable_avoid_boundingboxes, const ConfigOptionString avoid_boundingboxes_color);
 
     // Returns the resulting bed shape polygon. This value will be stored to the ini file.
     const std::vector<Vec2d>& get_shape() const { return m_shape; }
     const std::string& get_custom_texture() const { return (m_custom_texture != NONE) ? m_custom_texture : EMPTY_STRING; }
     const std::string& get_custom_model() const { return (m_custom_model != NONE) ? m_custom_model : EMPTY_STRING; }
+    const std::vector<BoundingBox>& get_avoid_boundingboxes() const { return m_avoid_boundingboxes; }
+    const bool get_enable_avoid_boundingboxes() const { return m_enable_avoid_boundingboxes; }
+    const std::string get_avoid_boundingboxes_color() const { return m_avoid_boundingboxes_color; }
 
 private:
     ConfigOptionsGroupShp	init_shape_options_page(const wxString& title);
@@ -100,6 +106,7 @@ private:
 	void		update_shape();
 	void		load_stl();
     void		load_texture();
+    void		populate_avoid_boundingboxes(const Vec2d& bed_rect_size);
     void		load_model();
 
 	wxChoicebook*	m_shape_options_book;
@@ -115,11 +122,14 @@ public:
 	BedShapeDialog(wxWindow* parent) : DPIDialog(parent, wxID_ANY, _(L("Bed Shape")),
         wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {}
 
-    void build_dialog(const ConfigOptionPoints& default_pt, const ConfigOptionString& custom_texture, const ConfigOptionString& custom_model);
+    void build_dialog(const ConfigOptionPoints& default_pt, const ConfigOptionString& custom_texture, const ConfigOptionString& custom_model, const ConfigOptionBoundingBoxes& avoid_boundingboxes, const ConfigOptionBool& enable_avoid_boundingboxes, const ConfigOptionString avoid_boundingboxes_color);
 
     const std::vector<Vec2d>& get_shape() const { return m_panel->get_shape(); }
     const std::string& get_custom_texture() const { return m_panel->get_custom_texture(); }
     const std::string& get_custom_model() const { return m_panel->get_custom_model(); }
+    const std::vector<BoundingBox>& get_avoid_boundingboxes() const { return m_panel->get_avoid_boundingboxes(); }
+    const bool get_enable_avoid_boundingboxes() const { return m_panel->get_enable_avoid_boundingboxes(); }
+    const std::string get_avoid_boundingboxes_color() const { return m_panel->get_avoid_boundingboxes_color(); }
 
 protected:
     void on_dpi_changed(const wxRect &suggested_rect) override;

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1394,7 +1394,10 @@ PageBedShape::PageBedShape(ConfigWizard *parent)
 
     shape_panel->build_panel(*wizard_p()->custom_config->option<ConfigOptionPoints>("bed_shape"),
         *wizard_p()->custom_config->option<ConfigOptionString>("bed_custom_texture"),
-        *wizard_p()->custom_config->option<ConfigOptionString>("bed_custom_model"));
+        *wizard_p()->custom_config->option<ConfigOptionString>("bed_custom_model"),
+        *wizard_p()->custom_config->option<ConfigOptionBoundingBoxes>("bed_avoid_boundingboxes"),
+        *wizard_p()->custom_config->option<ConfigOptionBool>("bed_enable_avoid_boundingboxes"),
+        *wizard_p()->custom_config->option<ConfigOptionString>("bed_avoid_boundingboxes_color"));
 
     append(shape_panel);
 }
@@ -1404,9 +1407,15 @@ void PageBedShape::apply_custom_config(DynamicPrintConfig &config)
     const std::vector<Vec2d>& points = shape_panel->get_shape();
     const std::string& custom_texture = shape_panel->get_custom_texture();
     const std::string& custom_model = shape_panel->get_custom_model();
+    const std::vector<BoundingBox>& avoid_boundingboxes = shape_panel->get_avoid_boundingboxes();
+    const bool enable_avoid_boundingboxes = shape_panel->get_enable_avoid_boundingboxes();
+    const std::string avoid_boundingboxes_color = shape_panel->get_avoid_boundingboxes_color();
     config.set_key_value("bed_shape", new ConfigOptionPoints(points));
     config.set_key_value("bed_custom_texture", new ConfigOptionString(custom_texture));
     config.set_key_value("bed_custom_model", new ConfigOptionString(custom_model));
+    config.set_key_value("bed_avoid_boundingboxes", new ConfigOptionBoundingBoxes(avoid_boundingboxes));
+    config.set_key_value("bed_enable_avoid_boundingboxes", new ConfigOptionBool(enable_avoid_boundingboxes));
+    config.set_key_value("bed_avoid_boundingboxes_color", new ConfigOptionString(avoid_boundingboxes_color));
 }
 
 static void focus_event(wxFocusEvent& e, wxTextCtrl* ctrl, double def_value) 
@@ -2793,7 +2802,7 @@ ConfigWizard::ConfigWizard(wxWindow *parent)
 
     p->load_vendors();
     p->custom_config.reset(DynamicPrintConfig::new_from_defaults_keys({
-        "gcode_flavor", "bed_shape", "bed_custom_texture", "bed_custom_model", "nozzle_diameter", "filament_diameter", "temperature", "bed_temperature",
+        "gcode_flavor", "bed_shape", "bed_custom_texture", "bed_custom_model", "bed_avoid_boundingboxes", "nozzle_diameter", "filament_diameter", "temperature", "bed_temperature",
     }));
 
     p->index = new ConfigWizardIndex(this);

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -196,6 +196,9 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 			config.option<ConfigOptionPoints>(opt_key)->set_at(vec_new, opt_index, 0);
 			}
 			break;
+                case coBoundingBoxes:
+                        config.option<ConfigOptionBoundingBoxes>(opt_key)->values = boost::any_cast<std::vector<BoundingBox>>(value);
+                        break;
 		case coNone:
 			break;
 		default:

--- a/src/slic3r/GUI/Jobs/ArrangeJob.cpp
+++ b/src/slic3r/GUI/Jobs/ArrangeJob.cpp
@@ -1,5 +1,7 @@
 #include "ArrangeJob.hpp"
 
+#include <boost/log/trivial.hpp>
+
 #include "libslic3r/MTUtils.hpp"
 #include "libslic3r/Model.hpp"
 
@@ -16,32 +18,33 @@
 namespace Slic3r { namespace GUI {
 
 // Cache the wti info
-class WipeTower: public GLCanvas3D::WipeTowerInfo {
+class WipeTower : public GLCanvas3D::WipeTowerInfo
+{
     using ArrangePolygon = arrangement::ArrangePolygon;
+
 public:
     explicit WipeTower(const GLCanvas3D::WipeTowerInfo &wti)
         : GLCanvas3D::WipeTowerInfo(wti)
     {}
-    
+
     explicit WipeTower(GLCanvas3D::WipeTowerInfo &&wti)
         : GLCanvas3D::WipeTowerInfo(std::move(wti))
     {}
 
-    void apply_arrange_result(const Vec2d& tr, double rotation)
+    void apply_arrange_result(const Vec2d &tr, double rotation)
     {
-        m_pos = unscaled(tr); m_rotation = rotation;
+        m_pos      = unscaled(tr);
+        m_rotation = rotation;
         apply_wipe_tower();
     }
-    
+
     ArrangePolygon get_arrange_polygon() const
     {
-        Polygon ap({
-            {scaled(m_bb.min)},
-            {scaled(m_bb.max.x()), scaled(m_bb.min.y())},
-            {scaled(m_bb.max)},
-            {scaled(m_bb.min.x()), scaled(m_bb.max.y())}
-            });
-        
+        Polygon ap({{scaled(m_bb.min)},
+                    {scaled(m_bb.max.x()), scaled(m_bb.min.y())},
+                    {scaled(m_bb.max)},
+                    {scaled(m_bb.min.x()), scaled(m_bb.max.y())}});
+
         ArrangePolygon ret;
         ret.poly.contour = std::move(ap);
         ret.translation  = scaled(m_pos);
@@ -60,12 +63,11 @@ static WipeTower get_wipe_tower(const Plater &plater)
 void ArrangeJob::clear_input()
 {
     const Model &model = m_plater->model();
-    
+
     size_t count = 0, cunprint = 0; // To know how much space to reserve
     for (auto obj : model.objects)
-        for (auto mi : obj->instances)
-            mi->printable ? count++ : cunprint++;
-    
+        for (auto mi : obj->instances) mi->printable ? count++ : cunprint++;
+
     m_selected.clear();
     m_unselected.clear();
     m_unprintable.clear();
@@ -75,12 +77,14 @@ void ArrangeJob::clear_input()
     m_unprintable.reserve(cunprint /* for optional wti */);
 }
 
-void ArrangeJob::prepare_all() {
+void ArrangeJob::prepare_all()
+{
     clear_input();
-    
-    for (ModelObject *obj: m_plater->model().objects)
+
+    for (ModelObject *obj : m_plater->model().objects)
         for (ModelInstance *mi : obj->instances) {
-            ArrangePolygons & cont = mi->printable ? m_selected : m_unprintable;
+            ArrangePolygons &cont = mi->printable ? m_selected :
+                                                    m_unprintable;
             cont.emplace_back(get_arrange_poly_(mi));
         }
 
@@ -88,43 +92,43 @@ void ArrangeJob::prepare_all() {
         m_selected.emplace_back(std::move(*wti));
 }
 
-void ArrangeJob::prepare_selected() {
+void ArrangeJob::prepare_selected()
+{
     clear_input();
-    
-    Model &model = m_plater->model();
+
+    Model &model  = m_plater->model();
     double stride = bed_stride(m_plater);
-    
+
     std::vector<const Selection::InstanceIdxsList *>
-            obj_sel(model.objects.size(), nullptr);
-    
+        obj_sel(model.objects.size(), nullptr);
+
     for (auto &s : m_plater->get_selection().get_content())
         if (s.first < int(obj_sel.size()))
             obj_sel[size_t(s.first)] = &s.second;
-    
+
     // Go through the objects and check if inside the selection
     for (size_t oidx = 0; oidx < model.objects.size(); ++oidx) {
-        const Selection::InstanceIdxsList * instlist = obj_sel[oidx];
-        ModelObject *mo = model.objects[oidx];
-        
+        const Selection::InstanceIdxsList *instlist = obj_sel[oidx];
+        ModelObject                       *mo       = model.objects[oidx];
+
         std::vector<bool> inst_sel(mo->instances.size(), false);
-        
+
         if (instlist)
-            for (auto inst_id : *instlist)
-                inst_sel[size_t(inst_id)] = true;
-        
+            for (auto inst_id : *instlist) inst_sel[size_t(inst_id)] = true;
+
         for (size_t i = 0; i < inst_sel.size(); ++i) {
-            ModelInstance * mi = mo->instances[i];
+            ModelInstance   *mi = mo->instances[i];
             ArrangePolygon &&ap = get_arrange_poly_(mi);
 
             ArrangePolygons &cont = mo->instances[i]->printable ?
-                        (inst_sel[i] ? m_selected :
-                                       m_unselected) :
-                        m_unprintable;
-            
+                                        (inst_sel[i] ? m_selected :
+                                                       m_unselected) :
+                                        m_unprintable;
+
             cont.emplace_back(std::move(ap));
         }
     }
-    
+
     if (auto wti = get_wipe_tower(*m_plater)) {
         ArrangePolygon &&ap = get_arrange_poly(wti, m_plater);
 
@@ -132,10 +136,10 @@ void ArrangeJob::prepare_selected() {
                                                                  m_unselected;
         cont.emplace_back(std::move(ap));
     }
-    
+
     // If the selection was empty arrange everything
     if (m_selected.empty()) m_selected.swap(m_unselected);
-    
+
     // The strides have to be removed from the fixed items. For the
     // arrangeable (selected) items bed_idx is ignored and the
     // translation is irrelevant.
@@ -149,8 +153,7 @@ arrangement::ArrangePolygon ArrangeJob::get_arrange_poly_(ModelInstance *mi)
     auto setter = ap.setter;
     ap.setter = [this, setter, mi](const arrangement::ArrangePolygon &set_ap) {
         setter(set_ap);
-        if (!set_ap.is_arranged())
-            m_unarranged.emplace_back(mi);
+        if (!set_ap.is_arranged()) m_unarranged.emplace_back(mi);
     };
 
     return ap;
@@ -164,8 +167,7 @@ void ArrangeJob::prepare()
 void ArrangeJob::on_exception(const std::exception_ptr &eptr)
 {
     try {
-        if (eptr)
-            std::rethrow_exception(eptr);
+        if (eptr) std::rethrow_exception(eptr);
     } catch (libnest2d::GeometryException &) {
         show_error(m_plater, _(L("Could not arrange model objects! "
                                  "Some geometries may be invalid.")));
@@ -180,15 +182,30 @@ void ArrangeJob::process()
 
     arrangement::ArrangeParams params = get_arrange_params(m_plater);
 
-    auto count = unsigned(m_selected.size() + m_unprintable.size());
+    auto   count  = unsigned(m_selected.size() + m_unprintable.size());
     Points bedpts = get_bed_shape(*m_plater->config());
-    
+
     params.stopcondition = [this]() { return was_canceled(); };
-    
+
     params.progressind = [this, count](unsigned st) {
         st += m_unprintable.size();
         if (st > 0) update_status(int(count - st), arrangestr);
     };
+
+    auto* cobb = m_plater->config()->option<ConfigOptionBoundingBoxes>("bed_avoid_boundingboxes");
+    if (cobb) {
+        for (const auto& bb : cobb->values) {
+            ArrangePolygon ap;
+            ap.poly.contour = Polygon(Points({
+                        Point(bb.min.x(), bb.min.y()),
+                        Point(bb.max.x(), bb.min.y()),
+                        Point(bb.max.x(), bb.max.y()),
+                        Point(bb.min.x(), bb.max.y())
+                    }));
+            ap.bed_idx = 0;
+            m_unselected.emplace_back(std::move(ap));                
+        }
+    }
 
     arrangement::arrange(m_selected, m_unselected, bedpts, params);
 
@@ -199,38 +216,37 @@ void ArrangeJob::process()
     arrangement::arrange(m_unprintable, {}, bedpts, params);
 
     // finalize just here.
-    update_status(int(count),
-                  was_canceled() ? _(L("Arranging canceled."))
-                                   : _(L("Arranging done.")));
+    update_status(int(count), was_canceled() ? _(L("Arranging canceled.")) :
+                                               _(L("Arranging done.")));
 }
 
 static std::string concat_strings(const std::set<std::string> &strings,
-                                  const std::string &delim = "\n")
+                                  const std::string           &delim = "\n")
 {
-    return std::accumulate(
-        strings.begin(), strings.end(), std::string(""),
-        [delim](const std::string &s, const std::string &name) {
-            return s + name + delim;
-        });
+    return std::accumulate(strings.begin(), strings.end(), std::string(""),
+                           [delim](const std::string &s,
+                                   const std::string &name) {
+                               return s + name + delim;
+                           });
 }
 
-void ArrangeJob::finalize() {
+void ArrangeJob::finalize()
+{
     // Ignore the arrange result if aborted.
     if (was_canceled()) return;
-    
+
     // Unprintable items go to the last virtual bed
     int beds = 0;
-    
+
     // Apply the arrange result to all selected objects
     for (ArrangePolygon &ap : m_selected) {
         beds = std::max(ap.bed_idx, beds);
         ap.apply();
     }
-    
+
     // Get the virtual beds from the unselected items
-    for (ArrangePolygon &ap : m_unselected)
-        beds = std::max(ap.bed_idx, beds);
-    
+    for (ArrangePolygon &ap : m_unselected) beds = std::max(ap.bed_idx, beds);
+
     // Move the unprintable items to the last virtual bed.
     for (ArrangePolygon &ap : m_unprintable) {
         ap.bed_idx += beds + 1;
@@ -245,16 +261,17 @@ void ArrangeJob::finalize() {
         for (ModelInstance *mi : m_unarranged)
             names.insert(mi->get_object()->name);
 
-        m_plater->get_notification_manager()->push_notification(GUI::format(
-            _L("Arrangement ignored the following objects which can't fit into a single bed:\n%s"),
-            concat_strings(names, "\n")));
+        m_plater->get_notification_manager()->push_notification(
+            GUI::format(_L("Arrangement ignored the following objects which "
+                           "can't fit into a single bed:\n%s"),
+                        concat_strings(names, "\n")));
     }
 
     Job::finalize();
 }
 
-std::optional<arrangement::ArrangePolygon>
-get_wipe_tower_arrangepoly(const Plater &plater)
+std::optional<arrangement::ArrangePolygon> get_wipe_tower_arrangepoly(
+    const Plater &plater)
 {
     if (auto wti = get_wipe_tower(plater))
         return get_arrange_poly(wti, &plater);
@@ -262,14 +279,15 @@ get_wipe_tower_arrangepoly(const Plater &plater)
     return {};
 }
 
-double bed_stride(const Plater *plater) {
+double bed_stride(const Plater *plater)
+{
     double bedwidth = plater->bed_shape_bb().size().x();
     return scaled<double>((1. + LOGICAL_BED_GAP) * bedwidth);
 }
 
 template<>
 arrangement::ArrangePolygon get_arrange_poly(ModelInstance *inst,
-                                             const Plater * plater)
+                                             const Plater  *plater)
 {
     return get_arrange_poly(PtrWrapper{inst}, plater);
 }
@@ -277,7 +295,7 @@ arrangement::ArrangePolygon get_arrange_poly(ModelInstance *inst,
 arrangement::ArrangeParams get_arrange_params(Plater *p)
 {
     const GLCanvas3D::ArrangeSettings &settings =
-        static_cast<const GLCanvas3D*>(p->canvas3D())->get_arrange_settings();
+        static_cast<const GLCanvas3D *>(p->canvas3D())->get_arrange_settings();
 
     arrangement::ArrangeParams params;
     params.allow_rotations  = settings.enable_rotation;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1917,7 +1917,8 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     : q(q)
     , main_frame(main_frame)
     , config(Slic3r::DynamicPrintConfig::new_from_defaults_keys({
-        "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "skirts", "skirt_distance",
+        "bed_shape", "bed_custom_texture", "bed_custom_model", "bed_avoid_boundingboxes", "bed_avoid_boundingboxes_color", "bed_enable_avoid_boundingboxes",
+        "complete_objects", "duplicate_distance", "extruder_clearance_radius", "skirts", "skirt_distance",
         "brim_width", "brim_separation", "brim_type", "variable_layer_height", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle", "wipe_tower_brim_width",
         "extruder_colour", "filament_colour", "material_colour", "max_print_height", "printer_model", "printer_technology",
@@ -6234,7 +6235,7 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
             p->reset_gcode_toolpaths();
             p->view3D->get_canvas3d()->reset_sequential_print_clearance();
         }
-        else if (opt_key == "bed_shape" || opt_key == "bed_custom_texture" || opt_key == "bed_custom_model") {
+        else if (opt_key == "bed_shape" || opt_key == "bed_custom_texture" || opt_key == "bed_custom_model" || opt_key == "bed_avoid_boundingboxes" || opt_key == "bed_avoid_boundingboxes_color" || opt_key == "bed_enable_avoid_boundingboxes") {
             bed_shape_changed = true;
             update_scheduled = true;
         }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3840,28 +3840,40 @@ wxSizer* TabPrinter::create_bed_shape_widget(wxWindow* parent)
             BedShapeDialog dlg(this);
             dlg.build_dialog(*m_config->option<ConfigOptionPoints>("bed_shape"),
                 *m_config->option<ConfigOptionString>("bed_custom_texture"),
-                *m_config->option<ConfigOptionString>("bed_custom_model"));
+                *m_config->option<ConfigOptionString>("bed_custom_model"),
+                *m_config->option<ConfigOptionBoundingBoxes>("bed_avoid_boundingboxes"),
+                *m_config->option<ConfigOptionBool>("bed_enable_avoid_boundingboxes"),
+                *m_config->option<ConfigOptionString>("bed_avoid_boundingboxes_color"));
             if (dlg.ShowModal() == wxID_OK) {
                 const std::vector<Vec2d>& shape = dlg.get_shape();
                 const std::string& custom_texture = dlg.get_custom_texture();
                 const std::string& custom_model = dlg.get_custom_model();
+                const std::vector<BoundingBox>& avoid_boundingboxes = dlg.get_avoid_boundingboxes();
+                const bool enable_avoid_boundingboxes = dlg.get_enable_avoid_boundingboxes();
+                const std::string& avoid_boundingboxes_color = dlg.get_avoid_boundingboxes_color();
                 if (!shape.empty())
                 {
                     load_key_value("bed_shape", shape);
                     load_key_value("bed_custom_texture", custom_texture);
                     load_key_value("bed_custom_model", custom_model);
+                    load_key_value("bed_avoid_boundingboxes", avoid_boundingboxes);
+                    load_key_value("bed_enable_avoid_boundingboxes", enable_avoid_boundingboxes);
+                    load_key_value("bed_avoid_boundingboxes_color", avoid_boundingboxes_color);
                     update_changed_ui();
                 }
             }
         }));
 
     // may be it is not a best place, but 
-    // add information about Category/Grope for "bed_custom_texture" and "bed_custom_model" as a copy from "bed_shape" option
+    // add information about Category/Group keys related to the "bed_shape" option
     {
         Search::OptionsSearcher& searcher = wxGetApp().sidebar().get_searcher();
         const Search::GroupAndCategory& gc = searcher.get_group_and_category("bed_shape");
         searcher.add_key("bed_custom_texture", m_type, gc.group, gc.category);
         searcher.add_key("bed_custom_model", m_type, gc.group, gc.category);
+        searcher.add_key("bed_avoid_boundingboxes", m_type, gc.group, gc.category);
+        searcher.add_key("bed_enable_avoid_boundingboxes", m_type, gc.group, gc.category);
+        searcher.add_key("bed_avoid_boundingboxes_color", m_type, gc.group, gc.category);
     }
 
     return sizer;


### PR DESCRIPTION
Makes auto-arrangement avoid parts of the bed that are marked with a
(solid, opaque) stroke color.

# New controls
This adds a new pair of controls (checkbox+colorpicker) to the Printer Settings -> Bed Shape -> Set panel: 
![image](https://user-images.githubusercontent.com/114212/140985931-6009c927-9e56-4a01-90db-7800d2d6f90e.png)
# Before (ignores bed texture ovals):
![image](https://user-images.githubusercontent.com/114212/140986001-5987b4b7-dfae-4d75-825c-5af2493b1c8f.png)
# After (avoids bed texture ovals):
![image](https://user-images.githubusercontent.com/114212/140986011-ec091824-3dd1-4325-b11b-e1c6c653fcb4.png)
