### PR TITLE
Order list of vendors in ConfigWizard

### DIFF
--- a/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -75,7 +75,7 @@ struct Bundle
 	const std::string& vendor_id() const { return vendor_profile->id; }
 };
 
-struct BundleMap : std::unordered_map<std::string /* = vendor ID */, Bundle>
+struct BundleMap : std::map<std::string /* = vendor ID */, Bundle>
 {
 	static BundleMap load();
 


### PR DESCRIPTION
This change orders the list of "Other Vendors" presented to the user in the Configuration Wizard.

Before:
<img width="781" alt="image" src="https://user-images.githubusercontent.com/609348/188006031-12bbedae-1e3a-49db-b63b-2608eb890d3f.png">
After:
<img width="786" alt="image" src="https://user-images.githubusercontent.com/609348/188006174-f8b34e90-98ae-4058-8db4-b0f396677c2e.png">
