### PR TITLE
Arrange room for skirt and brim

### DIFF
--- a/src/libslic3r/Arrange.hpp
+++ b/src/libslic3r/Arrange.hpp
@@ -42,12 +42,21 @@ static const constexpr int UNARRANGED = -1;
 /// polygon belongs: UNARRANGED means no place for the polygon
 /// (also the initial state before arrange), 0..N means the index of the bed.
 /// Zero is the physical bed, larger than zero means a virtual bed.
-struct ArrangePolygon { 
-    ExPolygon poly;                 /// The 2D silhouette to be arranged
+struct ArrangePolygon {
+    /// The 2D silhouette that will be packed against other
+    /// ArrangePolygon.poly's.  Must be a convex hull.
+    ExPolygon poly;
+
+    /// The 2D silhouette that will be packed against the bed
+    /// edges. Must be a convex hull.
+    ExPolygon first_layer_poly;
     Vec2crd   translation{0, 0};    /// The translation of the poly
     double    rotation{0.0};        /// The rotation of the poly in radians
-    coord_t   inflation = 0;        /// Arrange with inflated polygon
     int       bed_idx{UNARRANGED};  /// To which logical bed does poly belong...
+
+    /// How early should we try to place this ArrangePolygon?  Higher
+    /// number is earlier. Used to make sure the wipe tower is placed
+    /// on the first bed.
     int       priority{0};
     
     // If empty, any rotation is allowed (currently unsupported)


### PR DESCRIPTION
Hello

I've changed the Arrange function so that it makes sure that any skirt or brim added also fits the bed. No longer does one press the arrange button and then after one slices, the skirt/brim is outside the bed!

![brim-demo](https://user-images.githubusercontent.com/75159519/202836048-b8f79dbb-e64d-43cc-b5b0-9592077832c7.png)

I've contained the libnest2d changes so that they are backwards compatible with earlier versions, to make it easier to merge with upstream.

I believe these changes fixes https://github.com/prusa3d/PrusaSlicer/issues/3477 and https://github.com/prusa3d/PrusaSlicer/issues/3072

I wasn't aware of https://github.com/prusa3d/PrusaSlicer/pull/7653 until a couple of minutes ago. The major difference is that these changes I made are capable of handling individual brim settings, per object. I also found out that thread safety issue (but on my own, why didn't I read this earlier!!) and implemented the flow calculations directly from the configuration, much like [bubnikv suggested here](https://github.com/prusa3d/PrusaSlicer/pull/7653#issuecomment-1018548974)

Best,
David