### PR TITLE
Remove deprecated use of M107 for RepRapFirmware

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -500,6 +500,7 @@ std::string GCodeWriter::set_fan(const GCodeFlavor gcode_flavor, bool gcode_comm
     if (speed == 0) {
         switch (gcode_flavor) {
         case gcfTeacup:
+	case gcfRepRapFirmware:
             gcode << "M106 S0"; break;
         case gcfMakerWare:
         case gcfSailfish:


### PR DESCRIPTION
According to [RepRapFirmware's documentation for M107](https://docs.duet3d.com/en/User_manual/Reference/Gcodes#m107-fan-off), its usage is deprecated and should be replaced by M107.

This is also reported as #5600.