### PR TITLE
Fix reload from disk losing positioning information

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3861,9 +3861,12 @@ void Plater::priv::reload_from_disk()
                 new_volume->set_type(old_volume->type());
                 new_volume->set_material_id(old_volume->material_id());
 #if ENABLE_WORLD_COORDINATE
-                new_volume->set_transformation(Geometry::translation_transform(old_volume->source.transform.get_offset()) *
-                    old_volume->get_transformation().get_matrix_no_offset() * old_volume->source.transform.get_matrix_no_offset());
-                new_volume->translate(new_volume->get_transformation().get_matrix_no_offset() * (new_volume->source.mesh_offset - old_volume->source.mesh_offset));
+                new_volume->set_transformation(
+                    old_volume->get_transformation().get_matrix() *
+                    old_volume->source.transform.get_matrix() *
+                    Geometry::translation_transform(new_volume->source.mesh_offset - old_volume->source.mesh_offset) *
+                    new_volume->source.transform.get_matrix().inverse()
+                    );
 #else
                 new_volume->set_transformation(Geometry::assemble_transform(old_volume->source.transform.get_offset()) *
                                                old_volume->get_transformation().get_matrix(true) *


### PR DESCRIPTION
Using reload from disk was aligning the reloaded part in the middle of the instance instead of the original position.

This PR fixes the positioning offset.