### PR TITLE
Show GLEW error string on glewInit() initialization errors

### DIFF
--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -233,8 +233,9 @@ OpenGLManager::~OpenGLManager()
 bool OpenGLManager::init_gl()
 {
     if (!m_gl_initialized) {
-        if (glewInit() != GLEW_OK) {
-            BOOST_LOG_TRIVIAL(error) << "Unable to init glew library";
+        GLenum err = glewInit();
+        if (err != GLEW_OK) {
+            BOOST_LOG_TRIVIAL(error) << "Unable to init glew library: " << glewGetErrorString(err);
             return false;
         }
         m_gl_initialized = true;


### PR DESCRIPTION
If GLEW fails to initialize, debugging the reason can be quite tricky.
Display the reason string when this happens, which can help diagnosing the issue.