### PR TITLE
Updated support for Creality 32-bit printers

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -5,7 +5,7 @@
 name = Creality
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 0.1.4
+config_version = 0.1.5
 # Where to get the updates from?
 config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/Creality/
 # changelog_url = https://files.prusa3d.com/?latest=slicer-profiles&lng=%1%
@@ -923,6 +923,10 @@ pause_print_gcode = M25 ; pause print
 [printer:*descendingz*]
 end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; move print head out of the way\n{if max_layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed close to the bottom\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
 
+# Intended for printers with 32-bit control boards with Marlin 2.x for the initial release
+[printer:*marlin2*]
+gcode_flavor = marlin2
+
 [printer:*spriteextruder*]
 retract_length = 0.8
 retract_speed = 30
@@ -978,7 +982,7 @@ printer_model = ENDER3PRO
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3PRO\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 V2]
-inherits = *common*; *pauseprint*
+inherits = *common*; *pauseprint*; *marlin2*
 renamed_from = "Creality Ender-3V2"
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 250
@@ -986,14 +990,14 @@ printer_model = ENDER3V2
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3V2\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 S1]
-inherits = *common*; *pauseprint*; *spriteextruder*
+inherits = *common*; *pauseprint*; *spriteextruder*; *marlin2*
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 270
 printer_model = ENDER3S1
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3S1
 
 [printer:Creality Ender-3 Max]
-inherits = *common*; *pauseprint*
+inherits = *common*; *pauseprint*; *marlin2*
 retract_length = 6
 bed_shape = 5x5,295x5,295x295,5x295
 max_print_height = 340
@@ -1090,7 +1094,7 @@ printer_model = CR6MAX
 printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CR6MAX\nPRINTER_HAS_BOWDEN
 
 [printer:Creality CR-10 SMART]
-inherits = *common*; *straingauge*
+inherits = *common*; *straingauge*; *marlin2*
 retract_length = 6
 bed_shape = 5x5,295x5,295x295,5x295
 max_print_height = 400


### PR DESCRIPTION
In my effort to up level the support of the Creality printers in PrusaSlicer, I have updated support for Creality printers that are known to contain 32-bit boards and support Marlin 2.x. Printers that weren't initially released with 32-bit boards have been excluded (e.g. Ender 3 Pro).