### PR TITLE
Ask OctoPrint to `select` newly-uploaded files

### DIFF
--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -224,6 +224,7 @@ bool OctoPrint::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Erro
     set_auth(http);
     http.form_add("print", upload_data.post_action == PrintHostPostUploadAction::StartPrint ? "true" : "false")
         .form_add("path", upload_parent_path.string())      // XXX: slashes on windows ???
+        .form_add("select", "true")
         .form_add_file("file", upload_data.source_path.string(), upload_filename.string())
         .on_complete([&](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(debug) << boost::format("%1%: File uploaded: HTTP %2%: %3%") % name % status % body;


### PR DESCRIPTION
I have a computer in my living space, and a "headless" Prusa in my garage connected to an octopi.  My workflow is:

1. Export STL from Fusion 360 into PrusaSlicer
2. Set PrusaSlicer parameters and then click Slice Now
3. Have PrusaSlicer upload the gcode to OctoPrint
4. Walk to Prusa in garage, leaving the computer behind
5. Install the proper bed sheet, wipe down with alcohol, preheat, load filament, clean up "drooled" filament, etc.
6. When everything is ready, push a Start button next to the printer that emits an MQTT message via [zigbee2mqtt](https://www.zigbee2mqtt.io/)
7. [MQTT Subscribe](https://plugins.octoprint.org/plugins/mqttsubscribe/) plugin translates MQTT message to an OctoPrint REST query resembling `POST /api/job { "command": "start" }`
8. Printer starts the job

The MQTT/API step 7 only works correctly if the most recently uploaded file is selected in OctoPrint, so that OctoPrint knows which gcode file I want to print.  Otherwise, it has no effect (or it prints the wrong file).

Upstream PrusaSlicer does not currently tell OctoPrint to `select` the uploaded file to get it ready to print.  With this patch, it does.