### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/libslic3r/PNGReadWrite.hpp
+++ b/src/libslic3r/PNGReadWrite.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <istream>
+#include <cstdint>
 
 namespace Slic3r { namespace png {
 


### PR DESCRIPTION
See https://gcc.gnu.org/gcc-13/porting_to.html

> The following headers are used less widely in libstdc++
> and may need to be included explicitly when compiling with GCC 13:
> ...
> <cstdint> (for std::int8_t, std::int32_t etc.)

Authored by @swt2c for Fedora.