### PR TITLE
add G92 E0 to prevent marlin error accumulation BIBO profiles

### DIFF
--- a/resources/profiles/BIBO.idx
+++ b/resources/profiles/BIBO.idx
@@ -1,4 +1,5 @@
-min_slic3r_version = 2.3.0-beta2
+min_slic3r_version = 2.4.1-beta3
+0.0.4 Correct Marlin Error accumulation
 0.0.3 Removed obsolete host keys.
 min_slic3r_version = 2.2.0-alpha3
 0.0.2 General print quality improvements

--- a/resources/profiles/BIBO.ini
+++ b/resources/profiles/BIBO.ini
@@ -5,7 +5,7 @@
 name = BIBO
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 0.0.3
+config_version = 0.0.4
 # Where to get the updates from?
 config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/BIBO/
 
@@ -694,7 +694,7 @@ cooling = 1
 [printer:*common*]
 printer_technology = FFF
 bed_shape = -107x-93,107x-93,107x93,-107x93
-before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\n\n
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\nG92 E0\n
 between_objects_gcode = 
 deretract_speed = 0 # By setting this value to 0 deretract used the retract_speed
 extruder_colour = #FFFF00


### PR DESCRIPTION
As of PrusaSlicer 2.4.1 we need to add G92 E0 to layer change to prevent error accumulation in marlin firmware and relative extrusion. This also eliminates the "error" notice in the slicer for BIBO printers.
reference https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.4.1-beta3