### PR TITLE
Creality Bundle Enhancements for Ender-3 Pro

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -970,7 +970,7 @@ renamed_from = "Creality ENDER-3 BLTouch"
 printer_model = ENDER3BLTOUCH
 
 [printer:Creality Ender-3 Pro]
-inherits = *common*
+inherits = *common*; *pauseprint*
 renamed_from = "Creality Ender-3 Pro"
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 250
@@ -978,7 +978,7 @@ printer_model = ENDER3PRO
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3PRO\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 V2]
-inherits = *common*
+inherits = *common*; *pauseprint*
 renamed_from = "Creality Ender-3V2"
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 250
@@ -986,7 +986,7 @@ printer_model = ENDER3V2
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3V2\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 S1]
-inherits = *common*; *spriteextruder*
+inherits = *common*; *pauseprint*; *spriteextruder*
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 270
 printer_model = ENDER3S1

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -32,6 +32,15 @@ bed_model = ender3_bed.stl
 bed_texture = ender3.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY
 
+[printer_model:ENDER3PRO]
+name = Creality Ender-3 Pro
+variants = 0.4
+technology = FFF
+family = ENDER
+bed_model = ender3_bed.stl
+bed_texture = ender3.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY
+
 [printer_model:ENDER3V2]
 name = Creality Ender-3 V2
 variants = 0.4
@@ -959,6 +968,14 @@ printer_notes = Don't remove the following keywords! These keywords are used in 
 inherits = Creality Ender-3; *fastabl*
 renamed_from = "Creality ENDER-3 BLTouch"
 printer_model = ENDER3BLTOUCH
+
+[printer:Creality Ender-3 Pro]
+inherits = *common*
+renamed_from = "Creality Ender-3 Pro"
+bed_shape = 5x0,215x0,215x220,5x220
+max_print_height = 250
+printer_model = ENDER3PRO
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3PRO\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 V2]
 inherits = *common*

--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -5,7 +5,7 @@
 name = Creality
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 0.1.3
+config_version = 0.1.4
 # Where to get the updates from?
 config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Creality/
 # changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
@@ -993,7 +993,7 @@ printer_model = ENDER3S1
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3S1
 
 [printer:Creality Ender-3 Max]
-inherits = *common*
+inherits = *common*; *pauseprint*
 retract_length = 6
 bed_shape = 5x5,295x5,295x295,5x295
 max_print_height = 340


### PR DESCRIPTION
For the consideration of the PrusaSlicer team. With regards to the Creality Ender-3 Pro, that's based on the current information of the printer being sold in stores around the world. The printer is an enhanced version of the existing Creality Ender-3, that contains a wider Y-axis, upgraded power supply, and magnetic print bed.

I was surprised to not see this printer in the configuration given the popularity of the model, if there is a reason it hasn't been included to date, would you mind reconsidering that request to make this great software more approachable to those who use this model of printer.

I also added support for `*pauseprint*` to the Ender-3 Pro, Ender-3v2, and Ender-3 S1 as all of those support `M25` out of the box.

Thank you for your consideration.