### PR TITLE
Check MMU parameters during wipe tower generation to prevent overflow value -2147483648 from being emitted in g-code

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -904,7 +904,7 @@ void WipeTower::toolchange_Unload(
 
     // Cooling:
     const int& number_of_moves = m_filpar[m_current_tool].cooling_moves;
-    if (m_semm && number_of_moves > 0) {
+    if (m_semm && number_of_moves > 0 && m_cooling_tube_length != 0.f) {
         const float& initial_speed = m_filpar[m_current_tool].cooling_initial_speed;
         const float& final_speed   = m_filpar[m_current_tool].cooling_final_speed;
 
@@ -922,7 +922,7 @@ void WipeTower::toolchange_Unload(
         }
     }
 
-    if (m_semm) {
+    if (m_semm && m_cooling_tube_length != 0.f && m_cooling_tube_retraction != 0.f) {
         // let's wait is necessary:
         writer.wait(m_filpar[m_current_tool].delay);
         // we should be at the beginning of the cooling tube again - let's move to parking position:


### PR DESCRIPTION
In PrusaSlicer 2.5.1 and greater if a user configures the "Single extruder multimaterial parameters" to 0mm some portions of the tip forming process are skipped. However, not all parameters are checked before emitting g-code and can result in an overflow value generating invalid gcode. 

This appears to be the same problem mentioned here https://github.com/prusa3d/PrusaSlicer/issues/10147.

This change prevents the g-code on the right from being emitted when `m_cooling_tube_length` and `m_cooling_tube_retraction` are both set to 0mm.

![image](https://user-images.githubusercontent.com/122503080/227747672-a93401ff-c54d-45ec-8bed-74ff0635b6d9.png)

This change is also useful when using a Klipper macro for tool changes where the macro controls the tip forming parameters. An example of this would be when using an "Enraged Rabbit Carrot Feeder" (ERCF) with the "Happy Hare" (ERCF-Software-V3)'s 
`ERCF_CHANGE_TOOL TOOL=0 STANDALONE=1` macro. 