### PR TITLE
Account for skirt when arranging parts on bed

### DIFF
--- a/src/slic3r/GUI/Jobs/ArrangeJob.hpp
+++ b/src/slic3r/GUI/Jobs/ArrangeJob.hpp
@@ -60,6 +60,9 @@ static const constexpr double LOGICAL_BED_GAP = 1. / 5.;
 // Stride between logical beds
 double bed_stride(const Plater *plater);
 
+// Bed shape minus the skirt region
+Points get_trimmed_bed_shape(const Plater* plater);
+
 template<class T> struct PtrWrapper
 {
     T *ptr;

--- a/src/slic3r/GUI/Jobs/FillBedJob.cpp
+++ b/src/slic3r/GUI/Jobs/FillBedJob.cpp
@@ -38,7 +38,7 @@ void FillBedJob::prepare()
 
     if (m_selected.empty()) return;
 
-    m_bedpts = get_bed_shape(*m_plater->config());
+    m_bedpts = get_trimmed_bed_shape(m_plater);
 
     auto &objects = m_plater->model().objects;
     BoundingBox bedbb = get_extents(m_bedpts);


### PR DESCRIPTION
This PR fixes issue #3477 by subtracting the skirt region from the build plate area when arranging or filling the bed. The file `arrange_test_better.3mf` in [arrange_tests.zip](https://github.com/prusa3d/PrusaSlicer/files/7794061/arrange_tests.zip) demonstrates where this patch performs better by removing a model that cannot fit on the bed without pushing the skirt outside the printable area. You can test this by arranging and then slicing the file with patched and unpatched versions to see the difference.

This approach has the following tradeoffs:

1. Because the arrange algorithm uses 2D projections, it can lose some space for parts that would overhang but not intersect the skirt area in 3D space. The file `arrange_test_worse.3mf` in [arrange_tests.zip](https://github.com/prusa3d/PrusaSlicer/files/7794061/arrange_tests.zip) demonstrates a case where the old approach can fit all the parts on the bed, but this new approach unnecessarily removes a part. This hasn't been a problem for my use, and I've found the tradeoff to be quite a bit better than the current behavior, but other people may differ on that call.
2. The skirt can still run outside the printable area if the minimum length setting requires additional loops for multiple extruders. This isn't a change from the current behavior, but it seems worth mentioning that this change doesn't fix that problem.

I've been using this for a bit and haven't run into any issues. That stated, even after several hours of reading through the arrange code I can't say I know it well enough to be confident that there isn't a better approach to solving this.