### PR TITLE
Added tools_used placeholder to print_start gcode

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1254,6 +1254,15 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     m_placeholder_parser.set("has_wipe_tower", has_wipe_tower);
     m_placeholder_parser.set("has_single_extruder_multi_material_priming", has_wipe_tower && print.config().single_extruder_multi_material_priming);
     m_placeholder_parser.set("total_toolchanges", std::max(0, print.wipe_tower_data().number_of_toolchanges)); // Check for negative toolchanges (single extruder mode) and set to 0 (no tool change).
+    // Placeholder with list of tools used in print. Useful for MMU setup & checking prior to starting print
+    std::string tools_used = "";
+    for (unsigned int extruder_id : print.extruders()) {
+        if (print.wipe_tower_data().used_filament[extruder_id] > 0) {
+            if (tools_used.size() > 0)
+                tools_used += ",";
+            tools_used += std::to_string(extruder_id);
+        }
+    }
     {
         BoundingBoxf bbox(print.config().bed_shape.values);
         m_placeholder_parser.set("print_bed_min",  new ConfigOptionFloats({ bbox.min.x(), bbox.min.y() }));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1263,6 +1263,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
             tools_used += std::to_string(extruder_id);
         }
     }
+    m_placeholder_parser.set("tools_used", tools_used);
     {
         BoundingBoxf bbox(print.config().bed_shape.values);
         m_placeholder_parser.set("print_bed_min",  new ConfigOptionFloats({ bbox.min.x(), bbox.min.y() }));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1256,14 +1256,16 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     m_placeholder_parser.set("total_toolchanges", std::max(0, print.wipe_tower_data().number_of_toolchanges)); // Check for negative toolchanges (single extruder mode) and set to 0 (no tool change).
     // Placeholder with list of tools used in print. Useful for MMU setup & checking prior to starting print
     std::string tools_used = "";
-    for (unsigned int extruder_id : print.extruders()) {
-        if (print.wipe_tower_data().used_filament[extruder_id] > 0) {
-            if (tools_used.size() > 0)
-                tools_used += ",";
-            tools_used += std::to_string(extruder_id);
+    if (has_wipe_tower) {
+        for (unsigned int extruder_id : print.extruders()) {
+            if (print.wipe_tower_data().used_filament[extruder_id] > 0) {
+                if (tools_used.size() > 0)
+                    tools_used += ",";
+                tools_used += std::to_string(extruder_id);
+            }
         }
     }
-    m_placeholder_parser.set("tools_used", tools_used);
+    m_placeholder_parser.set("tools_used", tools_used); // Empty string if no tools explicitly defined
     {
         BoundingBoxf bbox(print.config().bed_shape.values);
         m_placeholder_parser.set("print_bed_min",  new ConfigOptionFloats({ bbox.min.x(), bbox.min.y() }));


### PR DESCRIPTION
This is a simple extension that adds a new placeholder to the print_start custom gcode.  The primary use case is to be able to validate the availability of all required tools in the print start logic.  This is particularly useful for MMU printing where you can validate the availability and readiness of all filaments prior to start to avoid failures later in the print.

The new placeholder is a string containing a comma separated list of tool numbers.  For example a MMU print using tools T0, T1 & T5 would result in

tools_used = "0,1,5"

if print does not include multiple (defined) extruders the tools_used will be an empty string.

