### PR TITLE
Fix frustum for off-bed origins

### DIFF
--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -341,6 +341,8 @@ BoundingBoxf3 Bed3D::calc_extended_bounding_box() const
     // Reset the build volume Z, we don't want to zoom to the top of the build volume if it is empty.
     out.min.z() = 0.0;
     out.max.z() = 0.0;
+    // extend to origin in case origin is off bed
+    out.merge(m_axes.get_origin());
     // extend to contain axes
     out.merge(m_axes.get_origin() + m_axes.get_total_length() * Vec3d::Ones());
 #if ENABLE_WORLD_COORDINATE


### PR DESCRIPTION
When the origin axes visualization is nearest to or farthest from the camera, parts of the arrows would get culled when the bed origin is defined off the bed (and no printer visualization is set)