### PR TITLE
Implement Z steps increment, aka "magic number" for variable layer height

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2945,6 +2945,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def = this->add("step_layer_height", coFloat);
+    def->label = L("Printer height increment");
+    def->tooltip = L("This is resolution of Z axis, a.k.a \"magic number\". Printer always change height with increments, despite commands precision. Typical values are between 0.01 mm and 0.04 mm. "
+                   "Also it's worth to set all other height parameters (layer, initial layer, support gaps) as multipliers of this value.");
+    def->sidetext = L("mm");
+    def->min = 0.001;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat{ 0.01 });
+
     def = this->add("wipe", coBools);
     def->label = L("Wipe while retracting");
     def->tooltip = L("This flag will move the nozzle while retracting to minimize the possible blob "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -787,6 +787,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,             wiping_volumes_matrix))
     ((ConfigOptionFloats,             wiping_volumes_extruders))
     ((ConfigOptionFloat,              z_offset))
+    ((ConfigOptionFloat,              step_layer_height))
 )
 
 PRINT_CONFIG_CLASS_DERIVED_DEFINE0(

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -109,6 +109,7 @@ SlicingParameters SlicingParameters::create_from_config(
     }
     params.min_layer_height = std::min(params.min_layer_height, params.layer_height);
     params.max_layer_height = std::max(params.max_layer_height, params.layer_height);
+    params.step_layer_height = print_config.step_layer_height;
 
     if (! soluble_interface) {
         params.gap_raft_object    = object_config.raft_contact_distance.value;
@@ -187,6 +188,7 @@ std::vector<coordf_t> layer_height_profile_from_ranges(
         coordf_t lo = it_range->first.first;
         coordf_t hi = it_range->first.second;
         coordf_t height = it_range->second;
+        height = round_to_factor(height, slicing_params.step_layer_height);
         coordf_t last_z      = layer_height_profile.empty() ? 0. : layer_height_profile[layer_height_profile.size() - 2];
         if (lo > last_z + EPSILON) {
             // Insert a step of normal layer height.
@@ -240,6 +242,7 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
         // Slic3r::debugf "\n Slice layer: %d\n", $id;
         // determine next layer height
         float cusp_height = as.next_layer_height(float(print_z), quality_factor, current_facet);
+        cusp_height = round_to_factor(cusp_height, slicing_params.step_layer_height);
 
 #if 0
         // check for horizontal features and object size
@@ -379,6 +382,7 @@ std::vector<double> smooth_height_profile(const std::vector<double>& profile, co
             height = std::clamp(weight_total == 0 ? hi : height / weight_total, slicing_params.min_layer_height, slicing_params.max_layer_height);
             if (smoothing_params.keep_min)
                 height = std::min(height, hi);
+            height = round_to_factor(height, slicing_params.step_layer_height);
         }
 
         return ret;
@@ -614,6 +618,7 @@ std::vector<coordf_t> generate_object_layers(
                 coordf_t z2 = layer_height_profile[next];
                 coordf_t h2 = layer_height_profile[next + 1];
                 height = lerp(h1, h2, (slice_z - z1) / (z2 - z1));
+                height = round_to_factor(height, slicing_params.step_layer_height);
                 assert(height >= slicing_params.min_layer_height - EPSILON && height <= slicing_params.max_layer_height + EPSILON);
             }
         }

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -63,6 +63,7 @@ struct SlicingParameters
     // or by an interactive layer height editor.
     coordf_t    min_layer_height { 0 };
     coordf_t    max_layer_height { 0 };
+    coordf_t    step_layer_height {0};
     coordf_t    max_suport_layer_height { 0 };
 
     // First layer height of the print, this may be used for the first layer of the raft

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -258,6 +258,12 @@ constexpr inline bool is_approx(Number value, Number test_value)
     return std::fabs(double(value) - double(test_value)) < double(EPSILON);
 }
 
+template<typename T, typename Number>
+constexpr inline T round_to_factor(T value, Number factor)
+{
+    return value < factor ? factor : std::round(value / factor) * factor;
+}
+
 // A meta-predicate which is true for integers wider than or equal to coord_t
 template<class I> struct is_scaled_coord
 {

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -787,8 +787,8 @@ wxString Control::get_label(int tick, LabelType label_type/* = ltHeightWithLayer
             return value < m_layers_times.size() ? short_and_splitted_time(get_time_dhms(m_layers_times[value])) : "";
         }
         wxString str = m_values.empty() ?
-            wxString::Format("%.*f", 2, m_label_koef * value) :
-            wxString::Format("%.*f", 2, m_values[value]);
+            wxString::Format("%.*f", 3, m_label_koef * value) :
+            wxString::Format("%.*f", 3, m_values[value]);
         if (label_type == ltHeight)
             return str;
         if (label_type == ltHeightWithLayer) {

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -343,6 +343,7 @@ std::string GLCanvas3D::LayersEditing::get_tooltip(const GLCanvas3D& canvas) con
                     float dz = zi - zi_1;
                     h = (dz != 0.0f) ? static_cast<float>(lerp(m_layer_height_profile[i - 1], m_layer_height_profile[i + 1], (z - zi_1) / dz)) :
                         static_cast<float>(m_layer_height_profile[i + 1]);
+                    h = round_to_factor(h, m_slicing_parameters->step_layer_height);
                     break;
                 }
             }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2001,7 +2001,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "layer_height", "first_layer_height", "min_layer_height", "max_layer_height",
         "brim_width", "perimeters", "perimeter_extruder", "fill_density", "infill_extruder", "top_solid_layers", 
         "support_material", "support_material_extruder", "support_material_interface_extruder", 
-        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers"
+        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers", "step_layer_height"
         }))
     , sidebar(new Sidebar(q))
     , notification_manager(std::make_unique<NotificationManager>(q))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2355,6 +2355,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("use_firmware_retraction");
         optgroup->append_single_option_line("use_volumetric_e");
         optgroup->append_single_option_line("variable_layer_height");
+        optgroup->append_single_option_line("step_layer_height");
 
     const int gcode_field_height = 15; // 150
     const int notes_field_height = 25; // 250


### PR DESCRIPTION
Currently variable height feature produces heights with float precision, thing without any physical meaning, as printer is capable to move only with fixed increments (steps). For example Creality and some (if not many) other printers has step 0.04 mm.

Though probably arbitrary layer height doesn't really affects print quality (there are different opinions) ( nevertheless having continues float precision in GUI is confusing and may make exact printing parameters adjusting more difficult.

So I added new parameter to Printer configuration tab, and round generated layer heights to its value. Also I increased displayed height precision to three digits to that height is not rounded in GUI.

Support generation is not changed.


WIP, do not merge!!!
