### PR TITLE
Fixes #2672, extruder moving to an incorrect position after color change

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2181,7 +2181,13 @@ GCode::LayerResult GCode::process_layer(
 
     if (single_object_instance_idx == size_t(-1)) {
         // Normal (non-sequential) print.
-        gcode += ProcessLayer::emit_custom_gcode_per_print_z(*this, layer_tools.custom_gcode, m_writer.extruder()->id(), first_extruder_id, print.config());
+        std::string custom_gcode = ProcessLayer::emit_custom_gcode_per_print_z(*this, layer_tools.custom_gcode, m_writer.extruder()->id(), first_extruder_id, print.config());
+        if (layer_tools.custom_gcode != nullptr && layer_tools.custom_gcode->type == CustomGCode::ColorChange) {
+            // We have a color change to do on this layer, but we want to do it immediately before the first extrusion instead of now, in order to fix GH #2672
+            m_pending_pre_extrusion_gcode = custom_gcode;
+        } else {
+            gcode += custom_gcode;
+        }
     }
     // Extrude skirt at the print_z of the raft layers and normal object layers
     // not at the print_z of the interlaced support material layers.
@@ -2871,6 +2877,12 @@ std::string GCode::_extrude(const ExtrusionPath &path, const std::string_view de
 
     // compensate retraction
     gcode += this->unretract();
+
+    if (!m_pending_pre_extrusion_gcode.empty()) {
+        // There is G-Code that is due to be inserted before an extrusion starts. Insert it.
+        gcode += m_pending_pre_extrusion_gcode;
+        m_pending_pre_extrusion_gcode.clear();
+    }
 
     // adjust acceleration
     if (m_config.default_acceleration.value > 0) {

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -420,6 +420,8 @@ private:
     bool                                m_brim_done;
     // Flag indicating whether the nozzle temperature changes from 1st to 2nd layer were performed.
     bool                                m_second_layer_things_done;
+    // G-code that is due to be written before the next extrusion
+    std::string                         m_pending_pre_extrusion_gcode;
     // Index of a last object copy extruded.
     std::pair<const PrintObject*, Point> m_last_obj_copy;
 


### PR DESCRIPTION
Please see issue #2672 to understand the problem this PR fixes.

Before my change, PrusaSlicer would generate G-Code like the following:

1. Finish the previous layer
2. **Color change**
3. Retract
4. Move to next layer and position
5. Unretract

This PR moves the color change (M600) so that it happens after the move:

1. Finish the previous layer
2. Retract
3. Move to next layer and position
4. Unretract
5. **Color change**

This fixes the issue of moving back to the previous layer's last position after a color change, and incorrectly depositing the new filament there.

I tested the change with multiple prints of a test model I created.

Test model in PrusaSlicer:
![sliced](https://user-images.githubusercontent.com/11064768/195501696-6ec6d434-089b-47ae-9035-97b9047d2d4d.png)

Result with original code. You can see the blob of new filament in the corner:
![before](https://user-images.githubusercontent.com/11064768/195501176-93b4db3f-92f6-4a18-a8ef-adff4637f1e0.png)

Result with the change. You can see the issue is gone:
![after](https://user-images.githubusercontent.com/11064768/195501221-a9782c1b-0339-4a48-8234-3bd0873e49d5.png)

Here is the STL of the test model:
[cctest.zip](https://github.com/prusa3d/PrusaSlicer/files/9770789/cctest.zip)
