### PR TITLE
Speed up multi-perimeter extrusion while preserving fidelity of surface

### DIFF
--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -192,13 +192,30 @@ class ExtrusionLoop : public ExtrusionEntity
 public:
     ExtrusionPaths paths;
     
-    ExtrusionLoop(ExtrusionLoopRole role = elrDefault) : m_loop_role(role) {}
-    ExtrusionLoop(const ExtrusionPaths &paths, ExtrusionLoopRole role = elrDefault) : paths(paths), m_loop_role(role) {}
-    ExtrusionLoop(ExtrusionPaths &&paths, ExtrusionLoopRole role = elrDefault) : paths(std::move(paths)), m_loop_role(role) {}
-    ExtrusionLoop(const ExtrusionPath &path, ExtrusionLoopRole role = elrDefault) : m_loop_role(role) 
-        { this->paths.push_back(path); }
-    ExtrusionLoop(ExtrusionPath &&path, ExtrusionLoopRole role = elrDefault) : m_loop_role(role)
-        { this->paths.emplace_back(std::move(path)); }
+    ExtrusionLoop(ExtrusionLoopRole role = elrDefault, unsigned short perimeter_idx = 0) : m_loop_role(role)
+    {
+        m_perimeter_idx = perimeter_idx;
+    }
+    ExtrusionLoop(const ExtrusionPaths &paths, ExtrusionLoopRole role = elrDefault, unsigned short perimeter_idx = 0)
+        : paths(paths), m_loop_role(role)
+    {
+        m_perimeter_idx = perimeter_idx;
+    }
+    ExtrusionLoop(ExtrusionPaths &&paths, ExtrusionLoopRole role = elrDefault, unsigned short perimeter_idx = 0)
+        : paths(std::move(paths)), m_loop_role(role)
+    {
+        m_perimeter_idx = perimeter_idx;
+    }
+    ExtrusionLoop(const ExtrusionPath &path, ExtrusionLoopRole role = elrDefault, unsigned short perimeter_idx = 0) : m_loop_role(role)
+    {
+        m_perimeter_idx = perimeter_idx;
+        this->paths.push_back(path);
+    }
+    ExtrusionLoop(ExtrusionPath &&path, ExtrusionLoopRole role = elrDefault, unsigned short perimeter_idx = 0) : m_loop_role(role)
+    {
+        m_perimeter_idx = perimeter_idx;
+        this->paths.emplace_back(std::move(path));
+    }
     bool is_loop() const override{ return true; }
     bool can_reverse() const override { return false; }
 	ExtrusionEntity* clone() const override{ return new ExtrusionLoop (*this); }
@@ -249,6 +266,7 @@ public:
     }
     double total_volume() const override { double volume =0.; for (const auto& path : paths) volume += path.total_volume(); return volume; }
 
+    unsigned short perimeter_idx() const { return this->m_perimeter_idx; }
 #ifndef NDEBUG
 	bool validate() const {
 		assert(this->first_point() == this->paths.back().polyline.points.back());
@@ -260,6 +278,7 @@ public:
 
 private:
     ExtrusionLoopRole m_loop_role;
+    unsigned short m_perimeter_idx;
 };
 
 inline void extrusion_paths_append(ExtrusionPaths &dst, Polylines &polylines, ExtrusionRole role, double mm3_per_mm, float width, float height)

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -293,9 +293,11 @@ static ExtrusionEntityCollection traverse_loops_classic(const PerimeterGenerator
     Polygon                     fuzzified;
     for (const PerimeterGeneratorLoop &loop : loops) {
         bool is_external = loop.is_external();
+        unsigned short perimeter_idx = loop.depth;
         
         ExtrusionLoopRole loop_role;
-        ExtrusionRole role_normal   = is_external ? ExtrusionRole::ExternalPerimeter : ExtrusionRole::Perimeter;
+        ExtrusionRole     role_normal   = is_external ? ExtrusionRole::ExternalPerimeter : ExtrusionRole::Perimeter;
+
         ExtrusionRole role_overhang = role_normal | ExtrusionRoleModifier::Bridge;
         if (loop.is_internal_contour()) {
             // Note that we set loop role to ContourInternalPerimeter
@@ -351,7 +353,7 @@ static ExtrusionEntityCollection traverse_loops_classic(const PerimeterGenerator
             paths.push_back(path);
         }
         
-        coll.append(ExtrusionLoop(std::move(paths), loop_role));
+        coll.append(ExtrusionLoop(std::move(paths), loop_role, perimeter_idx));
     }
     
     // Append thin walls to the nearest-neighbor search (only for first iteration)
@@ -599,7 +601,8 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator::P
         // Append paths to collection.
         if (!paths.empty()) {
             if (extrusion->is_closed) {
-                ExtrusionLoop extrusion_loop(std::move(paths));
+                unsigned short perimeter_idx = extrusion->inset_idx;
+                ExtrusionLoop  extrusion_loop(std::move(paths), ExtrusionLoopRole::elrDefault, perimeter_idx);
                 // Restore the orientation of the extrusion loop.
                 if (pg_extrusion.is_contour)
                     extrusion_loop.make_counter_clockwise();


### PR DESCRIPTION
**The problem:**
When one uses multiple internal perimeters (perimeters > 2), all of them are extruded with the same speed. Especially in case when one uses "external perimeter first" option, to make as accurate model as possible, should use not much faster speeds for internal perimeters, even though the further apart is the internal perimeter from the external one, the less effect it has on it by pressure force, overruns, and alike by the newly extruded internal perimeters. One is forced to use slow speeds for all inner perimeters as well, hence loosing time.

**Solution in this PR in high level:**
If external and internal perimeter speed is also defined, use a gradient speed increase (or decrease) from external perimeter to inner most perimeter, depending on it's perimeter index. This allows us to use higher speeds in the inner most perimeters, and lower ones where external perimeter is still close, thus speeding up printing times considerably while preserving external perimeter features. This is also possible, because the more inner is the perimeter, contains the less detailed/coarse of the external features, which also suites well more speed.

**In details:**
- Added private field for perimeter index in the ExtrusionLoop class + optional initializer parameter + getter
- Where it gets initialized, added perimeter index to it (for arachne and classic)
- In GCode generation added speed "override" like it was there for small perimeter speeds
- In _GCode::_extrude_ I made overhang speed settings to override any speed if it's smaller than the currently set speed to ensure it still functions as expected
- Speeds are caped by max internal perimeter speed, and always obeys max flow rates

Thought a new config option would be helpful, but in the end didn't add one (according to the guidelines) for the following reasons:
- If you have 1 or 2 perimeters, it functions identically as previously which I believe is the a sane setting for most printings oriented towards speed.
- If you have 3 perimeters (which probably is the default for most printer settings) you will get nicer results, though a bit slower.

**Findings:**
During prints, it really sped up, and/or produced nicer corners within the same overall print time on my printer. Mini figure ultra fine prints are considerably sped up. For simple XYZ cube, internal perimeter prints sped up from ~1 hour to ~45 minutes, using the same 2nd perimeter speed (or first internal perimeter speed), when printed with 4 perimeters.

_PR speeds (note the gradient colored perimeters, where external is 10mm/s, the second is 33.3 mm/s, the third 56.6 mm/s, and fourth 80 mm/s):_
![PR](https://user-images.githubusercontent.com/29096248/230733789-fca85b80-ea73-4694-ba6f-dfb30bab5d05.png)

_Times of the sliced cube (1/12mm layer height, 10mm/s external perimeter, 80mm/s internal perimeter):_
![times](https://user-images.githubusercontent.com/29096248/230733873-fb8a6959-859e-4845-a05e-dcdf3af4e084.png)

_PrusaSlicer 2.5:_
![PS25](https://user-images.githubusercontent.com/29096248/230733861-88d8348e-2c8a-48b0-af36-711246a01ad3.png)

