### PR TITLE
Label Objects By Default for Creality Printers

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -398,6 +398,7 @@ first_layer_height = 0.2
 first_layer_speed = 20
 gap_fill_speed = 30
 gcode_comments = 0
+gcode_label_objects = 1
 infill_every_layers = 1
 infill_extruder = 1
 infill_first = 0


### PR DESCRIPTION
This enables the Object Labels by default for all Creality printers. It improves gcode readability, and allows klipper and octoprint to cancel objects.

There is prior work for enabling this: https://github.com/prusa3d/PrusaSlicer/issues/5151