### PR TITLE
Remove 'custom' stats from legend scale for all plots

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -751,12 +751,13 @@ void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::v
         {
         case EMoveType::Extrude:
         {
-            m_extrusions.ranges.height.update_from(round_to_bin(curr.height));
-            m_extrusions.ranges.width.update_from(round_to_bin(curr.width));
-            m_extrusions.ranges.fan_speed.update_from(curr.fan_speed);
-            m_extrusions.ranges.temperature.update_from(curr.temperature);
-            if (curr.extrusion_role != erCustom || is_visible(erCustom))
+            if (curr.extrusion_role != erCustom || is_visible(erCustom)) {
+                m_extrusions.ranges.height.update_from(round_to_bin(curr.height));
+                m_extrusions.ranges.width.update_from(round_to_bin(curr.width));
+                m_extrusions.ranges.fan_speed.update_from(curr.fan_speed);
+                m_extrusions.ranges.temperature.update_from(curr.temperature);
                 m_extrusions.ranges.volumetric_rate.update_from(round_to_bin(curr.volumetric_rate()));
+            }
             [[fallthrough]];
         }
         case EMoveType::Travel:


### PR DESCRIPTION
Don't include metrics from 'custom' category in plot legend scale, as the prime/intro line tends to blow the range way out, making the rest of the plot nearly a single color.

See: https://github.com/prusa3d/PrusaSlicer/issues/8777
     https://github.com/prusa3d/PrusaSlicer/issues/7066