### PR TITLE
Add missing Boost Filesystem fstream header

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9,6 +9,7 @@
 #include <future>
 #include <boost/algorithm/string.hpp>
 #include <boost/optional.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/log/trivial.hpp>


### PR DESCRIPTION
Fixes error with GCC 12:

```
src/slic3r/GUI/Plater.cpp:5795:37: error: ‘fstream’ is not a member of ‘fs’; did you mean ‘std::fstream’?
 5795 |                 fs::fstream file(final_path, std::ios::out | std::ios::binary | std::ios::trunc);
      |                     ^~~~~~~
```