### PR TITLE
Update Repetier.cpp

### DIFF
--- a/src/slic3r/Utils/Repetier.cpp
+++ b/src/slic3r/Utils/Repetier.cpp
@@ -128,7 +128,8 @@ bool Repetier::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
     }
 
     if(upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
-        http.form_add("name", upload_filename.string());
+        http.form_add("name", upload_filename.string())
+            .form_add("autostart", "1");
     }
 
     http.form_add("a", "upload")


### PR DESCRIPTION
Add autostart=1 to start printing after upload

Reference: https://prgdoc.repetier-server.com/v1/docs/index.html#/en/web-api/direct?id=job
If no autostart value is given, print will only start for empty queue. With autostart=1 it will start, if no print is running. With autostart=0 it will always queue the file.