### PR TITLE
Pad date and time in export file name to 2-digits with leading zero

### DIFF
--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -99,11 +99,23 @@ void PlaceholderParser::update_timestamp(DynamicConfig &config)
         config.set_key_value("timestamp", new ConfigOptionString(ss.str()));
     }
     config.set_key_value("year",   new ConfigOptionInt(1900 + timeinfo->tm_year));
-    config.set_key_value("month",  new ConfigOptionInt(1 + timeinfo->tm_mon));
-    config.set_key_value("day",    new ConfigOptionInt(timeinfo->tm_mday));
-    config.set_key_value("hour",   new ConfigOptionInt(timeinfo->tm_hour));
-    config.set_key_value("minute", new ConfigOptionInt(timeinfo->tm_min));
-    config.set_key_value("second", new ConfigOptionInt(timeinfo->tm_sec));
+
+    char two_d[3];
+
+    sprintf(two_d, "%02d", 1 + timeinfo->tm_mon);
+    config.set_key_value("month", new ConfigOptionString(two_d));
+
+    sprintf(two_d, "%02d", timeinfo->tm_mday);
+    config.set_key_value("day", new ConfigOptionString(two_d));
+
+    sprintf(two_d, "%02d", timeinfo->tm_hour);
+    config.set_key_value("hour", new ConfigOptionString(two_d));
+
+    sprintf(two_d, "%02d", timeinfo->tm_min);
+    config.set_key_value("minute", new ConfigOptionString(two_d));
+
+    sprintf(two_d, "%02d", timeinfo->tm_sec);
+    config.set_key_value("second", new ConfigOptionString(two_d));
 }
 
 static inline bool opts_equal(const DynamicConfig &config_old, const DynamicConfig &config_new, const std::string &opt_key)


### PR DESCRIPTION
Marlin has option to sort files in reverse order, so if you set 
![image](https://user-images.githubusercontent.com/8691781/230735051-b1bb9098-ae53-44b1-8cab-391ad8e4d348.png)

latest file always be at the screen top. To accomplish it's necessary to use two digits for date and time with leading zero:

![image](https://user-images.githubusercontent.com/8691781/230735167-7101eba1-fcfe-4e78-9104-0757730789d7.png)
