### PR TITLE
Z clearance between nozzle and bed for moves.

### DIFF
--- a/src/libslic3r/GCode/Travels.cpp
+++ b/src/libslic3r/GCode/Travels.cpp
@@ -433,6 +433,9 @@ Points3 generate_travel_to_extrusion(
         elevation_params.slope_end + elevation_params.blend_width / 2.0,
         elevation_params.parabola_points_count
     );
+    if (initial_elevation + elevation_params.lift_height < config.z_clearance)
+        elevation_params.lift_height = config.z_clearance - initial_elevation;
+
     Points3 result{generate_elevated_travel(
         xy_path.points, ensure_points_at_distances, initial_elevation,
         ElevatedTravelFormula{elevation_params}

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -504,6 +504,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
 static std::vector<std::string> s_Preset_printer_options {
     "printer_technology", "autoemit_temperature_commands",
     "bed_shape", "bed_custom_texture", "bed_custom_model", "binary_gcode", "z_offset", "gcode_flavor", "use_relative_e_distances",
+    "z_clearance",
     "use_firmware_retraction", "use_volumetric_e", "variable_layer_height",
     //FIXME the print host keys are left here just for conversion from the Printer preset to Physical Printer preset.
     "host_type", "print_host", "printhost_apikey", "printhost_cafile",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -255,7 +255,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "travel_speed"
             || opt_key == "travel_speed_z"
             || opt_key == "first_layer_speed"
-            || opt_key == "z_offset") {
+            || opt_key == "z_offset"
+            || opt_key == "z_clearance") {
             steps.emplace_back(psWipeTower);
             steps.emplace_back(psSkirtBrim);
         } else if (opt_key == "filament_soluble") {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3449,6 +3449,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
+    def = this->add("z_clearance", coFloat);
+    def->label = L("Z clearance");
+    def->tooltip = L("This is a minimum height for lift after retraction. It prevents nozzle crash to glass clips, etc. "
+                   "Set to a bit more then such objects, if there is head movement over clips.");
+    def->sidetext = L("mm");
+    def->mode = comAdvanced;
+    def->min = 0;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("perimeter_generator", coEnum);
     def->label = L("Perimeter generator");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -756,6 +756,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              retract_length))
     ((ConfigOptionFloats,              retract_length_toolchange))
     ((ConfigOptionFloats,              retract_lift))
+    ((ConfigOptionFloat,               z_clearance))
     ((ConfigOptionFloats,              retract_lift_above))
     ((ConfigOptionFloats,              retract_lift_below))
     ((ConfigOptionFloats,              retract_restart_extra))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2628,6 +2628,7 @@ void TabPrinter::build_fff()
 
         optgroup->append_single_option_line("max_print_height");
         optgroup->append_single_option_line("z_offset");
+        optgroup->append_single_option_line("z_clearance");
 
         optgroup = page->new_optgroup(L("Capabilities"));
         ConfigOptionDef def;


### PR DESCRIPTION
Currently only Z lift 
![image](https://user-images.githubusercontent.com/8691781/233092112-b54d3a42-c80b-4e62-9f81-ad6da15e6d6a.png)

is applied for non-extrusion moves. But it could be not enough when glass clips has more height and object is reach edges between clips. For example 2mm clips are available:

![image](https://user-images.githubusercontent.com/8691781/233092781-cb19aaa8-6fa2-4efb-8a21-720c9f8647a6.png)

This PR add printer parameter
![image](https://user-images.githubusercontent.com/8691781/233093042-2463d434-b1ea-45ce-8bb8-5264242a0f4c.png)

ensuring that on each lift nozzle goes up at least for this height.