### PR TITLE
Display more precision for fill_density

### DIFF
--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -890,8 +890,7 @@ boost::any ConfigOptionsGroup::get_config_value(const DynamicPrintConfig& config
 	}
 	case coPercent:{
 		double val = config.option<ConfigOptionPercent>(opt_key)->value;
-		text_value = wxString::Format(_T("%i"), int(val));
-		ret = text_value;// += "%";
+        ret = double_to_string(val);
 	}
 		break;
 	case coPercents:


### PR DESCRIPTION
The `fill_density` option is managed as a float, but not displaying precision in the GUI. This change leverages the existing `double_to_string` conversion rather than casting to an int when retrieving the config value.