### PR TITLE
Set RatOS extrusion mode in Rat Rig profiles

### DIFF
--- a/resources/profiles/RatRig.ini
+++ b/resources/profiles/RatRig.ini
@@ -436,7 +436,7 @@ retract_restart_extra_toolchange = 0
 retract_speed = 40
 silent_mode = 0
 single_extruder_multi_material = 0
-start_gcode = M190 S0 ; Prevents prusaslicer from prepending m190 to the gcode interfering with the macro\nM109 S0 ; Prevents prusaslicer from prepending m109 to the gcode interfering with the macro\nSTART_PRINT EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]\n;enable this if you have a BTT Smart Filament Sensor\nSET_FILAMENT_SENSOR SENSOR=my_sensor ENABLE=0\n
+start_gcode = M190 S0 ; Prevents prusaslicer from prepending m190 to the gcode interfering with the macro\nM109 S0 ; Prevents prusaslicer from prepending m109 to the gcode interfering with the macro\nSET_GCODE_VARIABLE MACRO=RatOS VARIABLE=relative_extrusion VALUE=True\nSTART_PRINT EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]\n;enable this if you have a BTT Smart Filament Sensor\nSET_FILAMENT_SENSOR SENSOR=my_sensor ENABLE=0\n
 thumbnails = 16x16,220x220
 toolchange_gcode = 
 use_firmware_retraction = 0
@@ -499,7 +499,7 @@ retract_restart_extra_toolchange = 0
 retract_speed = 40
 silent_mode = 0
 single_extruder_multi_material = 0
-start_gcode = M190 S0 ; Prevents prusaslicer from prepending m190 to the gcode interfering with the macro\nM109 S0 ; Prevents prusaslicer from prepending m109 to the gcode interfering with the macro\nSTART_PRINT EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]\n;enable this if you have a BTT Smart Filament Sensor\nSET_FILAMENT_SENSOR SENSOR=my_sensor ENABLE=0\n
+start_gcode = M190 S0 ; Prevents prusaslicer from prepending m190 to the gcode interfering with the macro\nM109 S0 ; Prevents prusaslicer from prepending m109 to the gcode interfering with the macro\nSET_GCODE_VARIABLE MACRO=RatOS VARIABLE=relative_extrusion VALUE=True\nSTART_PRINT EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]\n;enable this if you have a BTT Smart Filament Sensor\nSET_FILAMENT_SENSOR SENSOR=my_sensor ENABLE=0\n
 start_gcode_manual = 0
 template_custom_gcode = 
 thumbnails = 16x16,220x220


### PR DESCRIPTION
This PR makes the RatRig profiles work out of the box by setting relative extrusion mode in RatOS. The user previously had to remember to set it in their config files, this change fixes that problem.

@top-gun i forgot to remind you, so i just did it myself :)