### PR TITLE
Added Client certificate authentication to physical printer options

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2506,7 +2506,9 @@ void GCode::append_full_config(const Print &print, std::string &str)
         //FIXME The print host keys should not be exported to full_print_config anymore. The following keys may likely be removed.
         "print_host"sv,
         "printhost_apikey"sv,
-        "printhost_cafile"sv
+        "printhost_cafile"sv,
+        "printhost_client_cert"sv,
+        "printhost_clinet_cert_password"sv
     };
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));
     auto is_banned = [](const std::string &key) {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1430,6 +1430,8 @@ static std::vector<std::string> s_PhysicalPrinter_opts {
     "print_host",
     "printhost_apikey",
     "printhost_cafile",
+    "printhost_client_cert",
+    "printhost_client_cert_password",
     "printhost_port",
     "printhost_authorization_type",
     // HTTP digest authentization (RFC 2617)
@@ -1475,12 +1477,14 @@ const std::set<std::string>& PhysicalPrinter::get_preset_names() const
 
 bool PhysicalPrinter::has_empty_config() const
 {
-    return  config.opt_string("print_host"        ).empty() &&
-            config.opt_string("printhost_apikey"  ).empty() &&
-            config.opt_string("printhost_cafile"  ).empty() &&
-            config.opt_string("printhost_port"    ).empty() &&
-            config.opt_string("printhost_user"    ).empty() &&
-            config.opt_string("printhost_password").empty();
+    return  config.opt_string("print_host"                      ).empty() &&
+            config.opt_string("printhost_apikey"                ).empty() &&
+            config.opt_string("printhost_cafile"                ).empty() &&
+            config.opt_string("printhost_client_cert"           ).empty() && 
+            config.opt_string("printhost_client_cert_password"  ).empty() && 
+            config.opt_string("printhost_port"                  ).empty() &&
+            config.opt_string("printhost_user"                  ).empty() &&
+            config.opt_string("printhost_password"              ).empty();
 }
 
 // temporary workaround for compatibility with older Slicer

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -342,6 +342,22 @@ void PrintConfigDef::init_common_params()
     def->cli = ConfigOptionDef::nocli;
     def->set_default_value(new ConfigOptionString(""));
 
+    def = this->add("printhost_client_cert", coString);
+    def->label = L("Client Certificate File");
+    def->tooltip = L("A Client certificate file for use with 2-way ssl authentication, in p12/pfx format.  "
+                   "If left blank, no client certificate is used.");
+    def->mode = comAdvanced;
+    def->cli = ConfigOptionDef::nocli;
+    def->set_default_value(new ConfigOptionString(""));
+
+    def = this->add("printhost_client_cert_password", coString);
+    def->label = L("Client Certificate Password");
+    def->tooltip = L("Password for client certificate for 2-way ssl authentication. "
+                   "Leave blank if no password is needed");
+    def->mode = comAdvanced;
+    def->cli = ConfigOptionDef::nocli;
+    def->set_default_value(new ConfigOptionString(""));
+
     // Only available on Windows.
     def = this->add("printhost_ssl_ignore_revoke", coBool);
     def->label = L("Ignore HTTPS certificate revocation checks");

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -361,6 +361,49 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     port_line.append_widget(print_host_printers);
     m_optgroup->append_line(port_line);
 
+     option = m_optgroup->get_option("printhost_client_cert");
+    option.opt.width = Field::def_width_wider();
+    Line client_cert_line = m_optgroup->create_single_option_line(option);
+
+    auto printhost_client_cert_browse = [=](wxWindow* parent) {
+        auto sizer = create_sizer_with_btn(parent, &m_printhost_client_cert_browse_btn, "browse", _L("Browse") + " " + dots);
+        m_printhost_client_cert_browse_btn->Bind(wxEVT_BUTTON, [this, m_optgroup](wxCommandEvent e) {
+            static const auto filemasks = _L("Client certificate files (*.pfx, *.p12)|*.pfx;*.p12|All files|*.*");
+            wxFileDialog openFileDialog(this, _L("Open Client certificate file"), "", "", filemasks, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+            if (openFileDialog.ShowModal() != wxID_CANCEL) {
+                m_optgroup->set_value("printhost_client_cert", std::move(openFileDialog.GetPath()), true);
+                m_optgroup->get_field("printhost_client_cert")->field_changed();
+            }
+            });
+
+        return sizer;
+    };
+
+    client_cert_line.append_widget(printhost_client_cert_browse);
+    m_optgroup->append_line(client_cert_line);
+
+    option = m_optgroup->get_option("printhost_client_cert_password");
+    option.opt.width = Field::def_width_wider();
+    m_optgroup->append_single_option_line(option);
+    
+    auto client_cert_hint =  _u8L("Client certificate (2-way SSL):") + "\n\t" +
+        _u8L("Client certificate is optional. It is only needed if you use 2-way ssl.");
+#ifdef __APPLE__
+    client_cert_hint += "\n\t" +
+        _u8L("To use a client cert on MacOS, you might need to add your certificate to your keychain and make sure it's trusted.") + "\n\t" +
+        _u8L("You can either use a path to your certificate or the name of your certificate as you can find it in your Keychain");
+#endif //__APPLE__
+
+    Line clientcert_hint{ "", "" };
+    clientcert_hint.full_width = 1;
+    clientcert_hint.widget = [this, client_cert_hint](wxWindow* parent) {
+        auto txt = new wxStaticText(parent, wxID_ANY, client_cert_hint);
+        auto sizer = new wxBoxSizer(wxHORIZONTAL);
+        sizer->Add(txt);
+        return sizer;
+    };
+    m_optgroup->append_line(clientcert_hint);
+
     const auto ca_file_hint = _u8L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate.");
 
     if (Http::ca_file_supported()) {

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -69,13 +69,14 @@ class PhysicalPrinterDialog : public DPIDialog
 
     ConfigOptionsGroup* m_optgroup          { nullptr };
 
-    ScalableButton*     m_add_preset_btn                {nullptr};
-    ScalableButton*     m_printhost_browse_btn          {nullptr};
-    ScalableButton*     m_printhost_test_btn            {nullptr};
-    ScalableButton*     m_printhost_cafile_browse_btn   {nullptr};
-    ScalableButton*     m_printhost_port_browse_btn     {nullptr};
+    ScalableButton*     m_add_preset_btn                    {nullptr};
+    ScalableButton*     m_printhost_browse_btn              {nullptr};
+    ScalableButton*     m_printhost_test_btn                {nullptr};
+    ScalableButton*     m_printhost_cafile_browse_btn       {nullptr};
+    ScalableButton*     m_printhost_client_cert_browse_btn  {nullptr};
+    ScalableButton*     m_printhost_port_browse_btn         {nullptr};
 
-    wxBoxSizer*         m_presets_sizer                 {nullptr};
+    wxBoxSizer*         m_presets_sizer                     {nullptr};
 
     void build_printhost_settings(ConfigOptionsGroup* optgroup);
     void OnOK(wxEvent& event);

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -489,6 +489,15 @@ Http& Http::ca_file(const std::string &name)
 	return *this;
 }
 
+Http& Http::client_cert(const std::string &name, const std::string &password)
+{
+	curl_easy_setopt(p->curl, CURLOPT_SSLCERT, name.c_str());
+	curl_easy_setopt(p->curl, CURLOPT_SSLCERTTYPE, "P12");
+	curl_easy_setopt(p->curl, CURLOPT_KEYPASSWD, password.c_str());
+
+	return *this;
+}
+
 Http& Http::form_add(const std::string &name, const std::string &contents)
 {
 	if (p) {

--- a/src/slic3r/Utils/Http.hpp
+++ b/src/slic3r/Utils/Http.hpp
@@ -77,6 +77,8 @@ public:
 	// specifically, this is supported with OpenSSL and NOT supported with Windows and OS X native certificate store.
 	// See also ca_file_supported().
 	Http& ca_file(const std::string &filename);
+	// Set a client certificate for usage with 2-way ssl authentication (password for key is optional)
+	Http& client_cert(const std::string &filename, const std::string &password = "");
 	// Add a HTTP multipart form field
 	Http& form_add(const std::string &name, const std::string &contents);
 	// Add a HTTP multipart form file data contents, `name` is the name of the part

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -98,6 +98,8 @@ OctoPrint::OctoPrint(DynamicPrintConfig *config) :
     m_host(config->opt_string("print_host")),
     m_apikey(config->opt_string("printhost_apikey")),
     m_cafile(config->opt_string("printhost_cafile")),
+    m_client_cert(config->opt_string("printhost_client_cert")),
+    m_client_cert_password(config->opt_string("printhost_client_cert_password")),
     m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
 {}
 
@@ -261,6 +263,10 @@ void OctoPrint::set_auth(Http &http) const
     if (!m_cafile.empty()) {
         http.ca_file(m_cafile);
     }
+
+    if (! m_client_cert.empty()) {
+        http.client_cert(m_client_cert, m_client_cert_password);
+    }
 }
 
 std::string OctoPrint::make_url(const std::string &path) const
@@ -318,6 +324,10 @@ void SL1Host::set_auth(Http &http) const
     if (! get_cafile().empty()) {
         http.ca_file(get_cafile());
     }
+
+    if (! get_client_cert().empty()) {
+        http.client_cert(get_client_cert(), get_client_cert_password());
+    }
 }
 
 // PrusaLink
@@ -361,6 +371,10 @@ void PrusaLink::set_auth(Http& http) const
 
     if (!get_cafile().empty()) {
         http.ca_file(get_cafile());
+    }
+
+    if (! get_client_cert().empty()) {
+        http.client_cert(get_client_cert(), get_client_cert_password());
     }
 }
 

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -32,6 +32,8 @@ public:
     std::string get_host() const override { return m_host; }
     const std::string& get_apikey() const { return m_apikey; }
     const std::string& get_cafile() const { return m_cafile; }
+    const std::string& get_client_cert() const { return m_client_cert; }
+    const std::string& get_client_cert_password() const { return m_client_cert_password; }
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;
@@ -41,6 +43,8 @@ private:
     std::string m_apikey;
     std::string m_cafile;
     bool        m_ssl_revoke_best_effort;
+    std::string m_client_cert;
+    std::string m_client_cert_password;
 
     virtual void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;


### PR DESCRIPTION
I've added the option of adding a 2-way ssl certificate when uploading to a http host.
in reference to issue #8565

This change will allow users to add a client certificate to their request when it's send to their printer host.
The code was mostly copied from my implementation of this feature in SuperSlicer with some slight alterations to make it compatible with PrusaSlicer.

![image](https://user-images.githubusercontent.com/9167905/182153452-59518a57-9890-43ed-93b4-567826fdfc68.png)
