### PR TITLE
calculation of gcode based center of gravity

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -39,11 +39,11 @@ class OozePrevention {
 public:
     bool enable;
     Points standby_points;
-    
+
     OozePrevention() : enable(false) {}
     std::string pre_toolchange(GCode &gcodegen);
     std::string post_toolchange(GCode &gcodegen);
-    
+
 private:
     int _get_temp(GCode &gcodegen);
 };
@@ -52,7 +52,7 @@ class Wipe {
 public:
     bool enable;
     Polyline path;
-    
+
     Wipe() : enable(false) {}
     bool has_path() const { return !this->path.points.empty(); }
     void reset_path() { this->path = Polyline(); }
@@ -116,15 +116,15 @@ public:
 };
 
 class GCode {
-public:        
-    GCode() : 
+public:
+    GCode() :
     	m_origin(Vec2d::Zero()),
-        m_enable_loop_clipping(true), 
-        m_enable_cooling_markers(false), 
+        m_enable_loop_clipping(true),
+        m_enable_cooling_markers(false),
         m_enable_extrusion_role_markers(false),
         m_last_processor_extrusion_role(erNone),
         m_layer_count(0),
-        m_layer_index(-1), 
+        m_layer_index(-1),
         m_layer(nullptr),
         m_object_layer_over_raft(false),
         m_volumetric_speed(0),
@@ -191,7 +191,7 @@ private:
 
         bool is_open() const { return f; }
         bool is_error() const;
-        
+
         void flush();
         void close();
 
@@ -199,12 +199,12 @@ private:
         void write(const std::string& what) { this->write(what.c_str()); }
         void write(const char* what);
 
-        // Write a string into a file. 
+        // Write a string into a file.
         // Add a newline, if the string does not end with a newline already.
         // Used to export a custom G-code section processed by the PlaceholderParser.
         void writeln(const std::string& what);
 
-        // Formats and write into a file the given data. 
+        // Formats and write into a file the given data.
         void write_format(const char* format, ...);
 
     private:
@@ -309,7 +309,7 @@ private:
 		InstanceToPrint(ObjectByExtruder &object_by_extruder, size_t layer_id, const PrintObject &print_object, size_t instance_id) :
 			object_by_extruder(object_by_extruder), layer_id(layer_id), print_object(print_object), instance_id(instance_id) {}
 
-		// Repository 
+		// Repository
 		ObjectByExtruder		&object_by_extruder;
 		// Index into std::vector<LayerToPrint>, which contains Object and Support layers for the current print_z, collected for a single object, or for possibly multiple objects with multiple instances.
 		const size_t       		 layer_id;
@@ -412,6 +412,15 @@ private:
     // Processor
     GCodeProcessor m_processor;
 
+    struct cog_t {
+        double x = 0;
+        double y = 0;
+        double z = 0;
+        double mass = 0;
+    };
+
+    cog_t _cog;
+
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1);
     void print_machine_envelope(GCodeOutputStream &file, Print &print);
     void _print_first_layer_bed_temperature(GCodeOutputStream &file, Print &print, const std::string &gcode, unsigned int first_printing_extruder_id, bool wait);
@@ -422,14 +431,14 @@ private:
     bool                                object_layer_over_raft() const { return m_object_layer_over_raft; }
 
     friend ObjectByExtruder& object_by_extruder(
-        std::map<unsigned int, std::vector<ObjectByExtruder>> &by_extruder, 
-        unsigned int                                           extruder_id, 
-        size_t                                                 object_idx, 
+        std::map<unsigned int, std::vector<ObjectByExtruder>> &by_extruder,
+        unsigned int                                           extruder_id,
+        size_t                                                 object_idx,
         size_t                                                 num_objects);
     friend std::vector<ObjectByExtruder::Island>& object_islands_by_extruder(
-        std::map<unsigned int, std::vector<ObjectByExtruder>>  &by_extruder, 
-        unsigned int                                            extruder_id, 
-        size_t                                                  object_idx, 
+        std::map<unsigned int, std::vector<ObjectByExtruder>>  &by_extruder,
+        unsigned int                                            extruder_id,
+        size_t                                                  object_idx,
         size_t                                                  num_objects,
         size_t                                                  num_islands);
 


### PR DESCRIPTION
Hi, for some purposes, it is important to know the resulting centre of gravity of the printed model. This PR adds a comment to the resulting gcode that contains this value. 

Resulting output in gcode:
```
; cog_x = 92.062
; cog_y = 92.133
; cog_z = 5.064
```
The COG coordinates are located at the origin of the bed coordinates. 
 This PR also partially solves the request in #4436. 

Current limitations:
 * It calculates COG including brim and skirt
 * It calculates all models at one (common COG at printplate)
These issues should be solved in following PR

In the next PR, I would like to add to the gcode translations that were made with the model. But I need a little help with that. 