### PR TITLE
build_win.bat: MSVC version selection and minor fixes

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -6,7 +6,8 @@
 @ECHO Performs initial build or rebuild of the app (build) and deps (build/deps).
 @ECHO Default options are determined from build directories and system state.
 @ECHO.
-@ECHO Usage: build_win [-ARCH ^<arch^>] [-CONFIG ^<config^>] [-DESTDIR ^<directory^>]
+@ECHO Usage: build_win [-ARCH ^<arch^>] [-CONFIG ^<config^>] [-VERSION ^<version^>]
+@ECHO                  [-PRODUCT ^<product^>] [-DESTDIR ^<directory^>]
 @ECHO                  [-STEPS ^<all^|all-dirty^|app^|app-dirty^|deps^|deps-dirty^>]
 @ECHO                  [-RUN ^<console^|custom^|none^|viewer^|window^>]
 @ECHO.
@@ -14,6 +15,10 @@
 @ECHO                Default: %PS_ARCH_HOST%
 @ECHO  -c -CONFIG    MSVC project config
 @ECHO                Default: %PS_CONFIG_DEFAULT%
+@ECHO  -v -VERSION   Major version number of MSVC installation to use for build
+@ECHO                Default: %PS_VERSION_SUPPORTED%
+@ECHO  -p -PRODUCT   Product ID of MSVC installation to use for build
+@ECHO                Default: %PS_PRODUCT_DEFAULT%
 @ECHO  -s -STEPS     Performs only the specified build steps:
 @ECHO                  all - clean and build deps and app
 @ECHO                  all-dirty - build deps and app without cleaning
@@ -55,6 +60,23 @@ SET PS_DEPS_PATH_FILE_NAME=.DEPS_PATH.txt
 SET PS_DEPS_PATH_FILE=%~dp0deps\build\%PS_DEPS_PATH_FILE_NAME%
 SET PS_CONFIG_LIST="Debug;MinSizeRel;Release;RelWithDebInfo"
 
+REM The officially supported toolchain version is 16 (Visual Studio 2019)
+REM TODO: Update versions after Boost gets rolled to 1.78 or later
+SET PS_VERSION_SUPPORTED=16
+SET PS_VERSION_EXCEEDED=17
+SET VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+IF NOT EXIST "%VSWHERE%" SET VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
+FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`"%VSWHERE%" -nologo -property productId`) DO SET PS_PRODUCT_DEFAULT=%%I
+IF "%PS_PRODUCT_DEFAULT%" EQU "" (
+    SET EXIT_STATUS=-1
+    @ECHO ERROR: No Visual Studio installation found. 1>&2
+    GOTO :HELP
+)
+REM Default to the latest supported version if multiple are available
+FOR /F "tokens=1 USEBACKQ delims=." %%I IN (
+    `^""%VSWHERE%" -version "[%PS_VERSION_SUPPORTED%,%PS_VERSION_EXCEEDED%)" -latest -nologo -property catalog_buildVersion^"`
+) DO SET PS_VERSION_SUPPORTED=%%I
+
 REM Probe build directories and system state for reasonable default arguments
 pushd %~dp0
 SET PS_CONFIG=RelWithDebInfo
@@ -62,6 +84,8 @@ SET PS_ARCH=%PROCESSOR_ARCHITECTURE:amd64=x64%
 CALL :TOLOWER PS_ARCH
 SET PS_RUN=none
 SET PS_DESTDIR=
+SET PS_VERSION=
+SET PS_PRODUCT=%PS_PRODUCT_DEFAULT%
 CALL :RESOLVE_DESTDIR_CACHE
 
 REM Set up parameters used by help menu
@@ -75,7 +99,7 @@ SET EXIT_STATUS=1
 SET PS_CURRENT_STEP=arguments
 SET PARSER_STATE=
 SET PARSER_FAIL=
-FOR %%I in (%*) DO CALL :PARSE_OPTION "ARCH CONFIG DESTDIR STEPS RUN" PARSER_STATE "%%~I"
+FOR %%I in (%*) DO CALL :PARSE_OPTION "ARCH CONFIG DESTDIR STEPS RUN VERSION PRODUCT" PARSER_STATE "%%~I"
 IF "%PARSER_FAIL%" NEQ "" (
     @ECHO ERROR: Invalid switch: %PARSER_FAIL% 1>&2
     GOTO :HELP
@@ -124,6 +148,15 @@ IF "%PS_RUN%" NEQ "none" IF "%PS_STEPS:~0,4%" EQU "deps" (
     @ECHO ERROR: RUN=none is the only valid option for STEPS "deps" or "deps-dirty"
     GOTO :HELP
 )
+IF DEFINED PS_VERSION (
+    SET /A PS_VERSION_EXCEEDED=%PS_VERSION% + 1
+) ELSE SET PS_VERSION=%PS_VERSION_SUPPORTED%
+SET MSVC_FILTER=-products Microsoft.VisualStudio.Product.%PS_PRODUCT% -version "[%PS_VERSION%,%PS_VERSION_EXCEEDED%)"
+FOR /F "tokens=* USEBACKQ" %%I IN (`^""%VSWHERE%" %MSVC_FILTER% -nologo -property installationPath^"`) DO SET MSVC_DIR=%%I
+IF NOT EXIST "%MSVC_DIR%" (
+    @ECHO ERROR: Compatible Visual Studio installation not found. 1>&2
+    GOTO :HELP
+)
 REM Give the user a chance to cancel if we found something odd.
 IF "%PS_ASK_TO_CONTINUE%" EQU "" GOTO :BUILD_ENV
 @ECHO.
@@ -142,9 +175,6 @@ SET PS_CURRENT_STEP=environment
 @ECHO ** Run App:      %PS_RUN%
 @ECHO ** Deps path:    %PS_DESTDIR%
 @ECHO ** Using Microsoft Visual Studio installation found at:
-SET VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
-IF NOT EXIST "%VSWHERE%" SET VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
-FOR /F "tokens=* USEBACKQ" %%I IN (`"%VSWHERE%" -nologo -property installationPath`) DO SET MSVC_DIR=%%I
 @ECHO **  %MSVC_DIR%
 CALL "%MSVC_DIR%\Common7\Tools\vsdevcmd.bat" -arch=%PS_ARCH% -host_arch=%PS_ARCH_HOST% -app_platform=Desktop
 IF %ERRORLEVEL% NEQ 0 GOTO :END
@@ -276,7 +306,7 @@ REM Functions and stubs start here.
 SET PS_DEPS_PATH_FILE_FOR_CONFIG=%~dp0build\.vs\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%
 mkdir "%~dp0build\.vs\%PS_ARCH%\%PS_CONFIG%" > nul 2> nul
 REM Copy a legacy file if we don't have one in the proper location.
-echo f|xcopy /D "%~dp0build\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%" "%PS_DEPS_PATH_FILE_FOR_CONFIG%"
+echo f|xcopy /D "%~dp0build\%PS_ARCH%\%PS_CONFIG%\%PS_DEPS_PATH_FILE_NAME%" "%PS_DEPS_PATH_FILE_FOR_CONFIG%" > nul 2> nul
 CALL :CANONICALIZE_PATH PS_DEPS_PATH_FILE_FOR_CONFIG
 IF EXIST "%PS_DEPS_PATH_FILE_FOR_CONFIG%" (
     FOR /F "tokens=* USEBACKQ" %%I IN ("%PS_DEPS_PATH_FILE_FOR_CONFIG%") DO (


### PR DESCRIPTION
Added Visual Studio product and version selection command line parameters plus some better error handling that made it easier to test the VS 2022 toolchain.

FYI, deps won't build with VS 2022 until Boost gets rolled to 1.78 (currently in beta). However, everything else builds and seems to run just fine with VS 2022 against deps compiled with VS 2019 (in case anyone wants to try out the new features and tooling).
