### PR TITLE
fixed double definition of target libexpat described in #9581

### DIFF
--- a/cmake/modules/FindEXPAT.cmake
+++ b/cmake/modules/FindEXPAT.cmake
@@ -25,7 +25,7 @@ if (NOT EXPAT_FOUND)
     endif ()
 endif()
 
-if (EXPAT_FOUND AND NOT TARGET EXPAT::EXPAT)
+if (EXPAT_FOUND AND NOT (TARGET EXPAT::EXPAT OR TARGET expat::expat))
     add_library(libexpat INTERFACE)
     add_library(EXPAT::EXPAT ALIAS libexpat)
     target_link_libraries(libexpat INTERFACE expat::expat)


### PR DESCRIPTION
This fixes the problem described in issue #9581, where on some system the expat target is not defined as EXPAT:EXPAT but rather as expat:expat resulting in a double definition of the libexpat cmake target.