### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ xs/assertlib*
 local-lib
 /src/TAGS
 /.vscode/
+build/*
 build-linux/*
+deps/build/*
 deps/build-linux/*
 **/.DS_Store
 **/.idea/


### PR DESCRIPTION
Documentation recommends to use ./build and ./deps/build directories but they were not in .gitignore.