### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ local-lib
 /.vscode/
 build-linux/*
 deps/build-linux/*
+**/.DS_Store


### PR DESCRIPTION
When developing on OSX, the os creates .DS_Store index files that clutter up the git working tree. 

Add this to the .gitignore file so those index files will never be included accidentally

Additional information

https://stackoverflow.com/questions/18393498/gitignore-all-the-ds-store-files-in-every-folder-and-subfolder