### PR TITLE
Variable perimeters and solid infill extrusion width on odd layer.

### DIFF
--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -112,7 +112,7 @@ double Flow::extrusion_width(const std::string& opt_key, const ConfigOptionResol
 
 // This constructor builds a Flow object from an extrusion width config setting
 // and other context properties.
-Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height)
+Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float width_delta, float nozzle_diameter, float height)
 {
     if (height <= 0)
         throw Slic3r::InvalidArgument("Invalid flow height supplied to new_from_config_width()");
@@ -125,6 +125,7 @@ Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent
         // If user set a manual value, use it.
         w = float(width.get_abs_value(height));
     }
+    w += width_delta;
     
     return Flow(w, height, rounded_rectangle_extrusion_spacing(w, height), nozzle_diameter, false);
 }
@@ -221,6 +222,7 @@ Flow support_material_flow(const PrintObject *object, float layer_height)
         frSupportMaterial,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (object->config().support_material_extrusion_width.value > 0) ? object->config().support_material_extrusion_width : object->config().extrusion_width,
+        0,
         // if object->config().support_material_extruder == 0 (which means to not trigger tool change, but use the current extruder instead), get_at will return the 0th component.
         float(object->print()->config().nozzle_diameter.get_at(object->config().support_material_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));
@@ -234,6 +236,7 @@ Flow support_material_1st_layer_flow(const PrintObject *object, float layer_heig
         frSupportMaterial,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (width.value > 0) ? width : object->config().extrusion_width,
+        0,
         float(print_config.nozzle_diameter.get_at(object->config().support_material_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(print_config.first_layer_height.get_abs_value(object->config().layer_height.value)));
 }
@@ -244,6 +247,7 @@ Flow support_material_interface_flow(const PrintObject *object, float layer_heig
         frSupportMaterialInterface,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (object->config().support_material_extrusion_width > 0) ? object->config().support_material_extrusion_width : object->config().extrusion_width,
+        0,
         // if object->config().support_material_interface_extruder == 0 (which means to not trigger tool change, but use the current extruder instead), get_at will return the 0th component.
         float(object->print()->config().nozzle_diameter.get_at(object->config().support_material_interface_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));

--- a/src/libslic3r/Flow.hpp
+++ b/src/libslic3r/Flow.hpp
@@ -96,7 +96,7 @@ public:
 
     static Flow bridging_flow(float dmr, float nozzle_diameter) { return Flow { dmr, dmr, bridge_extrusion_spacing(dmr), nozzle_diameter, true }; }
 
-    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height);
+    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float width_delta, float nozzle_diameter, float height);
 
     // Spacing of extrusions with rounded extrusion model.
     static float rounded_rectangle_extrusion_spacing(float width, float height);

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -24,7 +24,7 @@ Flow LayerRegion::flow(FlowRole role) const
 
 Flow LayerRegion::flow(FlowRole role, double layer_height) const
 {
-    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id() == 0);
+    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id());
 }
 
 Flow LayerRegion::bridging_flow(FlowRole role, bool force_thick_bridges) const

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -449,7 +449,7 @@ static std::vector<std::string> s_Preset_print_options {
     "extruder_clearance_height", "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",
     "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width",
-    "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width",
+    "perimeter_extrusion_width", "perimeter_extrusion_width_odd", "external_perimeter_extrusion_width", "external_perimeter_extrusion_width_odd", "infill_extrusion_width", "solid_infill_extrusion_width", "solid_infill_extrusion_width_odd",
     "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "infill_anchor", "infill_anchor_max", "bridge_flow_ratio",
     "elefant_foot_compensation", "xy_size_compensation", "threads", "resolution", "gcode_resolution", "wipe_tower", "wipe_tower_x", "wipe_tower_y",
     "wipe_tower_width", "wipe_tower_cone_angle", "wipe_tower_rotation_angle", "wipe_tower_brim_width", "wipe_tower_bridging", "single_extruder_multi_material_priming", "mmu_segmented_region_max_width",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -819,6 +819,7 @@ Flow Print::brim_flow() const
     return Flow::new_from_config_width(
         frPerimeter,
 		width,
+        0,
         (float)m_config.nozzle_diameter.get_at(m_print_regions.front()->config().perimeter_extruder-1),
 		(float)this->skirt_first_layer_height());
 }
@@ -839,6 +840,7 @@ Flow Print::skirt_flow() const
     return Flow::new_from_config_width(
         frPerimeter,
 		width,
+        0,
 		(float)m_config.nozzle_diameter.get_at(m_objects.front()->config().support_material_extruder-1),
 		(float)this->skirt_first_layer_height());
 }

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -91,7 +91,7 @@ public:
     int                         print_object_region_id() const throw() { return m_print_object_region_id; }
 	// 1-based extruder identifier for this region and role.
 	unsigned int 				extruder(FlowRole role) const;
-    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer = false) const;
+    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, int layer_id = -1) const;
     // Average diameter of nozzles participating on extruding this region.
     coordf_t                    nozzle_dmr_avg(const PrintConfig &print_config) const;
     // Average diameter of nozzles participating on extruding this region.

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -835,7 +835,7 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipMonotonic));
 
     def = this->add("external_perimeter_extrusion_width", coFloatOrPercent);
-    def->label = L("External perimeters");
+    def->label = L("");
     def->category = L("Extrusion Width");
     def->tooltip = L("Set this to a non-zero value to set a manual extrusion width for external perimeters. "
                    "If left zero, default extrusion width will be used if set, otherwise 1.125 x nozzle diameter will be used. "
@@ -845,6 +845,16 @@ void PrintConfigDef::init_fff_params()
     def->max_literal = 50;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
+
+    def = this->add("external_perimeter_extrusion_width_odd", coFloat);
+    def->label = L("Odd layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("External perimeter change (+/-) on odd layers. It overlaps perimeters border and help with interlayer strength.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max =  0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("external_perimeter_speed", coFloatOrPercent);
     def->label = L("External perimeters");
@@ -2041,7 +2051,7 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInt(1));
 
     def = this->add("perimeter_extrusion_width", coFloatOrPercent);
-    def->label = L("Perimeters");
+    def->label = L("");
     def->category = L("Extrusion Width");
     def->tooltip = L("Set this to a non-zero value to set a manual extrusion width for perimeters. "
                    "You may want to use thinner extrudates to get more accurate surfaces. "
@@ -2053,6 +2063,17 @@ void PrintConfigDef::init_fff_params()
     def->max_literal = 50;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
+
+    def = this->add("perimeter_extrusion_width_odd", coFloat);
+    def->label = L("Odd layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("Perimeter change on odd layers (+/-). It overlaps perimeters border and help with interlayer strength. "
+                   "You may set it to 'external perimeters delta/number of internal perimeters' to keep vertical shell thickness constant.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max = 0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("perimeter_speed", coFloat);
     def->label = L("Perimeters");
@@ -2430,7 +2451,7 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInt(0));
 
     def = this->add("solid_infill_extrusion_width", coFloatOrPercent);
-    def->label = L("Solid infill");
+    def->label = L("");
     def->category = L("Extrusion Width");
     def->tooltip = L("Set this to a non-zero value to set a manual extrusion width for infill for solid surfaces. "
                    "If left zero, default extrusion width will be used if set, otherwise 1.125 x nozzle diameter will be used. "
@@ -2440,6 +2461,16 @@ void PrintConfigDef::init_fff_params()
     def->max_literal = 50;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
+
+    def = this->add("solid_infill_extrusion_width_odd", coFloat);
+    def->label = L("Odd layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("Solid infill change on odd layers (+/-). Could be useful for infill going the same direction each layer, like concentric or Acrhimedean chords.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max = 0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("solid_infill_speed", coFloatOrPercent);
     def->label = L("Solid infill");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -574,6 +574,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<InfillPattern>,  top_fill_pattern))
     ((ConfigOptionEnum<InfillPattern>,  bottom_fill_pattern))
     ((ConfigOptionFloatOrPercent,       external_perimeter_extrusion_width))
+    ((ConfigOptionFloat,                external_perimeter_extrusion_width_odd))
     ((ConfigOptionFloatOrPercent,       external_perimeter_speed))
     ((ConfigOptionBool,                 enable_dynamic_overhang_speeds))
     ((ConfigOptionFloatOrPercent,       overhang_speed_0))
@@ -608,6 +609,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                 overhangs))
     ((ConfigOptionInt,                  perimeter_extruder))
     ((ConfigOptionFloatOrPercent,       perimeter_extrusion_width))
+    ((ConfigOptionFloat,                perimeter_extrusion_width_odd))
     ((ConfigOptionFloat,                perimeter_speed))
     // Total number of perimeters.
     ((ConfigOptionInt,                  perimeters))
@@ -615,6 +617,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                solid_infill_below_area))
     ((ConfigOptionInt,                  solid_infill_extruder))
     ((ConfigOptionFloatOrPercent,       solid_infill_extrusion_width))
+    ((ConfigOptionFloat,                solid_infill_extrusion_width_odd))
     ((ConfigOptionInt,                  solid_infill_every_layers))
     ((ConfigOptionFloatOrPercent,       solid_infill_speed))
     // Detect thin walls.

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -619,6 +619,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "extra_perimeters_on_overhangs"
             || opt_key == "first_layer_extrusion_width"
             || opt_key == "perimeter_extrusion_width"
+            || opt_key == "perimeter_extrusion_width_odd"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first") {
             steps.emplace_back(posPerimeters);
@@ -744,12 +745,15 @@ bool PrintObject::invalidate_state_by_config_options(
                 is_approx(new_density->value, 0.) || is_approx(new_density->value, 100.))
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
-        } else if (opt_key == "solid_infill_extrusion_width") {
+        } else if (
+               opt_key == "solid_infill_extrusion_width"
+            || opt_key == "solid_infill_extrusion_width_odd") {
             // This value is used for calculating perimeter - infill overlap, thus perimeters need to be recalculated.
             steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
         } else if (
                opt_key == "external_perimeter_extrusion_width"
+            || opt_key == "external_perimeter_extrusion_width_odd"
             || opt_key == "perimeter_extruder"
             || opt_key == "fuzzy_skin"
             || opt_key == "fuzzy_skin_thickness"

--- a/src/libslic3r/PrintRegion.cpp
+++ b/src/libslic3r/PrintRegion.cpp
@@ -18,22 +18,26 @@ unsigned int PrintRegion::extruder(FlowRole role) const
     return extruder;
 }
 
-Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer) const
+Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_height, int layer_id) const
 {
     const PrintConfig          &print_config = object.print()->config();
     ConfigOptionFloatOrPercent  config_width;
+    float width_delta = 0;
     // Get extrusion width from configuration.
     // (might be an absolute value, or a percent value, or zero for auto)
-    if (first_layer && print_config.first_layer_extrusion_width.value > 0) {
+    if (layer_id == 0 && print_config.first_layer_extrusion_width.value > 0) {
         config_width = print_config.first_layer_extrusion_width;
     } else if (role == frExternalPerimeter) {
         config_width = m_config.external_perimeter_extrusion_width;
+        width_delta  = m_config.external_perimeter_extrusion_width_odd;
     } else if (role == frPerimeter) {
         config_width = m_config.perimeter_extrusion_width;
+        width_delta  = m_config.perimeter_extrusion_width_odd;
     } else if (role == frInfill) {
         config_width = m_config.infill_extrusion_width;
     } else if (role == frSolidInfill) {
         config_width = m_config.solid_infill_extrusion_width;
+        width_delta  = m_config.solid_infill_extrusion_width_odd;
     } else if (role == frTopSolidInfill) {
         config_width = m_config.top_infill_extrusion_width;
     } else {
@@ -42,11 +46,15 @@ Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_he
 
     if (config_width.value == 0)
         config_width = object.config().extrusion_width;
-    
+
+    //even layer, reset delta
+    if (layer_id == 0 || layer_id % 2 == 1)
+        width_delta = 0;
+
     // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
     // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_config.nozzle_diameter.get_at(this->extruder(role) - 1));
-    return Flow::new_from_config_width(role, config_width, nozzle_diameter, float(layer_height));
+    return Flow::new_from_config_width(role, config_width, width_delta, nozzle_diameter, float(layer_height));
 }
 
 coordf_t PrintRegion::nozzle_dmr_avg(const PrintConfig &print_config) const

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -215,7 +215,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 {
     bool have_perimeters = config->opt_int("perimeters") > 0;
     for (auto el : { "extra_perimeters","extra_perimeters_on_overhangs", "thin_walls", "overhangs",
-                    "seam_position","staggered_inner_seams", "external_perimeters_first", "external_perimeter_extrusion_width",
+                    "seam_position","staggered_inner_seams", "external_perimeters_first", "external_perimeter_extrusion_width", "external_perimeter_extrusion_width_odd",
                     "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "enable_dynamic_overhang_speeds"})
         toggle_field(el, have_perimeters);
 
@@ -238,7 +238,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     bool has_solid_infill 		 = has_top_solid_infill || has_bottom_solid_infill;
     // solid_infill_extruder uses the same logic as in Print::extruders()
     for (auto el : { "top_fill_pattern", "bottom_fill_pattern", "infill_first", "solid_infill_extruder",
-                    "solid_infill_extrusion_width", "solid_infill_speed" })
+                    "solid_infill_extrusion_width", "solid_infill_extrusion_width_odd", "solid_infill_speed" })
         toggle_field(el, has_solid_infill);
 
     for (auto el : { "fill_angle", "bridge_angle", "infill_extrusion_width",
@@ -300,6 +300,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("support_material_synchronize_layers", have_support_soluble);
 
     toggle_field("perimeter_extrusion_width", have_perimeters || have_skirt || have_brim);
+    toggle_field("perimeter_extrusion_width_odd", have_perimeters);
     toggle_field("support_material_extruder", have_support_material || have_skirt);
     toggle_field("support_material_speed", have_support_material || have_brim || have_skirt);
 

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -158,7 +158,7 @@ std::string PresetHints::maximum_volumetric_flow_description(const PresetBundle 
             [first_layer_extrusion_width_ptr, extrusion_width, nozzle_diameter, lh, bridging, bridge_speed, bridge_flow_ratio, limit_by_first_layer_speed, max_print_speed, &max_flow, &max_flow_extrusion_type]
             (FlowRole flow_role, const ConfigOptionFloatOrPercent &this_extrusion_width, double speed, const char *err_msg) {
             Flow flow = bridging ?
-                Flow::new_from_config_width(flow_role, first_positive(first_layer_extrusion_width_ptr, this_extrusion_width, extrusion_width), nozzle_diameter, lh) :
+                Flow::new_from_config_width(flow_role, first_positive(first_layer_extrusion_width_ptr, this_extrusion_width, extrusion_width), 0, nozzle_diameter, lh) :
                 Flow::bridging_flow(nozzle_diameter * bridge_flow_ratio, nozzle_diameter);
             double volumetric_flow = flow.mm3_per_mm() * (bridging ? bridge_speed : limit_by_first_layer_speed(speed, max_print_speed));
             if (max_flow < volumetric_flow) {
@@ -224,10 +224,12 @@ std::string PresetHints::recommended_thin_wall_thickness(const PresetBundle &pre
             Flow external_perimeter_flow = Flow::new_from_config_width(
                 frExternalPerimeter, 
                 *print_config.opt<ConfigOptionFloatOrPercent>("external_perimeter_extrusion_width"), 
+                0,
                 nozzle_diameter, layer_height);
             Flow perimeter_flow          = Flow::new_from_config_width(
                 frPerimeter, 
                 *print_config.opt<ConfigOptionFloatOrPercent>("perimeter_extrusion_width"), 
+                0,
                 nozzle_diameter, layer_height);
 	        double width = external_perimeter_flow.width() + external_perimeter_flow.spacing();
 	        for (int i = 2; i <= num_lines; thin_walls ? ++ i : i += 2) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1620,10 +1620,24 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Extrusion width"));
         optgroup->append_single_option_line("extrusion_width");
         optgroup->append_single_option_line("first_layer_extrusion_width");
-        optgroup->append_single_option_line("perimeter_extrusion_width");
-        optgroup->append_single_option_line("external_perimeter_extrusion_width");
+
+        line = { "Perimeters", "" };
+        line.append_option(optgroup->get_option("perimeter_extrusion_width"));
+        line.append_option(optgroup->get_option("perimeter_extrusion_width_odd"));
+        optgroup->append_line(line);
+
+        line = { "External perimeters", "" };
+        line.append_option(optgroup->get_option("external_perimeter_extrusion_width"));
+        line.append_option(optgroup->get_option("external_perimeter_extrusion_width_odd"));
+        optgroup->append_line(line);
+
         optgroup->append_single_option_line("infill_extrusion_width");
-        optgroup->append_single_option_line("solid_infill_extrusion_width");
+
+        line = { "Solid infill", "" };
+        line.append_option(optgroup->get_option("solid_infill_extrusion_width"));
+        line.append_option(optgroup->get_option("solid_infill_extrusion_width_odd"));
+        optgroup->append_line(line);
+
         optgroup->append_single_option_line("top_infill_extrusion_width");
         optgroup->append_single_option_line("support_material_extrusion_width");
 

--- a/tests/fff_print/test_flow.cpp
+++ b/tests/fff_print/test_flow.cpp
@@ -155,18 +155,18 @@ SCENARIO("Flow: Flow math for non-bridges", "[Flow]") {
 
         // Spacing for non-bridges is has some overlap
         THEN("External perimeter flow has spacing fixed to 1.125 * nozzle_diameter") {
-            auto flow = Flow::new_from_config_width(frExternalPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frExternalPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(1.125 * nozzle_diameter - layer_height * (1.0 - PI / 4.0)));
         }
 
         THEN("Internal perimeter flow has spacing fixed to 1.125 * nozzle_diameter") {
-            auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(1.125 *nozzle_diameter - layer_height * (1.0 - PI / 4.0)));
         }
         THEN("Spacing for supplied width is 0.8927f") {
-            auto flow = Flow::new_from_config_width(frExternalPerimeter, width, nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frExternalPerimeter, width, 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(width.value - layer_height * (1.0 - PI / 4.0)));
-            flow = Flow::new_from_config_width(frPerimeter, width, nozzle_diameter, layer_height);
+            flow = Flow::new_from_config_width(frPerimeter, width, 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(width.value - layer_height * (1.0 - PI / 4.0)));
         }
     }
@@ -177,14 +177,14 @@ SCENARIO("Flow: Flow math for non-bridges", "[Flow]") {
         WHEN("layer height is set to 0.2") {
             layer_height = 0.15f;
             THEN("Max width is set.") {
-                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
                 REQUIRE(flow.width() == Approx(1.125 * nozzle_diameter));
             }
         }
         WHEN("Layer height is set to 0.25") {
             layer_height = 0.25f;
             THEN("Min width is set.") {
-                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
                 REQUIRE(flow.width() == Approx(1.125 * nozzle_diameter));
             }
         }


### PR DESCRIPTION
Currently variable layer height is calculated and shown with 6 digits, thing that has no practical meaning:

![image](https://user-images.githubusercontent.com/8691781/230735417-a571a37b-7d8e-4fdd-9451-3ed69b4e2ad8.png)


This PR rounds layer height to 0.01:

![image](https://user-images.githubusercontent.com/8691781/230735538-eb36cd57-d689-46a2-9f89-36ed6ddf476e.png)

Also it shows each layer height in double slider (though it can be wrong when support is not synchronized):

![image](https://user-images.githubusercontent.com/8691781/230735636-cebd65df-006b-43da-b89a-aa1eb14e6766.png)

