### PR TITLE
Cut: Keep results as parts of current object

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1469,18 +1469,20 @@ void ModelObject::process_solid_part_cut(ModelVolume* volume, const Transform3d&
     {
         indexed_triangle_set upper_its, lower_its;
         cut_mesh(mesh.its, 0.0f, &upper_its, &lower_its);
-        if (attributes.has(ModelObjectCutAttribute::KeepUpper))
+        if (attributes.has(ModelObjectCutAttribute::KeepUpper) || attributes.has(ModelObjectCutAttribute::KeepAsParts))
             upper_mesh = TriangleMesh(upper_its);
-        if (attributes.has(ModelObjectCutAttribute::KeepLower))
+        if (attributes.has(ModelObjectCutAttribute::KeepLower) || attributes.has(ModelObjectCutAttribute::KeepAsParts))
             lower_mesh = TriangleMesh(lower_its);
     }
 
     // Add required cut parts to the objects
 
-    if (attributes.has(ModelObjectCutAttribute::KeepUpper))
+    if (attributes.has(ModelObjectCutAttribute::KeepAsParts))
+        add_cut_volume(upper_mesh, lower, volume, cut_matrix);
+    else if (attributes.has(ModelObjectCutAttribute::KeepUpper))
         add_cut_volume(upper_mesh, upper, volume, cut_matrix);
 
-    if (attributes.has(ModelObjectCutAttribute::KeepLower) && !lower_mesh.empty()) {
+    if ((attributes.has(ModelObjectCutAttribute::KeepLower) && !lower_mesh.empty()) || attributes.has(ModelObjectCutAttribute::KeepAsParts)) {
         add_cut_volume(lower_mesh, lower, volume, cut_matrix);
 
         // Compute the displacement (in instance coordinates) to be applied to place the upper parts

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -316,7 +316,7 @@ enum class ModelVolumeType : int {
     SUPPORT_ENFORCER,
 };
 
-enum class ModelObjectCutAttribute : int { KeepUpper, KeepLower, FlipUpper, FlipLower, PlaceOnCutUpper, PlaceOnCutLower, CreateDowels };
+enum class ModelObjectCutAttribute : int { KeepUpper, KeepLower, KeepAsParts, FlipUpper, FlipLower, PlaceOnCutUpper, PlaceOnCutLower, CreateDowels };
 using ModelObjectCutAttributes = enum_bitmask<ModelObjectCutAttribute>;
 ENABLE_ENUM_BITMASK_OPERATORS(ModelObjectCutAttribute);
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.hpp
@@ -90,6 +90,7 @@ class GLGizmoCut3D : public GLGizmoBase
 
     bool m_keep_upper{ true };
     bool m_keep_lower{ true };
+    bool m_as_parts{ false };
     bool m_place_on_cut_upper{ true };
     bool m_place_on_cut_lower{ false };
     bool m_rotate_upper{ false };


### PR DESCRIPTION
This is a small change that adds the option to keep the cut piece in-place as a part of the current object. I'd been using this in my own build to add automatic color changes at layers in my MMU2 prints. But updating it to work with the new angled cut features in the 2.6 alpha now enables fun stuff like this (made from two cuts on pyramid.stl from the default **_Gallery_**).

![image](https://user-images.githubusercontent.com/13139373/216709090-7399deb2-02c3-4056-b777-8f43eee9c82f.png)

The UX for this PR adds an **_As part_** checkbox to the **_Cut_** dialog. When checked, the connector and placement options are disabled, since they really don't seem to make sense with keeping a single, untranslated object. Clicking either of the two **_As part_** options will result in an identical multi-part volume, but it seemed best to present it this way given the structure of the current dialog and code. Most of the code in this PR is just the GUI integration, since the change to the actual cut operation is so small. Here's what the UX looks like.

![image](https://user-images.githubusercontent.com/13139373/216710062-4b210478-309c-49b3-a47c-d00ed5de931c.png)

/CC @YuSanka 