### PR TITLE
Update PrusaSlicer_de.po

### DIFF
--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -5997,7 +5997,7 @@ msgstr ""
 
 #: src/slic3r/GUI/GUI_Factories.cpp:471
 msgid "Gallery"
-msgstr "Gallerie"
+msgstr "Galerie"
 
 #: src/slic3r/GUI/GUI_Preview.cpp:247 src/libslic3r/ExtrusionEntity.cpp:338
 #: src/libslic3r/ExtrusionEntity.cpp:368 src/libslic3r/PrintConfig.cpp:1325


### PR DESCRIPTION
Zeile 6000: "Galerie" wird im Deutschen mit nur einem "l" geschrieben.  https://www.duden.de/rechtschreibung/Galerie