### PR TITLE
creality.ini: Ender-3 S1 improvements

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -914,6 +914,13 @@ pause_print_gcode = M25 ; pause print
 [printer:*descendingz*]
 end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; move print head out of the way\n{if max_layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed close to the bottom\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
 
+[printer:*spriteextruder*]
+retract_length = 0.8
+retract_speed = 30
+deretract_speed = 30
+retract_before_travel = 1
+retract_before_wipe = 0%
+
 # Intended for printers with dual extruders and a single hotend/nozzle, like the CR-X series
 [printer:*dualextruder*]
 single_extruder_multi_material = 1
@@ -962,8 +969,7 @@ printer_model = ENDER3V2
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3V2\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 S1]
-inherits = *common*; *fastabl*
-retract_length = 1
+inherits = *common*; *spriteextruder*
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 270
 printer_model = ENDER3S1


### PR DESCRIPTION
It seems the firmware is setup to not have to run ABL for each print,
and thus Creality's example start_gcode does not include G29

Finetuning for the S1's Sprite Direct Drive extruder