### PR TITLE
Add missing setupapi.lib to slic3rutils tests

### DIFF
--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -4,6 +4,9 @@ add_executable(${_TEST_NAME}_tests
     )
 
 target_link_libraries(${_TEST_NAME}_tests test_common libslic3r_gui libslic3r)
+if (MSVC)
+    target_link_libraries(${_TEST_NAME}_tests Setupapi.lib)
+endif ()
 set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
 
 # catch_discover_tests(${_TEST_NAME}_tests TEST_PREFIX "${_TEST_NAME}: ")


### PR DESCRIPTION
This fixes a linker error on Windows after eddcd93e826a0e526e2a00fedaf136bdd25a1855 (I think). I'm not a CMake person and unclear on the preferred style for adding library dependencies, so I just went with the leaf node.

/CC @bubnikv