### PR TITLE
BIBO2 Correct missing profile improvement from 0.0.6 to set ensure_vertical_shell_thickness = 0 (off).

### DIFF
--- a/resources/profiles/BIBO.idx
+++ b/resources/profiles/BIBO.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.4.1-beta3
+0.0.7 Correct missing profile improvement from 0.0.6 to set ensure_vertical_shell_thickness = 0 (off).
 0.0.6 Correct start gcode, match profile and firmware settings, and other profile improvements.
 0.0.5 Correct Marlin Error accumulation for Ditto printer profiles.
 0.0.4 Correct Marlin Error accumulation

--- a/resources/profiles/BIBO.ini
+++ b/resources/profiles/BIBO.ini
@@ -5,7 +5,7 @@
 name = BIBO
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 0.0.6
+config_version = 0.0.7
 # Where to get the updates from?
 config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/PrusaSlicer-settings-master/live/BIBO/
 
@@ -38,7 +38,7 @@ compatible_printers =
 complete_objects = 0
 dont_support_bridges = 1
 elefant_foot_compensation = 0.3
-ensure_vertical_shell_thickness = 1
+ensure_vertical_shell_thickness = 0
 external_fill_pattern = rectilinear
 external_perimeters_first = 0
 external_perimeter_extrusion_width = 0.40


### PR DESCRIPTION
Correct missing profile improvement from 0.0.6 to set ensure_vertical_shell_thickness = 0 (off) which was missed from #9447
This was mentioned in the previous PR but was missing unfortunately not in the PR.