### PR TITLE
Use namespaces to link against libcereal >= 1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,9 @@ endif ()
 
 # Find the Cereal serialization library
 find_package(cereal REQUIRED)
+if (NOT TARGET cereal::cereal)
+    add_library(cereal::cereal ALIAS cereal)
+endif ()
 
 # l10n
 set(L10N_DIR "${SLIC3R_RESOURCES_DIR}/localization")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,7 @@ if (NOT WIN32 AND NOT APPLE)
     set_target_properties(PrusaSlicer PROPERTIES OUTPUT_NAME "prusa-slicer")
 endif ()
 
-target_link_libraries(PrusaSlicer libslic3r cereal)
+target_link_libraries(PrusaSlicer libslic3r cereal::cereal)
 if (APPLE)
 #    add_compile_options(-stdlib=libc++)
 #    add_definitions(-DBOOST_THREAD_DONT_USE_CHRONO -DBOOST_NO_CXX11_RVALUE_REFERENCES -DBOOST_THREAD_USES_MOVE)

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -337,7 +337,7 @@ target_include_directories(libslic3r PUBLIC ${EXPAT_INCLUDE_DIRS})
 target_link_libraries(libslic3r
     libnest2d
     admesh
-    cereal
+    cereal::cereal
     libigl
     miniz
     boost_libs

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -260,7 +260,7 @@ add_library(libslic3r_gui STATIC ${SLIC3R_GUI_SOURCES})
 
 encoding_check(libslic3r_gui)
 
-target_link_libraries(libslic3r_gui libslic3r avrdude cereal imgui GLEW::GLEW OpenGL::GL hidapi libcurl ${wxWidgets_LIBRARIES})
+target_link_libraries(libslic3r_gui libslic3r avrdude cereal::cereal imgui GLEW::GLEW OpenGL::GL hidapi libcurl ${wxWidgets_LIBRARIES})
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)


### PR DESCRIPTION
Debian recently switched libcereal to 1.3.1, which started to use cmake namespaces.

Linking to "cereal" now expands directly to "-lcereal", which is incorrect. This makes the build fail.

"cereal::cereal" should be used instead. Looks like that supporting libcereal prior to 1.3.1 requires a target alias. I came up with the following changes, but I didn't test if the target alias works as intended with libcereal 1.3.0 or lower.