### PR TITLE
Fix Compare Presets dialog

### DIFF
--- a/resources/localization/PrusaSlicer.pot
+++ b/resources/localization/PrusaSlicer.pot
@@ -5765,7 +5765,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/PrusaSlicer.pot
+++ b/resources/localization/PrusaSlicer.pot
@@ -8850,7 +8850,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, possible-boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/PrusaSlicer.pot
+++ b/resources/localization/PrusaSlicer.pot
@@ -8833,7 +8833,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/cs/PrusaSlicer_cs.po
+++ b/resources/localization/cs/PrusaSlicer_cs.po
@@ -6100,7 +6100,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Zobrazit okno s frontou nahrávání do tiskového serveru"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Porovnání přednastavení"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/cs/PrusaSlicer_cs.po
+++ b/resources/localization/cs/PrusaSlicer_cs.po
@@ -9504,7 +9504,7 @@ msgid "Extruders count"
 msgstr "Počet extruderů"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Zobrazit všechna přednastavení (včetně nekompatibilních)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/cs/PrusaSlicer_cs.po
+++ b/resources/localization/cs/PrusaSlicer_cs.po
@@ -9521,8 +9521,8 @@ msgstr "Porovnání přednastavení"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "Porovnat %1% Přednastavení"
+msgid "Compare Presets"
+msgstr "Porovnat přednastavení"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -9618,8 +9618,8 @@ msgstr "Voreinstellungen vergleichen"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "%1% Voreinstellungen vergleichen"
+msgid "Compare Presets"
+msgstr "Voreinstellungen vergleichen"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -9601,7 +9601,7 @@ msgid "Extruders count"
 msgstr "Extruder Anzahl"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Alle Voreinstellungen anzeigen (auch inkompatible)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -6158,7 +6158,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Zeige das Druckhost Warteschlangenfenster"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Voreinstellungen vergleichen"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/en/PrusaSlicer_en.po
+++ b/resources/localization/en/PrusaSlicer_en.po
@@ -8859,7 +8859,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/en/PrusaSlicer_en.po
+++ b/resources/localization/en/PrusaSlicer_en.po
@@ -8842,7 +8842,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/en/PrusaSlicer_en.po
+++ b/resources/localization/en/PrusaSlicer_en.po
@@ -5774,7 +5774,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/es/PrusaSlicer_es.po
+++ b/resources/localization/es/PrusaSlicer_es.po
@@ -9549,7 +9549,7 @@ msgid "Extruders count"
 msgstr "Contador de extrusores"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Mostrar todos los ajustes (incluidos los incompatibles)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/es/PrusaSlicer_es.po
+++ b/resources/localization/es/PrusaSlicer_es.po
@@ -6138,7 +6138,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Mostrar la ventana de la cola de carga del host de impresión"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Comparar justes"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/es/PrusaSlicer_es.po
+++ b/resources/localization/es/PrusaSlicer_es.po
@@ -9566,8 +9566,8 @@ msgstr "Comparar  Ajustes"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "Comparar %1% Ajustes"
+msgid "Compare Presets"
+msgstr "Comparar Ajustes"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/fr/PrusaSlicer_fr.po
+++ b/resources/localization/fr/PrusaSlicer_fr.po
@@ -6183,7 +6183,7 @@ msgstr ""
 "d'Impression"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Comparer les Préréglages"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/fr/PrusaSlicer_fr.po
+++ b/resources/localization/fr/PrusaSlicer_fr.po
@@ -9646,8 +9646,8 @@ msgstr "Comparer les préréglages"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "Comparer %1% Préréglages"
+msgid "Compare Presets"
+msgstr "Comparer Préréglages"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/fr/PrusaSlicer_fr.po
+++ b/resources/localization/fr/PrusaSlicer_fr.po
@@ -9629,7 +9629,7 @@ msgid "Extruders count"
 msgstr "Nombre d'extrudeurs"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Afficher tous les préréglages (y compris incompatibles)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -9559,8 +9559,8 @@ msgstr "Confronta Preset"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "Confronta i preset %1%"
+msgid "Compare Presets"
+msgstr "Confronta i preset"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -9542,7 +9542,7 @@ msgid "Extruders count"
 msgstr "Conteggio estrusori"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Mostra tutti i preset (compresi quelli incompatibili)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -6144,7 +6144,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Mostra la finestra della fila di caricamento all'host di stampa"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Confronta i preset"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ja/PrusaSlicer_ja.po
+++ b/resources/localization/ja/PrusaSlicer_ja.po
@@ -5902,7 +5902,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "プリントサーバーのアップロードキュー画面を表示する"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ja/PrusaSlicer_ja.po
+++ b/resources/localization/ja/PrusaSlicer_ja.po
@@ -9067,7 +9067,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/ja/PrusaSlicer_ja.po
+++ b/resources/localization/ja/PrusaSlicer_ja.po
@@ -9050,7 +9050,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/ko/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko/PrusaSlicer_ko_KR.po
@@ -8967,7 +8967,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/ko/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko/PrusaSlicer_ko_KR.po
@@ -8984,7 +8984,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/ko/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko/PrusaSlicer_ko_KR.po
@@ -5835,7 +5835,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "호스트 업로드 대기열 인쇄 창 표시"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ko_KR/PrusaSlicer_ko.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko.po
@@ -9143,7 +9143,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/ko_KR/PrusaSlicer_ko.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko.po
@@ -5930,7 +5930,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "인쇄 호스트 업로드 대기열 창 표시"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ko_KR/PrusaSlicer_ko.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko.po
@@ -9126,7 +9126,7 @@ msgid "Extruders count"
 msgstr "압출기 수"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
@@ -9143,7 +9143,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
@@ -5930,7 +5930,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "인쇄 호스트 업로드 대기열 창 표시"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
@@ -9126,7 +9126,7 @@ msgid "Extruders count"
 msgstr "압출기 수"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/nl/PrusaSlicer_nl.po
+++ b/resources/localization/nl/PrusaSlicer_nl.po
@@ -9242,7 +9242,7 @@ msgid "Extruders count"
 msgstr "Aantal extruders"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/nl/PrusaSlicer_nl.po
+++ b/resources/localization/nl/PrusaSlicer_nl.po
@@ -9259,7 +9259,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/nl/PrusaSlicer_nl.po
+++ b/resources/localization/nl/PrusaSlicer_nl.po
@@ -5994,7 +5994,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Toon het venster van de printhost uploadwachtrij"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/pl/PrusaSlicer_pl.po
+++ b/resources/localization/pl/PrusaSlicer_pl.po
@@ -9596,8 +9596,8 @@ msgstr "Porównaj zestawy ustawień"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
-msgstr "Porównaj %1% zestawów ustawień"
+msgid "Compare Presets"
+msgstr "Porównaj zestawów ustawień"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620
 msgid "One of the presets doesn't found"

--- a/resources/localization/pl/PrusaSlicer_pl.po
+++ b/resources/localization/pl/PrusaSlicer_pl.po
@@ -6113,7 +6113,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Wyświetl okno kolejki serwera druku"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr "Porównaj zestawy ustawień"
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/pl/PrusaSlicer_pl.po
+++ b/resources/localization/pl/PrusaSlicer_pl.po
@@ -9579,7 +9579,7 @@ msgid "Extruders count"
 msgstr "Liczba ekstruderów"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr "Pokaż wszystkie ustawienia (w tym niekompatybilne)"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
+++ b/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
@@ -9283,7 +9283,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
+++ b/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
@@ -9266,7 +9266,7 @@ msgid "Extruders count"
 msgstr "Contagem de extrusoras"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
+++ b/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
@@ -6005,7 +6005,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Exibir a janela fila de upload do host de impressão"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ru/PrusaSlicer_ru.po
+++ b/resources/localization/ru/PrusaSlicer_ru.po
@@ -9294,7 +9294,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/ru/PrusaSlicer_ru.po
+++ b/resources/localization/ru/PrusaSlicer_ru.po
@@ -6006,7 +6006,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Показать очередь загрузки на хост печати"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/ru/PrusaSlicer_ru.po
+++ b/resources/localization/ru/PrusaSlicer_ru.po
@@ -9277,7 +9277,7 @@ msgid "Extruders count"
 msgstr "Количество экструдеров"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/tr/PrusaSlicer_tr.po
+++ b/resources/localization/tr/PrusaSlicer_tr.po
@@ -5830,7 +5830,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Ana Bilgisayar Yükleme Sırasını Yazdır penceresini görüntüle"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/tr/PrusaSlicer_tr.po
+++ b/resources/localization/tr/PrusaSlicer_tr.po
@@ -8978,7 +8978,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/tr/PrusaSlicer_tr.po
+++ b/resources/localization/tr/PrusaSlicer_tr.po
@@ -8961,7 +8961,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/uk/PrusaSlicer_uk.po
+++ b/resources/localization/uk/PrusaSlicer_uk.po
@@ -9274,7 +9274,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/uk/PrusaSlicer_uk.po
+++ b/resources/localization/uk/PrusaSlicer_uk.po
@@ -6002,7 +6002,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "Показати вікна черги завантаження хоста друку"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/uk/PrusaSlicer_uk.po
+++ b/resources/localization/uk/PrusaSlicer_uk.po
@@ -9257,7 +9257,7 @@ msgid "Extruders count"
 msgstr "Кількість екструдерів"
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
+++ b/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
@@ -8876,7 +8876,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
+++ b/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
@@ -8893,7 +8893,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
+++ b/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
@@ -5787,7 +5787,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "显示打印主机上传队列窗口"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
+++ b/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
@@ -8836,7 +8836,7 @@ msgid "Extruders count"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1497
-msgid "Show all preset (including incompatible)"
+msgid "Show all presets (including incompatible)"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1512

--- a/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
+++ b/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
@@ -8853,7 +8853,7 @@ msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1558
 #, boost-format
-msgid "Compare %1% Presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/UnsavedChangesDialog.cpp:1620

--- a/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
+++ b/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
@@ -5765,7 +5765,7 @@ msgid "Display the Print Host Upload Queue window"
 msgstr "顯示 \"列印主機上載隊列\" 窗口"
 
 #: src/slic3r/GUI/MainFrame.cpp:1417
-msgid "Compare presets"
+msgid "Compare Presets"
 msgstr ""
 
 #: src/slic3r/GUI/MainFrame.cpp:1427

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1414,7 +1414,7 @@ void MainFrame::init_menubar_as_editor()
             [](wxCommandEvent&) { start_new_slicer(); }, "", nullptr, [this]() {return m_plater != nullptr && wxGetApp().app_config->get("single_instance") != "1"; }, this);
 
         windowMenu->AppendSeparator();
-        append_menu_item(windowMenu, wxID_ANY, _L("Compare presets")/* + "\tCtrl+F"*/, _L("Compare presets"), 
+        append_menu_item(windowMenu, wxID_ANY, _L("Compare Presets")/* + "\tCtrl+F"*/, _L("Compare Presets"), 
             [this](wxCommandEvent&) { diff_dialog.show();}, "compare", nullptr, []() {return true; }, this);
     }
 

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1555,7 +1555,7 @@ void DiffPresetDialog::update_bundles_from_app()
 
 void DiffPresetDialog::show(Preset::Type type /* = Preset::TYPE_INVALID*/)
 {
-    this->SetTitle(type == Preset::TYPE_INVALID ? _L("Compare Presets") : format_wxstr(_L("Compare %1% Presets"), wxGetApp().get_tab(type)->name()));
+    this->SetTitle(type == Preset::TYPE_INVALID ? _L("Compare Presets") : format_wxstr(_L("Compare Presets"), wxGetApp().get_tab(type)->name()));
     m_view_type = type;
 
     update_bundles_from_app();

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1494,7 +1494,7 @@ DiffPresetDialog::DiffPresetDialog(MainFrame* mainframe)
         });
     }
 
-    m_show_all_presets = new wxCheckBox(this, wxID_ANY, _L("Show all preset (including incompatible)"));
+    m_show_all_presets = new wxCheckBox(this, wxID_ANY, _L("Show all presets (including incompatible)"));
     m_show_all_presets->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
         bool show_all = m_show_all_presets->GetValue();
         for (auto preset_combos : m_preset_combos) {

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1555,7 +1555,7 @@ void DiffPresetDialog::update_bundles_from_app()
 
 void DiffPresetDialog::show(Preset::Type type /* = Preset::TYPE_INVALID*/)
 {
-    this->SetTitle(type == Preset::TYPE_INVALID ? _L("Compare Presets") : format_wxstr(_L("Compare Presets"), wxGetApp().get_tab(type)->name()));
+    this->SetTitle(_L("Compare Presets"));
     m_view_type = type;
 
     update_bundles_from_app();


### PR DESCRIPTION
- Title to upper case: Compare **P**resets
- Plural typo: Show all preset**s**
- Removing type from the title -> In my opinion, it is not necessary to use that. The user knows and has to choose what presets to compare. What is more, it does not work well in other translations, e.g., Porovnání printer/filament Přednastavení.