### PR TITLE
ensure a reduction of bridge flows, if user disabled thick_bridges

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -45,7 +45,7 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool force_thick_bridges) const
 
     // If extrusion_width * layer_height > nozzle_diameter ^ 2 * Pi/4, "normal" flow can get much higher than the rounded flow
     // In that case, bridges based on normal_flow would become thicker (and unusable) than with round_flow
-    // So, return rounded_flow to ensure that bridges are indeed thinner thick_bridges is disabled
+    // So, return rounded_flow to ensure that bridges are indeed thinner if thick_bridges is disabled
     if ((print_object.config().thick_bridges || force_thick_bridges) && (round_flow.mm3_per_mm() > normal_flow.mm3_per_mm()))
         return round_flow;
     else

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -32,17 +32,24 @@ Flow LayerRegion::bridging_flow(FlowRole role, bool force_thick_bridges) const
     const PrintRegion       &region         = this->region();
     const PrintRegionConfig &region_config  = region.config();
     const PrintObject       &print_object   = *this->layer()->object();
-    if (print_object.config().thick_bridges || force_thick_bridges) {
-        // The old Slic3r way (different from all other slicers): Use rounded extrusions.
-        // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
-        // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
-        auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
-        // Applies default bridge spacing.
-        return Flow::bridging_flow(float(sqrt(region_config.bridge_flow_ratio)) * nozzle_diameter, nozzle_diameter);
-    } else {
-        // The same way as other slicers: Use normal extrusions. Apply bridge_flow_ratio while maintaining the original spacing.
-        return this->flow(role).with_flow_ratio(region_config.bridge_flow_ratio);
-    }
+
+    // The old Slic3r way (different from all other slicers): Use rounded extrusions.
+    // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
+    // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
+    const auto nozzle_diameter = float(print_object.print()->config().nozzle_diameter.get_at(region.extruder(role) - 1));
+    // Applies default bridge spacing.
+    const auto round_flow = Flow::bridging_flow(float(sqrt(region_config.bridge_flow_ratio)) * nozzle_diameter, nozzle_diameter);
+
+    // The same way as other slicers: Use normal extrusions. Apply bridge_flow_ratio while maintaining the original spacing.
+    const auto normal_flow = this->flow(role).with_flow_ratio(region_config.bridge_flow_ratio);
+
+    // If extrusion_width * layer_height > nozzle_diameter ^ 2 * Pi/4, "normal" flow can get much higher than the rounded flow
+    // In that case, bridges based on normal_flow would become thicker (and unusable) than with round_flow
+    // So, return rounded_flow to ensure that bridges are indeed thinner thick_bridges is disabled
+    if ((print_object.config().thick_bridges || force_thick_bridges) && (round_flow.mm3_per_mm() > normal_flow.mm3_per_mm()))
+        return round_flow;
+    else
+        return normal_flow;
 }
 
 // Fill in layerm->fill_surfaces by trimming the layerm->slices by layerm->fill_expolygons.


### PR DESCRIPTION
This fix addresses the issue #9007 but also the problematic behavior triggered by #10340.
  
The current implementation of `thick_bridges=off` is broken (at least in combination with arachne perimeter generation or variable layer_height):

If `extrusion_width * layer_height > nozzle_diameter^2 * Pi/4`, the resulting bridge_flow with `thick_bridges=off` will be thicker than with `thick_bridges=on`.

This merge request will ensure that, if `thick_bridges=off`, the `LayerRegion::bridging_flow()` will always return the lesser flow. But it will not do the opposite, since the implementation with `thick_bridges=on` is not influenced by variations in layer_height and extrusion_width, so it does not have to be fixed.