### PR TITLE
Reduce wipe speed from travel to external_perimeter speed

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -158,9 +158,10 @@ namespace Slic3r {
     {
         std::string gcode;
 
-        /*  Reduce feedrate a bit; travel speed is often too high to move on existing material.
-            Too fast = ripping of existing material; too slow = short wipe path, thus more blob.  */
-        double wipe_speed = gcodegen.writer().config.travel_speed.value * 0.8;
+        /*  Holding hotend velocity constant while transitioning from extrusion to wipe + retraction
+            produces the best surface quality. Because surface quality is most important for external perimeters,
+            set wipe speed equal to external perimeter speed.  */
+        double wipe_speed = gcodegen.writer().config.external_perimeter_speed.value;
 
         // get the retraction length
         double length = toolchange


### PR DESCRIPTION
# Problem

Modern printers often run with travel speeds significantly higher than print speeds to reduce stringing and print times. I personally use a 350 mm/s travel speed and a 80 mm/s print speed on my inexpensive Kingroon KP3s printer. Even after scaling down by a 80% multiplier, wiping at travel speeds can result in ripping of existing material.

# This PR

Rather than benchmarking wipe speed against travel speed, let's use external perimeter speed. External perimeter speed is probably the best speed to use for wiping because:

Holding hotend velocity constant eliminates the need for the hotend to have to accelerate rapidly during the transition from extrusion to wipe + retraction.
The lack of acceleration generally prevents surface quality issues.
Because surface quality is most important for external perimeters, it is most important to optimize for surface quality when dealing with external perimeters.

