### PR TITLE
Add option to support MS Build Tools

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -69,8 +69,6 @@ SET PS_CUSTOM_RUN_FILE=custom_run.bat
 SET PS_DEPS_PATH_FILE_NAME=.DEPS_PATH.txt
 SET PS_DEPS_PATH_FILE=%~dp0deps\build\%PS_DEPS_PATH_FILE_NAME%
 SET PS_CONFIG_LIST="Debug;MinSizeRel;Release;RelWithDebInfo"
-SET PS_VERBOSE=--log-level=VERBOSE --log-context
-REM SET PS_VERBOSE=
 
 
 REM The officially supported toolchain version is 16 (Visual Studio 2019)
@@ -208,9 +206,9 @@ IF "%PS_STEPS_DIRTY%" EQU "" (
     CALL :MAKE_OR_CLEAN_DIRECTORY "%PS_DESTDIR%"
 )
 cd deps\build || GOTO :END
-cmake.exe .. -DDESTDIR="%PS_DESTDIR%" %PS_VERBOSE%
+cmake.exe .. -DDESTDIR="%PS_DESTDIR%"
 IF %ERRORLEVEL% NEQ 0 IF "%PS_STEPS_DIRTY%" NEQ "" (
-    (del CMakeCache.txt && cmake.exe .. -DDESTDIR="%PS_DESTDIR%" %PS_VERBOSE%) || GOTO :END
+    (del CMakeCache.txt && cmake.exe .. -DDESTDIR="%PS_DESTDIR%") || GOTO :END
 ) ELSE GOTO :END
 (echo %PS_DESTDIR%)> "%PS_DEPS_PATH_FILE%"
 msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% /v:quiet %PS_PRIORITY% || GOTO :END
@@ -231,9 +229,9 @@ SET PS_PROJECT_IS_OPEN=
 FOR /F "tokens=2 delims=," %%I in (
     'tasklist /V /FI "IMAGENAME eq devenv.exe " /NH /FO CSV ^| find "%PS_SOLUTION_NAME%"'
 ) do SET PS_PROJECT_IS_OPEN=%%~I
-cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% %PS_VERBOSE%
+cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST%
 IF %ERRORLEVEL% NEQ 0 IF "%PS_STEPS_DIRTY%" NEQ "" (
-    (del CMakeCache.txt && cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% %PS_VERBOSE%) || GOTO :END
+    (del CMakeCache.txt && cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST%) || GOTO :END
 ) ELSE GOTO :END
 REM Skip the build step if we're using the undocumented app-cmake to regenerate the full config from inside devenv
 IF "%PS_STEPS%" NEQ "app-cmake" msbuild /m ALL_BUILD.vcxproj /p:Configuration=%PS_CONFIG% /v:quiet %PS_PRIORITY% || GOTO :END
@@ -277,12 +275,12 @@ IF "%PS_RUN%" EQU "console" (
         @ECHO Preparing to run Visual Studio...
         cd ..\.. || GOTO :END
         REM This hack generates a single config for MSVS, guaranteeing it gets set as the active config.
-        cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG% %PS_VERBOSE% > nul 2> nul || GOTO :END
+        cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG% > nul 2> nul || GOTO :END
         REM Now launch devenv with the single config (setting it active) and a /command switch to re-run cmake and generate the full config list
         start devenv.exe %PS_SOLUTION_NAME%.sln /command ^"shell /o ^^^"%~f0^^^" -d ^^^"%PS_DESTDIR%^^^" -c %PS_CONFIG% -a %PS_ARCH% -r none -s app-cmake^"
         REM If devenv fails to launch just directly regenerate the full config list.
         IF %ERRORLEVEL% NEQ 0 (
-            cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% %PS_VERBOSE% 2> nul 1> nul || GOTO :END
+            cmake.exe .. -DCMAKE_PREFIX_PATH="%PS_DESTDIR%\usr\local" -DCMAKE_CONFIGURATION_TYPES=%PS_CONFIG_LIST% 2> nul 1> nul || GOTO :END
         )
     )
 )

--- a/build_win.bat
+++ b/build_win.bat
@@ -10,7 +10,7 @@
 @ECHO                  [-PRODUCT ^<product^>] [-DESTDIR ^<directory^>]
 @ECHO                  [-STEPS ^<all^|all-dirty^|app^|app-dirty^|deps^|deps-dirty^>]
 @ECHO                  [-RUN ^<console^|custom^|none^|viewer^|window^>]
-@ECHO                  [-PRIORITY ^<normal^|low^>]
+@ECHO                  [-PRIORITY ^<normal^|low^>] [-TOOL ^<auto^|visual^|msbuild^>]
 @ECHO.
 @ECHO  -a -ARCH      Target processor architecture
 @ECHO                Default: %PS_ARCH_HOST%
@@ -18,7 +18,9 @@
 @ECHO                Default: %PS_CONFIG_DEFAULT%
 @ECHO  -v -VERSION   Major version number of MSVC installation to use for build
 @ECHO                Default: %PS_VERSION_SUPPORTED%
-@ECHO  -p -PRODUCT   Product ID of MSVC installation to use for build
+@ECHO  -p -PRODUCT   Product IDs of MSVC installation to use for build
+@ECHO                  Can be a list in quotes: "BuildTools community"
+@ECHO                  It will use first found tool
 @ECHO                Default: %PS_PRODUCT_DEFAULT%
 @ECHO  -s -STEPS     Performs only the specified build steps:
 @ECHO                  all - clean and build deps and app
@@ -41,6 +43,11 @@
 @ECHO                Default: %PS_DESTDIR_DEFAULT_MSG%
 @ECHO  -p -PRIORITY  Build CPU priority
 @ECHO                Default: normal
+@ECHO  -t -TOOL      Specifies which build tool to use for build
+@ECHO                  auto - search for Visual Studio first, fall back on MS Build
+@ECHO                  visual - use Visual Studio, error if not found
+@ECHO                  msbuild - use MS Build Tools, error if not found
+@ECHO                Default: auto
 @ECHO.
 @ECHO  Examples:
 @ECHO.
@@ -62,41 +69,14 @@ SET PS_CUSTOM_RUN_FILE=custom_run.bat
 SET PS_DEPS_PATH_FILE_NAME=.DEPS_PATH.txt
 SET PS_DEPS_PATH_FILE=%~dp0deps\build\%PS_DEPS_PATH_FILE_NAME%
 SET PS_CONFIG_LIST="Debug;MinSizeRel;Release;RelWithDebInfo"
-REM SET PS_VERBOSE=--log-level=VERBOSE --log-context
-SET PS_VERBOSE=
-SET PS_USE_MSBUILD=
+SET PS_VERBOSE=--log-level=VERBOSE --log-context
+REM SET PS_VERBOSE=
+
 
 REM The officially supported toolchain version is 16 (Visual Studio 2019)
 REM TODO: Update versions after Boost gets rolled to 1.78 or later
 SET PS_VERSION_SUPPORTED=16
 SET PS_VERSION_EXCEEDED=17
-SET VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
-IF NOT EXIST "%VSWHERE%" SET VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
-IF NOT EXIST "%VSWHERE%" (
-    SET EXIT_STATUS=-1
-    @ECHO ERROR: vswhere.exe not found. 1>&2
-    GOTO :HELP
-)
-
-SET PS_VSWHERE_QUERY="%VSWHERE%" -version "[%PS_VERSION_SUPPORTED%,%PS_VERSION_EXCEEDED%)" -latest -nologo
-IF %PS_USE_MSBUILD% NEQ 1 FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`^"%PS_VSWHERE_QUERY% -property productID^"`) DO SET PS_PRODUCT_DEFAULT_A=%%I
-IF "%PS_PRODUCT_DEFAULT_A%" EQU "" (
-    @ECHO Visual Studio not found, searching for MSBuild Tools
-    FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`^"%PS_VSWHERE_QUERY% -products Microsoft.VisualStudio.Product.BuildTools -property productID^"`) DO SET PS_PRODUCT_DEFAULT_A=%%I
-)
-SET PS_PRODUCT_DEFAULT=%PS_PRODUCT_DEFAULT_A%
-
-IF "%PS_PRODUCT_DEFAULT%" EQU "" (
-    SET EXIT_STATUS=-1
-    @ECHO ERROR: No Visual Studio installation found. 1>&2
-    GOTO :HELP
-)
-SET PS_VSWHERE_QUERY_PRODUCT=-products Microsoft.VisualStudio.Product.%PS_PRODUCT_DEFAULT%
-
-REM Default to the latest supported version if multiple are available
-FOR /F "tokens=1 USEBACKQ delims=." %%I IN (
-    `^"%PS_VSWHERE_QUERY% %PS_VSWHERE_QUERY_PRODUCT% -property catalog_buildVersion^"`
-) DO SET PS_VERSION_SUPPORTED=%%I
 
 REM Probe build directories and system state for reasonable default arguments
 pushd %~dp0
@@ -106,15 +86,11 @@ CALL :TOLOWER PS_ARCH
 SET PS_RUN=none
 SET PS_DESTDIR=
 SET PS_VERSION=
-IF "%PS_PRODUCT_DEFAULT%" EQU "BuildTools" (
-    SET PS_PRODUCT=Community
-    SET PS_PRODUCT_NAME=MSBuild Tools
-) ELSE (
-    SET PS_PRODUCT=%PS_PRODUCT_DEFAULT%
-    SET PS_PRODUCT_NAME=Visual Studio
-)
-
 SET PS_PRIORITY=normal
+SET PS_TOOL=auto
+SET PS_PRODUCT=
+SET PS_VSWHERE_PRODUCTS=
+
 CALL :RESOLVE_DESTDIR_CACHE
 
 REM Set up parameters used by help menu
@@ -128,7 +104,7 @@ SET EXIT_STATUS=1
 SET PS_CURRENT_STEP=arguments
 SET PARSER_STATE=
 SET PARSER_FAIL=
-FOR %%I in (%*) DO CALL :PARSE_OPTION "ARCH CONFIG DESTDIR STEPS RUN VERSION PRODUCT PRIORITY" PARSER_STATE "%%~I"
+FOR %%I in (%*) DO CALL :PARSE_OPTION "ARCH CONFIG DESTDIR STEPS RUN VERSION PRODUCT PRIORITY TOOL" PARSER_STATE "%%~I"
 IF "%PARSER_FAIL%" NEQ "" (
     @ECHO ERROR: Invalid switch: %PARSER_FAIL% 1>&2
     GOTO :HELP
@@ -146,6 +122,12 @@ IF "%PS_CONFIG%" EQU "" GOTO :HELP
 CALL :PARSE_OPTION_VALUE "normal low" PS_PRIORITY
 SET PS_PRIORITY=%PS_PRIORITY:normal= %
 SET PS_PRIORITY=%PS_PRIORITY:low=-low% 
+
+SET PS_VSWHERE_PRODUCTS_DEFAULT="Enterprise Professional Community BuildTools"
+CALL :PARSE_OPTION_VALUE "auto visual msbuild" PS_TOOL
+IF "%PS_TOOL%" EQU "visual" SET PS_VSWHERE_PRODUCTS_DEFAULT="Enterprise Professional Community"
+IF "%PS_TOOL%" EQU "msbuild" SET PS_VSWHERE_PRODUCTS_DEFAULT="BuildTools"
+
 REM RESOLVE_DESTDIR_CACHE must go after PS_ARCH and PS_CONFIG, but before PS STEPS
 CALL :RESOLVE_DESTDIR_CACHE
 IF "%PS_STEPS%" EQU "" SET PS_STEPS=%PS_STEPS_DEFAULT%
@@ -180,17 +162,10 @@ IF "%PS_RUN%" NEQ "none" IF "%PS_STEPS:~0,4%" EQU "deps" (
     @ECHO ERROR: RUN=none is the only valid option for STEPS "deps" or "deps-dirty"
     GOTO :HELP
 )
-IF DEFINED PS_VERSION (
-    SET /A PS_VERSION_EXCEEDED=%PS_VERSION% + 1
-) ELSE SET PS_VERSION=%PS_VERSION_SUPPORTED%
-SET MSVC_FILTER=%PS_VSWHERE_QUERY_PRODUCT% -version "[%PS_VERSION%,%PS_VERSION_EXCEEDED%)"
-FOR /F "tokens=* USEBACKQ" %%I IN (`^""%VSWHERE%" %MSVC_FILTER% -nologo -property installationPath^"`) DO SET MSVC_DIR=%%I
-IF NOT EXIST "%MSVC_DIR%" (
-    @ECHO ERROR: Compatible Visual Studio installation not found. 1>&2
-    GOTO :HELP
-)
-REM Cmake always defaults to latest supported MSVC generator. Let's make sure it uses what we select.
-FOR /F "tokens=* USEBACKQ" %%I IN (`^""%VSWHERE%" %MSVC_FILTER% -nologo -property catalog_productLineVersion^"`) DO SET PS_PRODUCT_VERSION=%%I
+
+REM Search for the build tool to use
+CALL :SCAN_BUILD_TOOL
+IF %EXIT_STATUS% LSS 0 GOTO :HELP
 
 REM Give the user a chance to cancel if we found something odd.
 IF "%PS_ASK_TO_CONTINUE%" EQU "" GOTO :BUILD_ENV
@@ -337,6 +312,73 @@ exit /B %EXIT_STATUS%
 
 GOTO :EOF
 REM Functions and stubs start here.
+
+:SCAN_BUILD_TOOL
+REM Searches for a valid installation of MSBuild (EG Visual Studio, Build Tools)
+REM No Args
+REM Sets the following global variables:
+REM   PS_VERSION, PS_PRODUCT, PS_PRODUCT_NAME, MSVC_DIR, PS_PRODUCT_VERSION
+SET PS_VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+IF NOT EXIST "%PS_VSWHERE%" SET VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
+IF NOT EXIST "%PS_VSWHERE%" (
+    SET EXIT_STATUS=-1
+    @ECHO ERROR: vswhere.exe not found. 1>&2
+    GOTO :SCAN_BUILD_TOOL_END
+)
+
+IF DEFINED PS_VERSION (
+    SET /A PS_VERSION_EXCEEDED=%PS_VERSION% + 1
+) ELSE SET PS_VERSION=%PS_VERSION_SUPPORTED%
+SET PS_VSWHERE_QUERY_VERSION=-version "[%PS_VERSION%,%PS_VERSION_EXCEEDED%)"
+
+SET PS_VSWHERE_QUERY="%PS_VSWHERE%" -nologo
+
+REM if PS_PRODUCT was specified, we should search for that instead of BuildTools
+SET PS_VSWHERE_PRODUCTS=%PS_VSWHERE_PRODUCTS_DEFAULT%
+IF DEFINED PS_PRODUCT (
+    SET PS_VSWHERE_PRODUCTS="%PS_PRODUCT%"
+)
+
+CALL :VSWHERE_SEARCH %PS_VSWHERE_PRODUCTS% "-property productID" PS_PRODUCT
+FOR /F "tokens=4 delims=." %%I IN ("%PS_PRODUCT%") DO SET PS_PRODUCT=%%I
+
+IF "%PS_PRODUCT%" EQU "" (
+    SET EXIT_STATUS=-1
+    @ECHO ERROR: No Visual Studio ^(%PS_VSWHERE_PRODUCTS%^) installation found. 1>&2
+    GOTO :SCAN_BUILD_TOOL_END
+)
+
+CALL :VSWHERE_SEARCH %PS_PRODUCT% "-property displayName" PS_PRODUCT_NAME
+
+CALL :VSWHERE_SEARCH %PS_PRODUCT% "-property installationPath" MSVC_DIR
+
+IF NOT EXIST "%MSVC_DIR%" (
+    SET EXIT_STATUS=-1
+    @ECHO ERROR: Compatible Visual Studio installation not found. 1>&2
+    GOTO :SCAN_BUILD_TOOL_END
+)
+REM Cmake always defaults to latest supported MSVC generator. Let's make sure it uses what we select.
+CALL :VSWHERE_SEARCH %PS_PRODUCT% "-property catalog_productLineVersion" PS_PRODUCT_VERSION
+
+:SCAN_BUILD_TOOL_END
+
+GOTO :EOF
+
+:VSWHERE_SEARCH
+@REM Search for a product using vswhere.exe, ends of first one found
+@REM %1 - Valid list of Product IDs (EG "Community BuildTools")
+@REM %2 - Additional vswhere commandline options (EG "-property productID")
+@REM %3 - Out variable Name
+@REM Available ProductIDs: Enterprise, Professional, Community, BuildTools
+SetLocal EnableDelayedExpansion
+FOR %%I IN (%~1) DO (
+    FOR /F "tokens=* USEBACKQ" %%a IN (`^"%PS_VSWHERE_QUERY% %PS_VSWHERE_QUERY_VERSION% %~2 -products Microsoft.VisualStudio.Product.%%I^"`) DO SET PS_VSWHERE_RESULT=%%a
+    IF "!PS_VSWHERE_RESULT!" NEQ "" GOTO :VSWHERE_SEARCH_END
+)
+:VSWHERE_SEARCH_END
+endlocal & SET %~3=%PS_VSWHERE_RESULT%
+
+GOTO :EOF
 
 :RESOLVE_DESTDIR_CACHE
 @REM Resolves all DESTDIR cache values and sets PS_STEPS_DEFAULT

--- a/build_win.bat
+++ b/build_win.bat
@@ -64,6 +64,7 @@ SET PS_DEPS_PATH_FILE=%~dp0deps\build\%PS_DEPS_PATH_FILE_NAME%
 SET PS_CONFIG_LIST="Debug;MinSizeRel;Release;RelWithDebInfo"
 REM SET PS_VERBOSE=--log-level=VERBOSE --log-context
 SET PS_VERBOSE=
+SET PS_USE_MSBUILD=
 
 REM The officially supported toolchain version is 16 (Visual Studio 2019)
 REM TODO: Update versions after Boost gets rolled to 1.78 or later
@@ -78,7 +79,7 @@ IF NOT EXIST "%VSWHERE%" (
 )
 
 SET PS_VSWHERE_QUERY="%VSWHERE%" -version "[%PS_VERSION_SUPPORTED%,%PS_VERSION_EXCEEDED%)" -latest -nologo
-FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`^"%PS_VSWHERE_QUERY% -property productID^"`) DO SET PS_PRODUCT_DEFAULT_A=%%I
+IF %PS_USE_MSBUILD% NEQ 1 FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`^"%PS_VSWHERE_QUERY% -property productID^"`) DO SET PS_PRODUCT_DEFAULT_A=%%I
 IF "%PS_PRODUCT_DEFAULT_A%" EQU "" (
     @ECHO Visual Studio not found, searching for MSBuild Tools
     FOR /F "tokens=4 USEBACKQ delims=." %%I IN (`^"%PS_VSWHERE_QUERY% -products Microsoft.VisualStudio.Product.BuildTools -property productID^"`) DO SET PS_PRODUCT_DEFAULT_A=%%I


### PR DESCRIPTION
Added the option to use MS Build Tools with the command line parameter -TOOL
This also required some changes to -PRODUCT for compatibility and support.
All vswhere searches were consolidated to a single function to ensure consistent behavior.
It uses a for loop to search through valid Product ID's. the -PRODUCT switch can be used to define the products and the order they are searched. See https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2019&preserve-view=true for available product ID's. Setting -PRODUCT Overrides -TOOL behavior