### PR TITLE
Add new variable project_filename(_base)

### DIFF
--- a/src/libslic3r/PrintBase.cpp
+++ b/src/libslic3r/PrintBase.cpp
@@ -70,8 +70,8 @@ std::string PrintBase::output_filename(const std::string &format, const std::str
     PlaceholderParser::update_timestamp(cfg);
     this->update_object_placeholders(cfg, default_ext);
     if (! filename_base.empty()) {
-		cfg.set_key_value("input_filename", new ConfigOptionString(filename_base + default_ext));
-		cfg.set_key_value("input_filename_base", new ConfigOptionString(filename_base));
+		cfg.set_key_value("project_filename", new ConfigOptionString(filename_base + default_ext));
+		cfg.set_key_value("project_filename_base", new ConfigOptionString(filename_base));
     }
     try {
 		boost::filesystem::path filename = format.empty() ?


### PR DESCRIPTION
When a lot of STL files are open in project, I expected the exported gcode to have the sliced model STL filename in its filename, but with the project saved, the project filename replaces input_filename(_base)

So I'm trying to fix this and make a separate variable for the project filename

This is fine?