### PR TITLE
Try to use datadir from environment variable PRUSA_SLICER_DATADIR if set

### DIFF
--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -25,6 +25,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/nowide/args.hpp>
+#include <boost/log/trivial.hpp>
 #include <boost/nowide/cenv.hpp>
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/integration/filesystem.hpp>
@@ -721,7 +722,20 @@ bool CLI::setup(int argc, char **argv)
 
     set_data_dir(m_config.opt_string("datadir"));
     
-    //FIXME Validating at this stage most likely does not make sense, as the config is not fully initialized yet.
+    // if datadir is still empty (means no --datadir opt)
+    // then use datadir from environment
+    if (data_dir().empty()) {
+        auto data_dir_candidate = boost::nowide::getenv("PRUSA_SLICER_DATADIR");
+
+        if (data_dir_candidate != nullptr) {
+            set_data_dir(data_dir_candidate);
+            BOOST_LOG_TRIVIAL(info)
+                << "Trying to use datadir from environment variable: "
+                << data_dir_candidate << std::endl;
+        }
+    }
+
+    // FIXME Validating at this stage most likely does not make sense, as the config is not fully initialized yet.
     if (!validity.empty()) {
         boost::nowide::cerr << "error: " << validity << std::endl;
         return false;


### PR DESCRIPTION
### Why ? 

While i love PrusaSlicer i currently have to start it using some kind of proxy since i (like i assume many others) sync my Slicer settings via a cloud service. 
For this to work --datadir must be passed to PrusaSlicer, by e.g. creating a .bat-file or a script under Linux. 

### Solution 

I thought it would be nice to set this datadir via the environment, which would enable me to set it once and then just start the slicer without setting anything at all. Which is exactly what this request is trying to patch in. 

### Notes 
I checked that setting the --datadir option will take precedence, and not setting the environment variable will fallback to the default directories. So this change should be non-intrusive to current setups. 

While i consider this change trivial, i have not tested if boost:nowide::getenv properly works on windows.

Also if this was already considered and voted against then i am sorry for raising it again, I was unable to find this approach discussed in the issues. 