### PR TITLE
Variable perimeters and solid infill extrusion width on even layers.

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -184,7 +184,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        } else {
 					// Internal infill. Calculating infill line spacing independent of the current layer height and 1st layer status,
 					// so that internall infill will be aligned over all layers of the current region.
-		            params.spacing = layerm.region().flow(*layer.object(), frInfill, layer.object()->config().layer_height, false).spacing();
+		            params.spacing = layerm.region().flow(*layer.object(), frInfill, layer.object()->config().layer_height, layer.id()).spacing();
 		            // Anchor a sparse infill to inner perimeters with the following anchor length:
 			        params.anchor_length = float(region_config.infill_anchor);
 					if (region_config.infill_anchor.percent)

--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -122,7 +122,7 @@ double Flow::extrusion_width(const std::string& opt_key, const ConfigOptionResol
 
 // This constructor builds a Flow object from an extrusion width config setting
 // and other context properties.
-Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height)
+Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float width_delta, float nozzle_diameter, float height)
 {
     if (height <= 0)
         throw Slic3r::InvalidArgument("Invalid flow height supplied to new_from_config_width()");
@@ -135,6 +135,7 @@ Flow Flow::new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent
         // If user set a manual value, use it.
         w = float(width.get_abs_value(height));
     }
+    w += width_delta;
     
     return Flow(w, height, rounded_rectangle_extrusion_spacing(w, height), nozzle_diameter, false);
 }
@@ -231,6 +232,7 @@ Flow support_material_flow(const PrintObject *object, float layer_height)
         frSupportMaterial,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (object->config().support_material_extrusion_width.value > 0) ? object->config().support_material_extrusion_width : object->config().extrusion_width,
+        0,
         // if object->config().support_material_extruder == 0 (which means to not trigger tool change, but use the current extruder instead), get_at will return the 0th component.
         float(object->print()->config().nozzle_diameter.get_at(object->config().support_material_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));
@@ -244,6 +246,7 @@ Flow support_material_1st_layer_flow(const PrintObject *object, float layer_heig
         frSupportMaterial,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (width.value > 0) ? width : object->config().extrusion_width,
+        0,
         float(print_config.nozzle_diameter.get_at(object->config().support_material_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(print_config.first_layer_height.get_abs_value(object->config().layer_height.value)));
 }
@@ -254,6 +257,7 @@ Flow support_material_interface_flow(const PrintObject *object, float layer_heig
         frSupportMaterialInterface,
         // The width parameter accepted by new_from_config_width is of type ConfigOptionFloatOrPercent, the Flow class takes care of the percent to value substitution.
         (object->config().support_material_extrusion_width > 0) ? object->config().support_material_extrusion_width : object->config().extrusion_width,
+        0,
         // if object->config().support_material_interface_extruder == 0 (which means to not trigger tool change, but use the current extruder instead), get_at will return the 0th component.
         float(object->print()->config().nozzle_diameter.get_at(object->config().support_material_interface_extruder-1)),
         (layer_height > 0.f) ? layer_height : float(object->config().layer_height.value));

--- a/src/libslic3r/Flow.hpp
+++ b/src/libslic3r/Flow.hpp
@@ -105,7 +105,7 @@ public:
 
     static Flow bridging_flow(float dmr, float nozzle_diameter) { return Flow { dmr, dmr, bridge_extrusion_spacing(dmr), nozzle_diameter, true }; }
 
-    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float nozzle_diameter, float height);
+    static Flow new_from_config_width(FlowRole role, const ConfigOptionFloatOrPercent &width, float width_delta, float nozzle_diameter, float height);
 
     // Spacing of extrusions with rounded extrusion model.
     static float rounded_rectangle_extrusion_spacing(float width, float height);

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -31,7 +31,7 @@ Flow LayerRegion::flow(FlowRole role) const
 
 Flow LayerRegion::flow(FlowRole role, double layer_height) const
 {
-    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id() == 0);
+    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id());
 }
 
 Flow LayerRegion::bridging_flow(FlowRole role, bool force_thick_bridges) const

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -465,7 +465,7 @@ static std::vector<std::string> s_Preset_print_options {
     "extruder_clearance_height", "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",
     "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width",
-    "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width",
+    "perimeter_extrusion_width", "perimeter_extrusion_width_even_layers", "external_perimeter_extrusion_width", "external_perimeter_extrusion_width_even_layers", "infill_extrusion_width", "infill_extrusion_width_even_layers", "solid_infill_extrusion_width", "solid_infill_extrusion_width_even_layers",
     "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "infill_anchor", "infill_anchor_max", "bridge_flow_ratio",
     "elefant_foot_compensation", "xy_size_compensation", "resolution", "gcode_resolution", "arc_fitting",
     "wipe_tower", "wipe_tower_x", "wipe_tower_y",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -891,6 +891,7 @@ Flow Print::brim_flow() const
     return Flow::new_from_config_width(
         frPerimeter,
 		width,
+        0,
         (float)m_config.nozzle_diameter.get_at(m_print_regions.front()->config().perimeter_extruder-1),
 		(float)this->skirt_first_layer_height());
 }
@@ -911,6 +912,7 @@ Flow Print::skirt_flow() const
     return Flow::new_from_config_width(
         frPerimeter,
 		width,
+        0,
 		(float)m_config.nozzle_diameter.get_at(m_objects.front()->config().support_material_extruder-1),
 		(float)this->skirt_first_layer_height());
 }

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -111,7 +111,7 @@ public:
     int                         print_object_region_id() const throw() { return m_print_object_region_id; }
 	// 1-based extruder identifier for this region and role.
 	unsigned int 				extruder(FlowRole role) const;
-    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, bool first_layer = false) const;
+    Flow                        flow(const PrintObject &object, FlowRole role, double layer_height, int layer_id = 2/*default is not 1st and not even zero-based*/) const;
     // Average diameter of nozzles participating on extruding this region.
     coordf_t                    nozzle_dmr_avg(const PrintConfig &print_config) const;
     // Average diameter of nozzles participating on extruding this region.

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -893,6 +893,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
 
+    def = this->add("external_perimeter_extrusion_width_even_layers", coFloat);
+    def->label = L("External perimeters even layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("External perimeter change on even layers. It overlaps perimeters border and increase interlayer strength. "
+                   "Choose value about ±40-60% of layer height and opposite sign to internal perimeters and soild infill change.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max =  0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("external_perimeter_speed", coFloatOrPercent);
     def->label = L("External perimeters");
     def->category = L("Speed");
@@ -1632,6 +1643,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
 
+    def = this->add("infill_extrusion_width_even_layers", coFloat);
+    def->label = L("Infill even layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("Infill change on even layers. It overlaps perimeters border and increase with interlayer strength. Has meaning only for 100% concentric infill. "
+        "Choose value about ±40-60% of layer height.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max = 0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("infill_first", coBool);
     def->label = L("Infill before perimeters");
     def->tooltip = L("This option will switch the print order of perimeters and infill, making the latter first.");
@@ -2150,6 +2172,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
 
+    def = this->add("perimeter_extrusion_width_even_layers", coFloat);
+    def->label = L("Perimeters even layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("Perimeter change on even layers. It overlaps perimeters border and increase with interlayer strength. "
+                   "Choose value about ±40-60% of layer height.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max = 0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("perimeter_speed", coFloat);
     def->label = L("Perimeters");
     def->category = L("Speed");
@@ -2571,6 +2604,17 @@ void PrintConfigDef::init_fff_params()
     def->max_literal = 50;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloatOrPercent(0, false));
+
+    def = this->add("solid_infill_extrusion_width_even_layers", coFloat);
+    def->label = L("Solid infill even layers delta");
+    def->category = L("Extrusion Width");
+    def->tooltip = L("Solid infill change on even layers. It overlaps perimeters border and increase with interlayer strength. Could be useful for concentric infill. "
+                   "Choose value about ±40-60% of layer height.");
+    def->sidetext = L("mm");
+    def->min = -0.3f;
+    def->max = 0.3f;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("solid_infill_speed", coFloatOrPercent);
     def->label = L("Solid infill");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -612,6 +612,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<InfillPattern>,  top_fill_pattern))
     ((ConfigOptionEnum<InfillPattern>,  bottom_fill_pattern))
     ((ConfigOptionFloatOrPercent,       external_perimeter_extrusion_width))
+    ((ConfigOptionFloat,                external_perimeter_extrusion_width_even_layers))
     ((ConfigOptionFloatOrPercent,       external_perimeter_speed))
     ((ConfigOptionBool,                 enable_dynamic_overhang_speeds))
     ((ConfigOptionFloatOrPercent,       overhang_speed_0))
@@ -633,6 +634,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatOrPercent,       infill_anchor_max))
     ((ConfigOptionInt,                  infill_extruder))
     ((ConfigOptionFloatOrPercent,       infill_extrusion_width))
+    ((ConfigOptionFloat,                infill_extrusion_width_even_layers))
     ((ConfigOptionInt,                  infill_every_layers))
     ((ConfigOptionFloatOrPercent,       infill_overlap))
     ((ConfigOptionFloat,                infill_speed))
@@ -646,6 +648,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                 overhangs))
     ((ConfigOptionInt,                  perimeter_extruder))
     ((ConfigOptionFloatOrPercent,       perimeter_extrusion_width))
+    ((ConfigOptionFloat,                perimeter_extrusion_width_even_layers))
     ((ConfigOptionFloat,                perimeter_speed))
     // Total number of perimeters.
     ((ConfigOptionInt,                  perimeters))
@@ -653,6 +656,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                solid_infill_below_area))
     ((ConfigOptionInt,                  solid_infill_extruder))
     ((ConfigOptionFloatOrPercent,       solid_infill_extrusion_width))
+    ((ConfigOptionFloat,                solid_infill_extrusion_width_even_layers))
     ((ConfigOptionInt,                  solid_infill_every_layers))
     ((ConfigOptionFloatOrPercent,       solid_infill_speed))
     // Detect thin walls.

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -713,6 +713,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "extra_perimeters_on_overhangs"
             || opt_key == "first_layer_extrusion_width"
             || opt_key == "perimeter_extrusion_width"
+            || opt_key == "perimeter_extrusion_width_even_layers"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first"
             || opt_key == "arc_fitting") {
@@ -816,6 +817,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_extruder"
             || opt_key == "solid_infill_extruder"
             || opt_key == "infill_extrusion_width"
+            || opt_key == "infill_extrusion_width_even_layers"
             || opt_key == "bridge_angle") {
             steps.emplace_back(posPrepareInfill);
         } else if (
@@ -841,12 +843,15 @@ bool PrintObject::invalidate_state_by_config_options(
                 is_approx(new_density->value, 0.) || is_approx(new_density->value, 100.))
                 steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
-        } else if (opt_key == "solid_infill_extrusion_width") {
+        } else if (
+               opt_key == "solid_infill_extrusion_width"
+            || opt_key == "solid_infill_extrusion_width_even_layers") {
             // This value is used for calculating perimeter - infill overlap, thus perimeters need to be recalculated.
             steps.emplace_back(posPerimeters);
             steps.emplace_back(posPrepareInfill);
         } else if (
                opt_key == "external_perimeter_extrusion_width"
+            || opt_key == "external_perimeter_extrusion_width_even_layers"
             || opt_key == "perimeter_extruder"
             || opt_key == "fuzzy_skin"
             || opt_key == "fuzzy_skin_thickness"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -219,7 +219,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 {
     bool have_perimeters = config->opt_int("perimeters") > 0;
     for (auto el : { "extra_perimeters","extra_perimeters_on_overhangs", "thin_walls", "overhangs",
-                    "seam_position","staggered_inner_seams", "external_perimeters_first", "external_perimeter_extrusion_width",
+                    "seam_position","staggered_inner_seams", "external_perimeters_first", "external_perimeter_extrusion_width", "external_perimeter_extrusion_width_even_layers",
                     "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "enable_dynamic_overhang_speeds"})
         toggle_field(el, have_perimeters);
 
@@ -242,10 +242,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     bool has_solid_infill 		 = has_top_solid_infill || has_bottom_solid_infill;
     // solid_infill_extruder uses the same logic as in Print::extruders()
     for (auto el : { "top_fill_pattern", "bottom_fill_pattern", "infill_first", "solid_infill_extruder",
-                    "solid_infill_extrusion_width", "solid_infill_speed" })
+                    "solid_infill_extrusion_width", "solid_infill_extrusion_width_even_layers", "solid_infill_speed" })
         toggle_field(el, has_solid_infill);
 
-    for (auto el : { "fill_angle", "bridge_angle", "infill_extrusion_width",
+    for (auto el : { "fill_angle", "bridge_angle", "infill_extrusion_width", "infill_extrusion_width_even_layers",
                     "infill_speed", "bridge_speed" })
         toggle_field(el, have_infill || has_solid_infill);
 
@@ -305,6 +305,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("support_material_synchronize_layers", have_support_soluble);
 
     toggle_field("perimeter_extrusion_width", have_perimeters || have_skirt || have_brim);
+    toggle_field("perimeter_extrusion_width_even_layers", have_perimeters);
     toggle_field("support_material_extruder", have_support_material || have_skirt);
     toggle_field("support_material_speed", have_support_material || have_brim || have_skirt);
 

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -163,7 +163,7 @@ std::string PresetHints::maximum_volumetric_flow_description(const PresetBundle 
             [first_layer_extrusion_width_ptr, extrusion_width, nozzle_diameter, lh, bridging, bridge_speed, bridge_flow_ratio, limit_by_first_layer_speed, max_print_speed, &max_flow, &max_flow_extrusion_type]
             (FlowRole flow_role, const ConfigOptionFloatOrPercent &this_extrusion_width, double speed, const char *err_msg) {
             Flow flow = bridging ?
-                Flow::new_from_config_width(flow_role, first_positive(first_layer_extrusion_width_ptr, this_extrusion_width, extrusion_width), nozzle_diameter, lh) :
+                Flow::new_from_config_width(flow_role, first_positive(first_layer_extrusion_width_ptr, this_extrusion_width, extrusion_width), 0, nozzle_diameter, lh) :
                 Flow::bridging_flow(nozzle_diameter * bridge_flow_ratio, nozzle_diameter);
             double volumetric_flow = flow.mm3_per_mm() * (bridging ? bridge_speed : limit_by_first_layer_speed(speed, max_print_speed));
             if (max_flow < volumetric_flow) {
@@ -229,10 +229,12 @@ std::string PresetHints::recommended_thin_wall_thickness(const PresetBundle &pre
             Flow external_perimeter_flow = Flow::new_from_config_width(
                 frExternalPerimeter, 
                 *print_config.opt<ConfigOptionFloatOrPercent>("external_perimeter_extrusion_width"), 
+                0,
                 nozzle_diameter, layer_height);
             Flow perimeter_flow          = Flow::new_from_config_width(
                 frPerimeter, 
                 *print_config.opt<ConfigOptionFloatOrPercent>("perimeter_extrusion_width"), 
+                0,
                 nozzle_diameter, layer_height);
 	        double width = external_perimeter_flow.width() + external_perimeter_flow.spacing();
 	        for (int i = 2; i <= num_lines; thin_walls ? ++ i : i += 2) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1673,6 +1673,11 @@ void TabPrint::build()
         optgroup->append_single_option_line("solid_infill_extrusion_width");
         optgroup->append_single_option_line("top_infill_extrusion_width");
         optgroup->append_single_option_line("support_material_extrusion_width");
+        optgroup->append_separator();
+        optgroup->append_single_option_line("perimeter_extrusion_width_even_layers");
+        optgroup->append_single_option_line("external_perimeter_extrusion_width_even_layers");
+        optgroup->append_single_option_line("infill_extrusion_width_even_layers");
+        optgroup->append_single_option_line("solid_infill_extrusion_width_even_layers");
 
         optgroup = page->new_optgroup(L("Overlap"));
         optgroup->append_single_option_line("infill_overlap");

--- a/tests/fff_print/test_flow.cpp
+++ b/tests/fff_print/test_flow.cpp
@@ -155,18 +155,18 @@ SCENARIO("Flow: Flow math for non-bridges", "[Flow]") {
 
         // Spacing for non-bridges is has some overlap
         THEN("External perimeter flow has spacing fixed to 1.125 * nozzle_diameter") {
-            auto flow = Flow::new_from_config_width(frExternalPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frExternalPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(1.125 * nozzle_diameter - layer_height * (1.0 - PI / 4.0)));
         }
 
         THEN("Internal perimeter flow has spacing fixed to 1.125 * nozzle_diameter") {
-            auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(1.125 *nozzle_diameter - layer_height * (1.0 - PI / 4.0)));
         }
         THEN("Spacing for supplied width is 0.8927f") {
-            auto flow = Flow::new_from_config_width(frExternalPerimeter, width, nozzle_diameter, layer_height);
+            auto flow = Flow::new_from_config_width(frExternalPerimeter, width, 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(width.value - layer_height * (1.0 - PI / 4.0)));
-            flow = Flow::new_from_config_width(frPerimeter, width, nozzle_diameter, layer_height);
+            flow = Flow::new_from_config_width(frPerimeter, width, 0, nozzle_diameter, layer_height);
             REQUIRE(flow.spacing() == Approx(width.value - layer_height * (1.0 - PI / 4.0)));
         }
     }
@@ -177,14 +177,14 @@ SCENARIO("Flow: Flow math for non-bridges", "[Flow]") {
         WHEN("layer height is set to 0.2") {
             layer_height = 0.15f;
             THEN("Max width is set.") {
-                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
                 REQUIRE(flow.width() == Approx(1.125 * nozzle_diameter));
             }
         }
         WHEN("Layer height is set to 0.25") {
             layer_height = 0.25f;
             THEN("Min width is set.") {
-                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), nozzle_diameter, layer_height);
+                auto flow = Flow::new_from_config_width(frPerimeter, ConfigOptionFloatOrPercent(0, false), 0, nozzle_diameter, layer_height);
                 REQUIRE(flow.width() == Approx(1.125 * nozzle_diameter));
             }
         }


### PR DESCRIPTION
Related to/solves #8621 #10381

It's known that interline border is a weak point. Currently gap between lines corners is calculated in code as `layer_height*0.785` - 0.157 for 0.2 layer.

![image](https://user-images.githubusercontent.com/8691781/233833016-04fb6166-9a1a-46a2-b51c-1c5c176af71a.png)

Instead of shifting layers or lines that lead to rough surface this PR alternates lines width for every even layer:

![image](https://user-images.githubusercontent.com/8691781/233833135-e7c61547-5873-4f59-ace0-c2a12a07bf74.png)

Reasonable width change is about +/- 40%-60% of layer width:

40%:
![image](https://user-images.githubusercontent.com/8691781/233833404-6dbed680-89a3-4e0e-b08c-c7107c38f605.png)

60%:
![image](https://user-images.githubusercontent.com/8691781/233833427-a1c12a93-9857-4bfa-b3a9-757d9adc5f75.png)

Configuration:
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/464eae38-7745-4e55-a2dc-5f071b74515f)

Example 1:
![image](https://user-images.githubusercontent.com/8691781/233833553-adf411ea-8a8d-4b1d-a4ea-f5532b7d0595.png) 
![image](https://user-images.githubusercontent.com/8691781/233833578-95ce7198-f794-44df-aea7-4bd18e2994b1.png)

Example 2:

![image](https://user-images.githubusercontent.com/8691781/233833705-ee7190b9-3633-40b3-80d4-7634b0143e40.png)
![image](https://user-images.githubusercontent.com/8691781/233833725-7e54e089-1094-408b-ba3e-63f45457a358.png)

3:
![image](https://user-images.githubusercontent.com/8691781/233833781-fc7c4df3-8f58-4fdd-a830-3e3ffec3d784.png)
![image](https://user-images.githubusercontent.com/8691781/233833799-2161cf1b-8267-4b40-95b8-c5e37e879fae.png)

4:
![image](https://user-images.githubusercontent.com/8691781/233833890-bf49ef12-8ddb-4e30-b718-767b5b8f6815.png)
![image](https://user-images.githubusercontent.com/8691781/233833905-1be5cb26-ca1c-41ba-9469-f7bea01d3c8d.png)
