### PR TITLE
Don't change to color print view when no color change gcodes are set

### DIFF
--- a/src/slic3r/GUI/GUI_Preview.cpp
+++ b/src/slic3r/GUI/GUI_Preview.cpp
@@ -1011,8 +1011,10 @@ void Preview::load_print_as_fff(bool keep_z_range)
             std::vector<Item> gcodes = wxGetApp().is_editor() ?
                 wxGetApp().plater()->model().custom_gcode_per_print_z.gcodes :
                 m_canvas->get_custom_gcode_per_print_z();
+            const bool contains_color_gcodes = std::any_of(std::begin(gcodes), std::end(gcodes),
+                [] (auto const& item) { return item.type == CustomGCode::Type::ColorChange; });
 #if ENABLE_PREVIEW_LAYOUT
-            const GCodeViewer::EViewType choice = !gcodes.empty() ?
+            const GCodeViewer::EViewType choice = contains_color_gcodes ?
                 GCodeViewer::EViewType::ColorPrint :
                 (number_extruders > 1) ? GCodeViewer::EViewType::Tool : GCodeViewer::EViewType::FeatureType;
             if (choice != gcode_view_type) {
@@ -1022,7 +1024,7 @@ void Preview::load_print_as_fff(bool keep_z_range)
                 refresh_print();
             }
 #else
-            const wxString choice = !gcodes.empty() ?
+            const wxString choice = contains_color_gcodes ?
                 _L("Color Print") :
                 (number_extruders > 1) ? _L("Tool") : _L("Feature type");
             int type = m_choice_view_type->FindString(choice);


### PR DESCRIPTION
Both #8413 and #5837 mention that automatically changing to color view is annoying when you add a pause.
#5837 was cut short by closing it so I looked into the code myself and made a small change.

The change to color view now only happens when at least one color change exists. Otherwise it is not changed.
I would propose that the change should only happen when a new color change is added but that seems to be a more difficult code change because that information is not propagated with the `wxCUSTOMEVT_TICKSCHANGED` event.

I testet the change in `master` on my Arch Linux machine using the compile flags from the prusa-slicer-git AUR Package.

#8413 mentioned that this is intended behaviour but I would like a discussion if this is really an expected behaviour from the user perspective. Adding a pause or custom gcode has nothing to do with color changes and I would guess that most people don't use color changes at all. I would argue that they get confused when the color coding of the features unexpectedly vanishes (as has happend to me when is first tried it).
