### PR TITLE
Fix build on CGAL 5.5

### DIFF
--- a/src/libslic3r/CutSurface.cpp
+++ b/src/libslic3r/CutSurface.cpp
@@ -1098,7 +1098,13 @@ namespace priv {
 /// Track source of intersection 
 /// Help for anotate inner and outer faces
 /// </summary>
-struct Visitor {
+struct Visitor : public CGAL::Polygon_mesh_processing::Corefinement::Default_visitor<CutMesh> {
+    Visitor(const CutMesh &object, const CutMesh &shape, EdgeShapeMap edge_shape_map,
+            FaceShapeMap face_shape_map, VertexShapeMap vert_shape_map, bool* is_valid) :
+        object(object), shape(shape), edge_shape_map(edge_shape_map), face_shape_map(face_shape_map),
+        vert_shape_map(vert_shape_map), is_valid(is_valid)
+    {}
+
     const CutMesh &object;
     const CutMesh &shape;
 
@@ -1160,16 +1166,6 @@ struct Visitor {
     /// <param name="v">New added vertex</param>
     /// <param name="tm">Affected mesh</param>
     void new_vertex_added(std::size_t i_id, VI v, const CutMesh &tm);
-
-    // Not used visitor functions
-    void before_subface_creations(FI /* f_old */, CutMesh &/* mesh */){}
-    void after_subface_created(FI /* f_new */, CutMesh &/* mesh */) {}
-    void after_subface_creations(CutMesh&) {}
-    void before_subface_created(CutMesh&) {}
-    void before_edge_split(HI /* h */, CutMesh& /* tm */) {}
-    void edge_split(HI /* hnew */, CutMesh& /* tm */) {}
-    void after_edge_split() {}
-    void add_retriangulation_edge(HI /* h */, CutMesh& /* tm */) {}
 };
 
 /// <summary>
@@ -1411,7 +1407,7 @@ priv::CutAOIs priv::cut_from_model(CutMesh                &cgal_model,
     // NOTE: map are created when convert shapes to cgal model
     const EdgeShapeMap& edge_shape_map = cgal_shape.property_map<EI, IntersectingElement>(edge_shape_map_name).first;
     const FaceShapeMap& face_shape_map = cgal_shape.property_map<FI, IntersectingElement>(face_shape_map_name).first;
-    Visitor visitor{cgal_model, cgal_shape, edge_shape_map, face_shape_map, vert_shape_map, &is_valid};
+    Visitor visitor(cgal_model, cgal_shape, edge_shape_map, face_shape_map, vert_shape_map, &is_valid);
 
     // a property map containing the constrained-or-not status of each edge
     EdgeBoolMap ecm = cgal_model.add_property_map<EI, bool>(is_constrained_edge_name, false).first;

--- a/tests/libslic3r/test_emboss.cpp
+++ b/tests/libslic3r/test_emboss.cpp
@@ -848,7 +848,16 @@ TEST_CASE("Emboss extrude cut", "[Emboss-Cut]")
     using EcmType = CGAL::internal::Dynamic<MyMesh, ecm_it>;
     EcmType ecm = get(d_prop_bool(), cgal_object);
     
-    struct Visitor {
+    struct Visitor : public CGAL::Polygon_mesh_processing::Corefinement::Default_visitor<MyMesh> {
+        Visitor(const MyMesh &object, const MyMesh &shape,
+                MyMesh::Property_map<CGAL::SM_Edge_index, IntersectingElemnt> edge_shape_map,
+                MyMesh::Property_map<CGAL::SM_Face_index, IntersectingElemnt> face_shape_map,
+                MyMesh::Property_map<CGAL::SM_Face_index, int32_t> face_map,
+                MyMesh::Property_map<CGAL::SM_Vertex_index, IntersectingElemnt> vert_shape_map) :
+            object(object), shape(shape), edge_shape_map(edge_shape_map), face_shape_map(face_shape_map),
+            face_map(face_map), vert_shape_map(vert_shape_map)
+        {}
+
         const MyMesh &object;
         const MyMesh &shape;
         // Properties of the shape mesh:
@@ -947,14 +956,8 @@ TEST_CASE("Emboss extrude cut", "[Emboss-Cut]")
             vert_shape_map[vh] = glyph ? *glyph : IntersectingElemnt{};
         }
 
-        void after_subface_creations(MyMesh&) {}
-        void before_subface_created(MyMesh&) {}
-        void before_edge_split(halfedge_descriptor /* h */, MyMesh& /* tm */) {}
-        void edge_split(halfedge_descriptor /* hnew */, MyMesh& /* tm */) {}
-        void after_edge_split() {}
-        void add_retriangulation_edge(halfedge_descriptor /* h */, MyMesh& /* tm */) {}
-    } visitor{cgal_object, cgal_shape, edge_shape_map, face_shape_map,
-              face_map, vert_shape_map};
+    } visitor(cgal_object, cgal_shape, edge_shape_map, face_shape_map,
+              face_map, vert_shape_map);
 
     const auto& p = CGAL::Polygon_mesh_processing::parameters::throw_on_self_intersection(false).visitor(visitor).edge_is_constrained_map(ecm);
     const auto& q = CGAL::Polygon_mesh_processing::parameters::do_not_modify(true);


### PR DESCRIPTION
Fixes issue #9582. It does so by making the Visitor struct inherit [`CGAL::Polygon_mesh_processing::Corefinement::Default_visitor`](https://doc.cgal.org/5.5/Polygon_mesh_processing/structCGAL_1_1Polygon__mesh__processing_1_1Corefinement_1_1Default__visitor.html), which supplies default implementations of diagnostic methods. This should future-proof the code if CGAL decides to add more methods.