### PR TITLE
Problem with fuzzy on small paths

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -180,12 +180,14 @@ static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuz
         dist_left_over = p0p1_size - dist_last_point;
         p0 = &p1;
     }
-    while (out.size() < 3) {
+    if (out.size() < 3) {
         size_t point_idx = poly.size() - 2;
-        out.emplace_back(poly[point_idx]);
-        if (point_idx == 0)
-            break;
-        -- point_idx;
+        while (out.size() < 3) {
+            out.emplace_back(poly[point_idx]);
+	    if (point_idx == 0)
+	        break;
+	    -- point_idx;
+        }
     }
     if (out.size() >= 3)
         poly.points = std::move(out);
@@ -221,12 +223,14 @@ static void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, double fuzzy
         p0             = &p1;
     }
 
-    while (out.size() < 3) {
+    if (out.size() < 3) {
         size_t point_idx = ext_lines.size() - 2;
-        out.emplace_back(ext_lines[point_idx].p, ext_lines[point_idx].w, ext_lines[point_idx].perimeter_index);
-        if (point_idx == 0)
-            break;
-        -- point_idx;
+        while (out.size() < 3) {
+            out.emplace_back(ext_lines[point_idx].p, ext_lines[point_idx].w, ext_lines[point_idx].perimeter_index);
+	    if (point_idx == 0)
+	        break;
+	    -- point_idx;
+        }
     }
 
     if (ext_lines.back().p == ext_lines.front().p) // Connect endpoints.


### PR DESCRIPTION
There is a problem with the current fuzzy algorithm. the part for small path doesn't make sense.
I change it to at least to something more sane.

But I don't really understand the need for that. Can you explain?
Now that Arachne create many small segments, these are mangled by this algo.

That's what I may use for now on:
```
// Thanks Cura developers for this function.
static void fuzzy_paths(ExtrusionPaths& paths, coordf_t fuzzy_skin_thickness, coordf_t fuzzy_skin_point_dist)
{
    const coordf_t min_dist_between_points = fuzzy_skin_point_dist * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
    const coordf_t range_random_point_dist = fuzzy_skin_point_dist / 2.;
    coordf_t dist_left_over = coordf_t(rand()) * (min_dist_between_points / 2) / double(RAND_MAX); // the distance to be traversed on the line before making the first new point

    const Point last_point = paths.back().last_point();
    //not always a loop, with arachne
    bool is_loop = paths.front().first_point() == last_point;
#ifdef _DEBUG
    assert(paths.back().last_point() == paths.front().first_point());
    for (int i = 1; i < paths.size(); i++) {
        assert(paths[i - 1].last_point() == paths[i].first_point());
    }
    if (is_loop)
        assert(paths.front().polyline.points.front() == paths.back().polyline.points.back());
#endif
    Point p0 = is_loop ? last_point : paths.front().first_point();
    const Point* previous_point = is_loop ? &last_point : &paths.front().first_point();
    for (ExtrusionPath &path : paths) {
        Points out;
        size_t next_idx = 1;
        assert(p0 == path.polyline.points.front());
        // it always follow
        if (p0 != path.polyline.points.front()) {
            next_idx = 0;
        }
        out.reserve(path.polyline.points.size());
        out.push_back(*previous_point);
        for (; next_idx < path.polyline.points.size(); next_idx++)
        {
            Point& p1 = path.polyline.points[next_idx];
            // 'a' is the (next) new point between p0 and p1
            Vec2d  p0p1 = (p1 - p0).cast<double>();
            coordf_t p0p1_size = p0p1.norm();
            // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
            coordf_t dist_last_point = dist_left_over + p0p1_size * 2.;
            for (coordf_t p0pa_dist = dist_left_over; p0pa_dist < p0p1_size;
                p0pa_dist += min_dist_between_points + coordf_t(rand()) * range_random_point_dist / double(RAND_MAX))
            {
                coordf_t r = coordf_t(rand()) * (fuzzy_skin_thickness * 2.) / double(RAND_MAX) - fuzzy_skin_thickness;
                out.emplace_back(p0 + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * r).cast<coord_t>());
                dist_last_point = p0pa_dist;
            }
            dist_left_over = p0p1_size - dist_last_point;
            p0 = p1;
        }
        //if (out.size() < 3) {
        //    size_t point_idx = path.polyline.size() - 2;
        //    while (out.size() < 3) {
        //        out.emplace_back(path.polyline.points[point_idx]);
        //        if (point_idx == 0)
        //            break;
        //        --point_idx;
        //    }
        //}
        //if (out.size() >= 3)
            path.polyline.points = std::move(out);
        previous_point = &path.polyline.points.back();
    }
    if (is_loop) {
        assert(paths.front().polyline.points.front() != paths.back().polyline.points.back());
        paths.back().polyline.points.push_back(paths.front().polyline.points.front());
        assert(paths.front().polyline.points.front() == paths.back().polyline.points.back());
    } else {
        paths.back().polyline.points.push_back(last_point);
    }
#ifdef _DEBUG
    assert(paths.back().last_point() == paths.front().first_point());
    for (int i = 1; i < paths.size(); i++) {
        assert(paths[i - 1].last_point() == paths[i].first_point());
    }
#endif
}
```