### PR TITLE
Round shown var layer height to 0.01, show height in double slider.

### DIFF
--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -783,7 +783,13 @@ wxString Control::get_label(int tick, LabelType label_type/* = ltHeightWithLayer
             return str;
         if (label_type == ltHeightWithLayer) {
             size_t layer_number = m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
-            return format_wxstr("%1%\n(%2%)", str, layer_number);
+            double layer_height = m_values.empty() ? m_label_koef : m_values[layer_number - 1] - (layer_number > 1 ? m_values[layer_number - 2] : 0);
+
+            //could be negative when custom G-code has layer height bigger than real one.
+            //Also could be less then real height when support not synchronized
+            if (layer_height <= 0)
+                layer_height = m_values[layer_number - 1];
+            return format_wxstr("%1%\n(%2%,\n%3%)", str, wxString::Format("%.2f", layer_height), layer_number);
         }
     }
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -346,7 +346,7 @@ std::string GLCanvas3D::LayersEditing::get_tooltip(const GLCanvas3D& canvas) con
                 }
             }
             if (h > 0.0f)
-                ret = std::to_string(h);
+                ret = wxString::Format("%.2f", h).ToStdString();
         }
     }
     return ret;


### PR DESCRIPTION
Currently variable layer height is calculated and shown with 6 digits, thing that has no practical meaning:
![image](https://user-images.githubusercontent.com/8691781/230735724-8b3b59f2-60e0-460c-ae95-5125f41a03e0.png)

This PR rounds layer height to 0.01:
![image](https://user-images.githubusercontent.com/8691781/230735739-fdaf6b24-a8e2-436d-a1ed-e51162b6dbb2.png)

Also it shows each layer height in double slider (though it can be wrong when support is not synchronized):
![image](https://user-images.githubusercontent.com/8691781/230735756-c727feec-d44a-4146-81b9-fbdf64a3a3d6.png)
