### PR TITLE
use the great intelligient profile change recognition in a stand alone todo app for IT installation steps

### DIFF
--- a/lib/Slic3r/GUI/MainFrame.pm
+++ b/lib/Slic3r/GUI/MainFrame.pm
@@ -100,6 +100,9 @@ sub new {
 
     $self->update_ui_from_settings;
     
+    # TODO: updatecheck from here
+    Slic3r::Utils::preset_update_check();
+
     return $self;
 }
 

--- a/xs/CMakeLists.txt
+++ b/xs/CMakeLists.txt
@@ -205,6 +205,8 @@ add_library(libslic3r_gui STATIC
     ${LIBDIR}/slic3r/Utils/OctoPrint.hpp
     ${LIBDIR}/slic3r/Utils/Bonjour.cpp
     ${LIBDIR}/slic3r/Utils/Bonjour.hpp
+    ${LIBDIR}/slic3r/Utils/PresetUpdate.cpp
+    ${LIBDIR}/slic3r/Utils/PresetUpdate.hpp
 )
 
 add_library(admesh STATIC
@@ -345,6 +347,7 @@ set(XS_XSP_FILES
     ${XSP_DIR}/SurfaceCollection.xsp
     ${XSP_DIR}/TriangleMesh.xsp
     ${XSP_DIR}/Utils_OctoPrint.xsp
+    ${XSP_DIR}/Utils_PresetUpdate.xsp
     ${XSP_DIR}/XS.xsp
 )
 foreach (file ${XS_XSP_FILES})

--- a/xs/src/libslic3r/Config.hpp
+++ b/xs/src/libslic3r/Config.hpp
@@ -1,7 +1,12 @@
 #ifndef slic3r_Config_hpp_
 #define slic3r_Config_hpp_
 
-#include <assert.h>
+// FIXME: XXX
+#ifndef NDEBUG
+#define NDEBUG 1
+#endif
+
+#include <cassert>
 #include <map>
 #include <climits>
 #include <cstdio>
@@ -14,6 +19,7 @@
 #include "Point.hpp"
 
 #include <boost/property_tree/ptree.hpp>
+#include <boost/nowide/fstream.hpp>
 
 namespace Slic3r {
 
@@ -1060,6 +1066,7 @@ public:
     void load_from_gcode_string(const char* str);
     void load(const boost::property_tree::ptree &tree);
     void save(const std::string &file) const;
+    void save_only(const std::string &file, const t_config_option_keys &keys) const;
 
 private:
     // Set a configuration value from a string.

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -22,7 +22,36 @@ PrintConfigDef::PrintConfigDef()
     // Maximum extruder temperature, bumped to 1500 to support printing of glass.
     const int max_temp = 1500;
 
-	def = this->add("avoid_crossing_perimeters", coBool);
+	//! On purpose of localization there is that changes at text of tooltip and sidetext:
+	//! - ° -> \u00B0
+	//! - ² -> \u00B2
+	//! - ³ -> \u00B3
+
+    def = this->add("_locked", coBool);
+    def->label = L("Preset file lock status");
+    def->tooltip = L("Preset file lock status");
+    def->cli = "_locked!";
+    def->default_value = new ConfigOptionBool(false);
+
+    def = this->add("_version", coInt);
+    def->label = L("Preset file version number");
+    def->tooltip = L("Preset file version number");
+    def->cli = "_version=i";
+    def->default_value = new ConfigOptionInt(1);
+
+    def = this->add("_url", coString);
+    def->label = L("Preset file update URL");
+    def->tooltip = L("Preset file update URL");
+    def->cli = "_url=s";
+    def->default_value = new ConfigOptionString("");
+
+    def = this->add("_parent", coString);
+    def->label = L("Preset file parent preset name");
+    def->tooltip = L("Preset file parent preset name");
+    def->cli = "_parent=s";
+    def->default_value = new ConfigOptionString("");
+
+    def = this->add("avoid_crossing_perimeters", coBool);
     def->label = L("Avoid crossing perimeters");
 	def->tooltip = L("Optimize travel moves in order to minimize the crossing of perimeters. "
                    "This is mostly useful with Bowden extruders which suffer from oozing. "

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -553,6 +553,10 @@ public:
     double                          min_object_distance() const;
     static double                   min_object_distance(const ConfigBase *config);
 
+    ConfigOptionBool                _locked;
+    ConfigOptionInt                 _version;
+    ConfigOptionString              _url;
+    ConfigOptionString              _parent;
     ConfigOptionBool                avoid_crossing_perimeters;
     ConfigOptionPoints              bed_shape;
     ConfigOptionInts                bed_temperature;
@@ -617,6 +621,10 @@ protected:
     void initialize(StaticCacheBase &cache, const char *base_ptr)
     {
         this->GCodeConfig::initialize(cache, base_ptr);
+        OPT_PTR(_locked);
+        OPT_PTR(_version);
+        OPT_PTR(_url);
+        OPT_PTR(_parent);
         OPT_PTR(avoid_crossing_perimeters);
         OPT_PTR(bed_shape);
         OPT_PTR(bed_temperature);

--- a/xs/src/slic3r/Utils/PresetUpdate.cpp
+++ b/xs/src/slic3r/Utils/PresetUpdate.cpp
@@ -9,13 +9,13 @@ namespace Utils {
 
 void preset_update_check()
 {
-    std::cerr << "preset_update_check()" << std::endl;
+	std::cerr << "preset_update_check()" << std::endl;
 
-    // TODO:
-    // 1. Get a version tag or the whole bundle from the web
-    // 2. Store into temporary location (?)
-    // 3. ???
-    // 4. Profit!
+	// TODO:
+	// 1. Get a version tag or the whole bundle from the web
+	// 2. Store into temporary location (?)
+	// 3. ???
+	// 4. Profit!
 }
 
 }

--- a/xs/src/slic3r/Utils/PresetUpdate.cpp
+++ b/xs/src/slic3r/Utils/PresetUpdate.cpp
@@ -1,0 +1,23 @@
+#include "PresetUpdate.hpp"
+
+#include <iostream>
+
+namespace Slic3r {
+
+
+namespace Utils {
+
+void preset_update_check()
+{
+    std::cerr << "preset_update_check()" << std::endl;
+
+    // TODO:
+    // 1. Get a version tag or the whole bundle from the web
+    // 2. Store into temporary location (?)
+    // 3. ???
+    // 4. Profit!
+}
+
+}
+
+}

--- a/xs/src/slic3r/Utils/PresetUpdate.hpp
+++ b/xs/src/slic3r/Utils/PresetUpdate.hpp
@@ -1,0 +1,19 @@
+#ifndef slic3r_PresetUpdate_hpp_
+#define slic3r_PresetUpdate_hpp_
+
+
+namespace Slic3r {
+
+
+// class PresetUpdate {
+// };
+
+namespace Utils {
+
+void preset_update_check();
+
+}
+
+}
+
+#endif

--- a/xs/xsp/Utils_PresetUpdate.xsp
+++ b/xs/xsp/Utils_PresetUpdate.xsp
@@ -1,0 +1,11 @@
+%module{Slic3r::XS};
+
+%{
+#include <xsinit.h>
+#include "slic3r/Utils/PresetUpdate.hpp"
+%}
+
+%package{Slic3r::Utils};
+
+void preset_update_check()
+    %code%{ Slic3r::Utils::preset_update_check(); %};


### PR DESCRIPTION
I really like the feature in Prusa Slicer, that recognises changes made in the profile settings and pops up a request window to apply or cancel these changes, when I close Prusa Slicer. 

As I'm working in an IT department, where we have to install client PC step by step in a certain order, I would be very happy to see it in the ToDo app, we are using for this purpose. Atm we made templates and when something changes during the installation process we have to change the template manually.

Perhaps you would find this useful also for your own processes. It would be cool to have a Prusa ToDo Tool.