### PR TITLE
Bump minimum openvdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,7 +552,7 @@ if(SLIC3R_STATIC)
     set(USE_BLOSC TRUE)
 endif ()
 
-find_package(OpenVDB 5.0 COMPONENTS openvdb)
+find_package(OpenVDB 7.1 COMPONENTS openvdb)
 if(OpenVDB_FOUND)
     slic3r_remap_configs(IlmBase::Half RelWithDebInfo Release)
     slic3r_remap_configs(Blosc::blosc RelWithDebInfo Release)


### PR DESCRIPTION
FastSweeping.h, first used by 1a6a2a0b9a53da907355a577f18ce07323bbdca5 was introduced  in OpenVDB 7.1 https://github.com/AcademySoftwareFoundation/openvdb/commit/d2c92d0f56f2b5f79b85feac36dafb575391e233