### PR TITLE
Improve Pressure Equalizer and fix related bugs

### DIFF
--- a/src/libslic3r/GCode/ExtrusionProcessor.hpp
+++ b/src/libslic3r/GCode/ExtrusionProcessor.hpp
@@ -260,14 +260,13 @@ public:
     std::vector<ProcessedPoint> estimate_extrusion_quality(const ExtrusionPath                &path,
                                                            const ConfigOptionPercents         &overlaps,
                                                            const ConfigOptionFloatsOrPercents &speeds,
-                                                           float                               ext_perimeter_speed,
                                                            float                               original_speed)
     {
         size_t                               speed_sections_count = std::min(overlaps.values.size(), speeds.values.size());
         std::vector<std::pair<float, float>> speed_sections;
         for (size_t i = 0; i < speed_sections_count; i++) {
             float distance = path.width * (1.0 - (overlaps.get_at(i) / 100.0));
-            float speed    = speeds.get_at(i).percent ? (ext_perimeter_speed * speeds.get_at(i).value / 100.0) : speeds.get_at(i).value;
+            float speed    = speeds.get_at(i).percent ? (original_speed * speeds.get_at(i).value / 100.0) : speeds.get_at(i).value;
             speed_sections.push_back({distance, speed});
         }
         std::sort(speed_sections.begin(), speed_sections.end(),

--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -1,6 +1,7 @@
 #include <memory.h>
 #include <cstring>
 #include <cfloat>
+#include <algorithm>
 
 #include "../libslic3r.h"
 #include "../PrintConfig.hpp"
@@ -20,12 +21,18 @@ static const std::string EXTERNAL_PERIMETER_TAG = ";_EXTERNAL_PERIMETER";
 
 // Maximum segment length to split a long segment if the initial and the final flow rate differ.
 // Smaller value means a smoother transition between two different flow rates.
-static constexpr float max_segment_length = 5.f;
+static constexpr float max_segment_length = 1.f;
 
 // For how many GCode lines back will adjust a flow rate from the latest line.
 // Bigger values affect the GCode export speed a lot, and smaller values could
 // affect how distant will be propagated a flow rate adjustment.
 static constexpr int max_look_back_limit = 128;
+
+// Max non-extruding XY distance (travel move) in mm between two continous extrusions where we pretend
+// its all one continous extruded line. Above this distance we assume extruder pressure hits 0
+// This exists because often there's tiny travel moves between stuff like infill 
+// lines where some extruder pressure will remain (so we should equalize between these small travels)
+static constexpr long max_ignored_gap_between_extruding_segments = 3;
 
 PressureEqualizer::PressureEqualizer(const Slic3r::GCodeConfig &config) : m_use_relative_e_distances(config.use_relative_e_distances.value)
 {
@@ -59,8 +66,8 @@ PressureEqualizer::PressureEqualizer(const Slic3r::GCodeConfig &config) : m_use_
         extrusion_rate_slope.positive = m_max_volumetric_extrusion_rate_slope_positive;
     }
 
-    // Don't regulate the pressure before and after gap-fill and ironing.
-    for (const GCodeExtrusionRole er : {GCodeExtrusionRole::GapFill, GCodeExtrusionRole::Ironing}) {
+    // Don't regulate the pressure before and after ironing.
+    for (const GCodeExtrusionRole er : {GCodeExtrusionRole::Ironing}) {
         m_max_volumetric_extrusion_rate_slopes[size_t(er)].negative = 0;
         m_max_volumetric_extrusion_rate_slopes[size_t(er)].positive = 0;
     }
@@ -97,7 +104,70 @@ void PressureEqualizer::process_layer(const std::string &gcode)
         }
         assert(!this->opened_extrude_set_speed_block);
     }
+
+    // at this point, we have an entire layer of gcode lines loaded into m_gcode_lines
+    // now we will split the mix of travels and extrudes into segments of continous extrusion and process those
+    // We skip over large travels, and pretend small ones are part of a continous extrusion segment
+    long idx_end_current_extrusion = 0;
+    while (idx_end_current_extrusion < m_gcode_lines.size()) {
+        // find beginning of next extrusion segment from current pos
+        const long idx_begin_current_extrusion   = find_if(m_gcode_lines.begin() + idx_end_current_extrusion, m_gcode_lines.end(),
+                                                          [](GCodeLine line) { return line.extruding(); }) - m_gcode_lines.begin();
+        // (extrusion begin idx = extrusion end idx) here because we start with extrusion length of zero
+        idx_end_current_extrusion = idx_begin_current_extrusion;
+
+        // inner loop extends the extrusion segment over small travel moves
+        while (idx_end_current_extrusion < m_gcode_lines.size()) {
+            // find end of the current extrusion segment
+            const auto just_after_end_extrusion = find_if(m_gcode_lines.begin() + idx_end_current_extrusion, m_gcode_lines.end(),
+                                                          [](GCodeLine line) { return !line.extruding(); });
+            idx_end_current_extrusion = std::max<long>(0,(just_after_end_extrusion - m_gcode_lines.begin()) - 1);
+            const long idx_begin_segment_continuation = advance_segment_beyond_small_gap(idx_end_current_extrusion);
+            if (idx_begin_segment_continuation > idx_end_current_extrusion) {
+                // extend the continous line over the small gap
+                idx_end_current_extrusion = idx_begin_segment_continuation;
+                continue; // keep going, loop again to find new end of extrusion segment
+            } else {
+                // gap to next extrude is too big, stop looking forward. We've found end of this segment
+                break;
+            }
+        }
+
+        // now run the pressure equalizer across the segment like a streamroller
+        // it operates on a sliding window that moves forward across gcode line by line
+        for (int i = idx_begin_current_extrusion; i < idx_end_current_extrusion; ++i) {
+            // feed pressure equalizer past lines, going back to max_look_back_limit (or start of segment)
+            const auto start_idx = std::max<long>(idx_begin_current_extrusion, i - max_look_back_limit);
+            adjust_volumetric_rate(start_idx, i);
+        }
+        // current extrusion is all done processing so advance beyond it for next loop
+        idx_end_current_extrusion++;
+    }
 }
+
+
+long PressureEqualizer::advance_segment_beyond_small_gap(const long idx_orig)
+{
+    // this should only be run on the last extruding line before a gap
+    assert(m_gcode_lines[idx_cur_pos].extruding());
+    double distance_traveled = 0.0;
+    // start at beginning of gap, advance till extrusion found or gap too big
+    for (auto idx_cur_pos = idx_orig + 1; idx_cur_pos < m_gcode_lines.size(); idx_cur_pos++) {
+        // started extruding again! return segment extension
+        if (m_gcode_lines[idx_cur_pos].extruding()) {
+            return idx_cur_pos;
+        }
+
+        distance_traveled += m_gcode_lines[idx_cur_pos].dist_xy();
+        // gap too big, dont extend segment
+        if (distance_traveled > max_ignored_gap_between_extruding_segments) {
+            return idx_orig;
+        }
+    }
+    // looped until end of layer and couldn't extend extrusion
+     return idx_orig;
+}
+
 
 LayerResult PressureEqualizer::process_layer(LayerResult &&input)
 {
@@ -390,8 +460,6 @@ bool PressureEqualizer::process_line(const char *line, const char *line_end, GCo
 
     buf.extruder_id = m_current_extruder;
     memcpy(buf.pos_end, m_current_pos, sizeof(float)*5);
-
-    adjust_volumetric_rate();
 #ifdef PRESSURE_EQUALIZER_DEBUG
     ++line_idx;
 #endif
@@ -506,14 +574,12 @@ void PressureEqualizer::output_gcode_line(const size_t line_idx)
     }
 }
 
-void PressureEqualizer::adjust_volumetric_rate()
+void PressureEqualizer::adjust_volumetric_rate(const size_t fist_line_idx, const size_t last_line_idx)
 {
-    if (m_gcode_lines.size() < 2)
+    // don't bother adjusting volumetric rate if there's no gcode to adjust
+    if (last_line_idx-fist_line_idx < 2)
         return;
 
-    // Go back from the current circular_buffer_pos and lower the feedtrate to decrease the slope of the extrusion rate changes.
-    size_t       fist_line_idx = size_t(std::max<int>(0, int(m_gcode_lines.size()) - max_look_back_limit));
-    const size_t last_line_idx = m_gcode_lines.size() - 1;
     size_t       line_idx      = last_line_idx;
     if (line_idx == fist_line_idx || !m_gcode_lines[line_idx].extruding())
         // Nothing to do, the last move is not extruding.
@@ -528,8 +594,8 @@ void PressureEqualizer::adjust_volumetric_rate()
         for (; !m_gcode_lines[idx_prev].extruding() && idx_prev != fist_line_idx; --idx_prev);
         if (!m_gcode_lines[idx_prev].extruding())
             break;
-        // Don't decelerate before ironing and gap-fill.
-        if (m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::Ironing || m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::GapFill) {
+        // Don't decelerate before ironing.
+        if (m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::Ironing) {
             line_idx = idx_prev;
             continue;
         }
@@ -549,7 +615,8 @@ void PressureEqualizer::adjust_volumetric_rate()
                 // Limit by the succeeding volumetric flow rate.
                 rate_end = rate_succ;
 
-            if (!line.adjustable_flow || line.extrusion_role == GCodeExtrusionRole::ExternalPerimeter || line.extrusion_role == GCodeExtrusionRole::GapFill || line.extrusion_role == GCodeExtrusionRole::BridgeInfill || line.extrusion_role == GCodeExtrusionRole::Ironing) {
+            // don't alter the flow rate for these extrusion types
+            if (!line.adjustable_flow || line.extrusion_role == GCodeExtrusionRole::BridgeInfill || line.extrusion_role == GCodeExtrusionRole::Ironing) {
                 rate_end = line.volumetric_extrusion_rate_end;
             } else if (line.volumetric_extrusion_rate_end > rate_end) {
                 line.volumetric_extrusion_rate_end = rate_end;
@@ -572,8 +639,8 @@ void PressureEqualizer::adjust_volumetric_rate()
                 }
             }
 //            feedrate_per_extrusion_role[iRole] = (iRole == line.extrusion_role) ? line.volumetric_extrusion_rate_start : rate_start;
-            // Don't store feed rate for ironing and gap-fill.
-            if (line.extrusion_role != GCodeExtrusionRole::Ironing && line.extrusion_role != GCodeExtrusionRole::GapFill)
+            // Don't store feed rate for ironing
+            if (line.extrusion_role != GCodeExtrusionRole::Ironing)
                 feedrate_per_extrusion_role[iRole] = line.volumetric_extrusion_rate_start;
         }
     }
@@ -587,8 +654,8 @@ void PressureEqualizer::adjust_volumetric_rate()
         for (; !m_gcode_lines[idx_next].extruding() && idx_next != last_line_idx; ++idx_next);
         if (!m_gcode_lines[idx_next].extruding())
             break;
-        // Don't accelerate after ironing and gap-fill.
-        if (m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::Ironing || m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::GapFill) {
+        // Don't accelerate after ironing.
+        if (m_gcode_lines[line_idx].extrusion_role == GCodeExtrusionRole::Ironing) {
             line_idx = idx_next;
             continue;
         }
@@ -603,7 +670,8 @@ void PressureEqualizer::adjust_volumetric_rate()
                 continue; // The positive rate is unlimited or the rate for GCodeExtrusionRole iRole is unlimited.
 
             float rate_start = feedrate_per_extrusion_role[iRole];
-            if (!line.adjustable_flow || line.extrusion_role == GCodeExtrusionRole::ExternalPerimeter || line.extrusion_role == GCodeExtrusionRole::GapFill || line.extrusion_role == GCodeExtrusionRole::BridgeInfill || line.extrusion_role == GCodeExtrusionRole::Ironing) {
+            // don't alter the flow rate for these extrusion types
+            if (!line.adjustable_flow  || line.extrusion_role == GCodeExtrusionRole::BridgeInfill || line.extrusion_role == GCodeExtrusionRole::Ironing) {
                 rate_start = line.volumetric_extrusion_rate_start;
             } else if (iRole == size_t(line.extrusion_role) && rate_prec < rate_start)
                 rate_start = rate_prec;
@@ -628,8 +696,8 @@ void PressureEqualizer::adjust_volumetric_rate()
                 }
             }
 //            feedrate_per_extrusion_role[iRole] = (iRole == line.extrusion_role) ? line.volumetric_extrusion_rate_end : rate_end;
-            // Don't store feed rate for ironing and gap-fill.
-            if (line.extrusion_role != GCodeExtrusionRole::Ironing && line.extrusion_role != GCodeExtrusionRole::GapFill)
+            // Don't store feed rate for ironing
+            if (line.extrusion_role != GCodeExtrusionRole::Ironing)
                 feedrate_per_extrusion_role[iRole] = line.volumetric_extrusion_rate_end;
         }
     }

--- a/src/libslic3r/GCode/PressureEqualizer.hpp
+++ b/src/libslic3r/GCode/PressureEqualizer.hpp
@@ -180,11 +180,12 @@ private:
 #endif
 
     bool process_line(const char *line, const char *line_end, GCodeLine &buf);
+    long advance_segment_beyond_small_gap(long idx_cur_pos);
     void output_gcode_line(size_t line_idx);
 
     // Go back from the current circular_buffer_pos and lower the feedtrate to decrease the slope of the extrusion rate changes.
     // Then go forward and adjust the feedrate to decrease the slope of the extrusion rate changes.
-    void adjust_volumetric_rate();
+    void adjust_volumetric_rate(size_t first_line_idx, size_t last_line_idx);
 
     // Push the text to the end of the output_buffer.
     inline void push_to_output(GCodeG1Formatter &formatter);


### PR DESCRIPTION
**Hello all, this is my first PR so forgive me if I screw something up!**

**The pressure equalizer wasn't working as well as I hoped, so went on a journey to improve it, fixing things along the way.**

## Bugs fixed:
###  Pressure equalizer and cooling adjustments broken when using dynamic speed(dynamic overhangs)
Cooling markers were missing on lines drawn using dynamic speed. This prevents both the pressure equalizer and cooling code from adjusting the speed on these lines. This bug can be seen in uneven slowing of different parts of print to meet layer time because the model walls are not adjusted.

My fix may resolve https://github.com/prusa3d/PrusaSlicer/issues/9594
### Example
### broken
<img width="344" alt="BUG1_broken" src="https://user-images.githubusercontent.com/7324060/216895266-de7893b0-e69c-45e9-a53d-5f04746c9716.png">

### fixed
<img width="371" alt="BUG1_fixed" src="https://user-images.githubusercontent.com/7324060/216895274-c75b4fae-6301-40fa-8951-702f1ad15e85.png">

### Chaos when auto speed enabled for perimeters when dynamic overhangs are also on and specified using percentages
When using this combination, the overhang speed calculation was using the perimeter speed (zero) as a basis for % speed slowdown. Which results in garbage speeds. I fixed this by using speed calculated by code above it, which already takes into account volumetric speed and appears to work properly in all cases.

My fix may resolve https://github.com/prusa3d/PrusaSlicer/issues/9485 and https://github.com/prusa3d/PrusaSlicer/issues/9563 (my issue lol)
### Example
### broken
<img width="478" alt="BUG2_broken" src="https://user-images.githubusercontent.com/7324060/216896004-042e79ec-fe99-4813-a2c7-6cfae90e2414.png">


### fixed
<img width="460" alt="BUG2_fixed" src="https://user-images.githubusercontent.com/7324060/216896033-34bdc09d-14ea-47c3-9a08-f7e32c5d28ae.png">


# Improving pressure equalizer
**Finally, what I set out to accomplish.** 
## Small improvements

### Re-enabled pressure equalizer for gap filling and external perimeters.
 **In my printing experience, abrupt flow changes in external perimeters cause the worst defects, and pressure equalizer was disabled where it would help the most**. The pressure equalizer behaves better after my improvements. And enabling it for external perimeters allows us to slow down for overhang perimeters and dynamic overhangs. Many people, me included, didn't use dynamic overhangs because the rapid flow change causes artifacts and pressure equalizer couldn't help, I wanted to fix that.

### Example
### broken
<img width="325" alt="ABRUPT_broken" src="https://user-images.githubusercontent.com/7324060/216898186-406e7ac9-9967-4c61-b2ff-66324fe05ff6.png">

### fixed 🌈
<img width="405" alt="ABRUPT_fixed" src="https://user-images.githubusercontent.com/7324060/216898195-8ba81d1e-0f53-4f4f-a88a-fc96deb5251c.png">

### Lowered `max_segment_length` from 5->1 when subdividing. 
This results in smoother flow changes
### Example
### broken
<img width="552" alt="SMOOTHING_broken" src="https://user-images.githubusercontent.com/7324060/216897103-4d20d5f8-cf7b-403a-92f8-8c3557182769.png">

### fixed
<img width="551" alt="SMOOTHING_fixed" src="https://user-images.githubusercontent.com/7324060/216897125-2ac1787b-f8c9-4ece-a46e-32c68d98b4f0.png">

## Main Contribution To Pressure Equalizer - Only equalize across near-contiguous extrusions
### Shortcomings of previous approach
The main issue with existing code is not accounting for travel moves. You could travel move across whole build plate and pressure equalizer would still try to make a smooth transition from flow rates at each end. Extruder pressure drops to zero after a few mm of travel without extruding, and longer moves will retract on top of that. So it doesn't make sense to smooth flow between extrusions separated by a travel move more than a few mm. I believe this shortcoming is why pressure equalization was originally disabled for outer perimeters here https://github.com/prusa3d/PrusaSlicer/commit/9c07218d820985a2c8cd3a606392c9317ad8b466 by @hejllukas , and why I feel confident turning it back on.

### Changes
I've added some processing between the layer parsing and pressure adjustments. This new middle stage splits the lines into groups of continuous (or near continuous) extrusions. Each time there's a travel move of more than a few mm, it resets the pressure equalizer. This prevents smoothing of flow transitions between discontinuous areas of the print connected by a long (non-extruding) travel move.

## What pressure equalization looked like before I added detection for contiguous line segments

You can see it is happily equalizing pressure between unconnected line ends many centimeters apart. This is because they're sequential in the gcode with a travel move between them, and the old code was blind to travel between extrusions. 


<img width="847" alt="old_code" src="https://user-images.githubusercontent.com/7324060/216904163-de3a4b50-1238-41f0-a2a9-b869f2e760d7.png">

These artifacts are an artificial best-case. Slicing with a normal slope smears these spurious pressure adjustments across most of the layer and I can't demonstrate whats happening. With the new contiguous segment detection shown below, spurious flow adjustments are no longer present.

# Final Results

## The hook from above, without spurious flow adjustments (and with dynamic overhangs fixed)
<img width="647" alt="good_hook_1" src="https://user-images.githubusercontent.com/7324060/216901927-9b4676c8-ede3-4029-b6f0-8f84935e20e3.png">

**🚀🚀🚀Those are some nice overhangs!  🚀🚀🚀**

<img width="359" alt="good_1" src="https://user-images.githubusercontent.com/7324060/216900950-ccb49b89-e41f-4131-98c0-68b03965752d.png">
<img width="676" alt="hook_good_2" src="https://user-images.githubusercontent.com/7324060/216902611-36b55f0b-37ce-4ddc-959b-e7873d65918d.png">
<img width="370" alt="flow_between_perimeters" src="https://user-images.githubusercontent.com/7324060/217171801-ed3dc3d7-00cc-41dd-9451-3b460ec79b83.png">


# Additional recommendation - Update pressure equalizer docs
I found the maximum recommended slopes too low. Modern printers don't need several seconds to transition between min and max flow... They just need a little help from non-instant flow changes and Linear Advance can take care of the rest.

The document states `We suggest using values between 2-10.` in https://help.prusa3d.com/article/pressure-equalizer-_331504

Instead, I recommend the following:
- **Direct drive -** 5-10X your maximum volumetric flow. So 0.2 to 0.1 seconds of smoothing between zero and max flow.
- **Bowden -** 2-4X your maximum volumetric flow. So 0.50 to 0.25 seconds of smoothing between zero and max flow.

For example, my main printer is direct drive, and hot end can handle 20mm^3/sec of flow. So I would use a slope between 100 and 200

**Can someone update that doc page for me or show me where to do it?**

### cheers

#### EDIT: The maximum slope could use test prints and tuning procedures in the future. The pressure equalizer trades between axis acceleration and flow rate of change. If you choose a volumetric slope too low, you can end up exceeding the printer's axis acceleration limits, which introduces its own artifacts. Paradoxically, I found high slope values to be "safer" since Linear Advance will help even out abrupt flow changes. But there's nothing to compensate for rapid axis acceleration that comes with low slope values.