### PR TITLE
Introduce codespell checking + fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg
-#
-# ignore-words-list =
+skip = .git,*.pdf,*.svg,localization,atmel-docs,*.html
+# for now ignore all "misspelled" of size 4 and under, although some
+# are obviously typos
+ignore-words-list = alle,alow,anid,ans,basf,blok,bu,cach,cant,clen,coud,doen,dota,dout,enew,fo,fro,fron,fuly,gord,grup,ist,larg,leat,lod,lowd,mata,matc,ment,nd,ned,nin,nwe,ot,oter,othe,padd,paht,parm,poit,puls,seh,ser,shal,sie,tabl,te,tha,ther,thes,thie,trys,ture,ue,upto,valu,vave,whe,whih,wich,wiht,wont

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,6 @@
 skip = .git,*.pdf,*.svg,localization,atmel-docs,*.html
 # for now ignore all "misspelled" of size 4 and under, although some
 # are obviously typos
-ignore-words-list = alle,alow,anid,ans,basf,blok,bu,cach,cant,clen,coud,doen,dota,dout,enew,fo,fro,fron,fuly,gord,grup,ist,larg,leat,lod,lowd,mata,matc,ment,nd,ned,nin,nwe,ot,oter,othe,padd,paht,parm,poit,puls,seh,ser,shal,sie,tabl,te,tha,ther,thes,thie,trys,ture,ue,upto,valu,vave,whe,whih,wich,wiht,wont
+# Tesselate - internal file name misspelled (no ll)
+# actived,archtype - internal attribute/variable
+ignore-words-list = alle,alow,anid,ans,basf,blok,bu,cach,cant,clen,coud,doen,dota,dout,enew,fo,fro,fron,fuly,gord,grup,ist,larg,leat,lod,lowd,mata,matc,ment,nd,ned,nin,nwe,ot,oter,othe,padd,paht,parm,poit,puls,seh,ser,shal,sie,tabl,te,tha,ther,thes,thie,trys,ture,ue,upto,valu,vave,whe,whih,wich,wiht,wont,tesselate,actived,archtype

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,3 +17,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
+        with:
+          path: src/slic3r/

--- a/src/avrdude/windows/status_giveio.bat
+++ b/src/avrdude/windows/status_giveio.bat
@@ -6,7 +6,7 @@
 @goto exit
 
 :error
-@echo ERROR: Status querry for %DIRVERNAME% failed
+@echo ERROR: Status query for %DIRVERNAME% failed
 
 :exit
 

--- a/src/libslic3r/CutSurface.cpp
+++ b/src/libslic3r/CutSurface.cpp
@@ -15,7 +15,7 @@
 ///                     - Same meaning of color as constrained
 /// {N} .. Order of cutted Area of Interestmodel from model surface
 /// model_AOIs/{M}/cutAOI{N}.obj - Extracted Area of interest from corefined model
-/// model_AOIs/{M}/outline{N}.obj - Outline of Cutted Area
+/// model_AOIs/{M}/outline{N}.obj - Outline of Cut Area
 /// {O} .. Order number of patch
 /// patches/patch{O}.off
 /// result.obj - Merged result its
@@ -241,7 +241,7 @@ void create_reduce_map(ReductionMap &reduction_map, const CutMesh &meshes);
 // Patch made by Cut area of interest from model
 // connected faces(triangles) and outlines(halfEdges) for one surface cut
 using CutAOI = std::pair<std::vector<FI>, std::vector<HI>>;
-// vector of Cutted Area of interest cutted from one CGAL model
+// vector of Cut Area of interest cutted from one CGAL model
 using CutAOIs = std::vector<CutAOI>;
 // vector of CutAOIs for each model
 using VCutAOIs = std::vector<CutAOIs>;
@@ -337,7 +337,7 @@ public:
 /// Differenciate other models
 /// </summary>
 /// <param name="cuts">Patches from meshes</param>
-/// <param name="cut_models">Source points for Cutted AOIs
+/// <param name="cut_models">Source points for Cut AOIs
 /// NOTE: Create Reduction map as mesh property - clean on end</param>
 /// <param name="models">Original models without cut modifications
 /// used for differenciation
@@ -435,7 +435,7 @@ VDistances calc_distances(const SurfacePatches &patches,
 /// <param name="shapes">Vector of letters</param>
 /// <param name="start">Pivot for start projection in 2d</param>
 /// <param name="s2i">Convert index to addresss inside of shape</param>
-/// <param name="patches">Cutted parts from surface</param>
+/// <param name="patches">Cut parts from surface</param>
 /// <returns>Closest distance projection indexed by points in shapes(see s2i)</returns>
 ProjectionDistances choose_best_distance(
     const VDistances       &distances,
@@ -1230,7 +1230,7 @@ void collect_surface_data(std::queue<FI>  &process,
 /// Create areas from mesh surface
 /// </summary>
 /// <param name="mesh">Model</param>
-/// <param name="shapes">Cutted shapes</param>
+/// <param name="shapes">Cut shapes</param>
 /// <param name="face_type_map">Define Triangles of interest.
 /// Edge between inside / outside.
 /// NOTE: Not const because it need to flag proccessed faces</param>
@@ -2721,7 +2721,7 @@ using BBS = std::vector<BoundingBoxf3>;
 /// <summary>
 /// Create bounding boxes for AOI
 /// </summary>
-/// <param name="cuts">Cutted AOI from models</param>
+/// <param name="cuts">Cut AOI from models</param>
 /// <param name="cut_models">Source points of cuts</param>
 /// <returns>Bounding boxes</returns>
 BBS create_bbs(const VCutAOIs &cuts, const CutMeshes &cut_models);

--- a/src/libslic3r/CutSurface.hpp
+++ b/src/libslic3r/CutSurface.hpp
@@ -33,7 +33,7 @@ struct SurfaceCut : public indexed_triangle_set
 /// 1 .. means use closest to back projection
 /// value from <0, 1>
 /// </param>
-/// <returns>Cutted surface from model</returns>
+/// <returns>Cut surface from model</returns>
 SurfaceCut cut_surface(const ExPolygons                        &shapes,
                        const std::vector<indexed_triangle_set> &models,
                        const Emboss::IProjection               &projection,

--- a/src/slic3r/Config/Version.cpp
+++ b/src/slic3r/Config/Version.cpp
@@ -176,7 +176,7 @@ size_t Index::load(const boost::filesystem::path &path)
     			if (! svalue.empty())
 					semver = Semver::parse(svalue);
                 if (! semver)
-		    		throw file_parser_error(std::string(key) + " must referece a valid semantic version", path, idx_line);
+		    		throw file_parser_error(std::string(key) + " must reference a valid semantic version", path, idx_line);
                 if (strcmp(key, "min_slic3r_version") == 0)
     				ver.min_slic3r_version = *semver;
                 else

--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -143,7 +143,7 @@ BoundingBoxf3 Bed3D::calc_extended_bounding_box() const
 {
     BoundingBoxf3 out { m_build_volume.bounding_volume() };
     const Vec3d size = out.size();
-    // ensures that the bounding box is set as defined or the following calls to merge() will not work as intented
+    // ensures that the bounding box is set as defined or the following calls to merge() will not work as intended
     if (size.x() > 0.0 && size.y() > 0.0 && !out.defined)
         out.defined = true;
     // Reset the build volume Z, we don't want to zoom to the top of the build volume if it is empty.

--- a/src/slic3r/GUI/3DBed.hpp
+++ b/src/slic3r/GUI/3DBed.hpp
@@ -33,7 +33,7 @@ private:
     Type m_type{ Type::Custom };
     std::string m_texture_filename;
     std::string m_model_filename;
-    // Print volume bounding box exteded with axes and model.
+    // Print volume bounding box extended with axes and model.
     BoundingBoxf3 m_extended_bounding_box;
     // Print bed polygon
     ExPolygon m_contour;

--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -1014,7 +1014,7 @@ static void thick_lines_to_geometry(
     double width_initial = 0.0;
     double bottom_z_initial = 0.0;
 
-    // Reserve for a smooth path. Likley the path will not be that smooth, but better than nothing.
+    // Reserve for a smooth path. Likely the path will not be that smooth, but better than nothing.
     // Allocated 1.5x more data than minimum.
     // Number of indices, not triangles.
     geometry.reserve_more_indices((lines.size() * 8 * 3) * 3 / 2);

--- a/src/slic3r/GUI/3DScene.hpp
+++ b/src/slic3r/GUI/3DScene.hpp
@@ -165,15 +165,15 @@ public:
 	    bool                is_active : 1;
 	    // Whether or not to use this volume when applying zoom_to_volumes()
 	    bool                zoom_to_volumes : 1;
-	    // Wheter or not this volume is enabled for outside print volume detection in shader.
+	    // Whether or not this volume is enabled for outside print volume detection in shader.
 	    bool                shader_outside_printer_detection_enabled : 1;
-	    // Wheter or not this volume is outside print volume.
+	    // Whether or not this volume is outside print volume.
 	    bool                is_outside : 1;
-	    // Wheter or not this volume has been generated from a modifier
+	    // Whether or not this volume has been generated from a modifier
 	    bool                is_modifier : 1;
-	    // Wheter or not this volume has been generated from the wipe tower
+	    // Whether or not this volume has been generated from the wipe tower
 	    bool                is_wipe_tower : 1;
-	    // Wheter or not this volume has been generated from an extrusion path
+	    // Whether or not this volume has been generated from an extrusion path
 	    bool                is_extrusion_path : 1;
         // Whether or not always use the volume's own color (not using SELECTED/HOVER/DISABLED/OUTSIDE)
 	    bool                force_native_color : 1;

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -252,7 +252,7 @@ void BackgroundSlicingProcess::thread_proc()
 }
 
 #ifdef _WIN32
-// Only these SEH exceptions will be catched and turned into Slic3r::HardCrash C++ exceptions.
+// Only these SEH exceptions will be caught and turned into Slic3r::HardCrash C++ exceptions.
 static bool is_win32_seh_harware_exception(unsigned long ex) throw() {
 	return
 		ex == STATUS_ACCESS_VIOLATION ||
@@ -680,7 +680,7 @@ void BackgroundSlicingProcess::finalize_gcode()
 	catch (...)
 	{
 		remove_post_processed_temp_file();
-		throw Slic3r::ExportError(_u8L("Unknown error occured during exporting G-code."));
+		throw Slic3r::ExportError(_u8L("Unknown error occurred during exporting G-code."));
 	}
 	switch (copy_ret_val) {
 	case CopyFileResult::SUCCESS: break; // no error
@@ -700,8 +700,8 @@ void BackgroundSlicingProcess::finalize_gcode()
 		throw Slic3r::ExportError(GUI::format(_L("Copying of the temporary G-code has finished but the exported code couldn't be opened during copy check. The output G-code is at %1%.tmp."), export_path));
 		break;
 	default:
-		throw Slic3r::ExportError(_u8L("Unknown error occured during exporting G-code."));
-		BOOST_LOG_TRIVIAL(error) << "Unexpected fail code(" << (int)copy_ret_val << ") durring copy_file() to " << export_path << ".";
+		throw Slic3r::ExportError(_u8L("Unknown error occurred during exporting G-code."));
+		BOOST_LOG_TRIVIAL(error) << "Unexpected fail code(" << (int)copy_ret_val << ") during copy_file() to " << export_path << ".";
 		break;
 	}
 

--- a/src/slic3r/GUI/BackgroundSlicingProcess.hpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.hpp
@@ -177,7 +177,7 @@ private:
 	void 	thread_proc_safe() throw();
 #ifdef _WIN32
 	// Wrapper for Win32 structured exceptions. Win32 structured exception blocks and C++ exception blocks cannot be mixed in the same function.
-	// Catch a SEH exception and return its ID or zero if no SEH exception has been catched.
+	// Catch a SEH exception and return its ID or zero if no SEH exception has been caught.
 	unsigned long 	thread_proc_safe_seh() throw();
 	// Calls thread_proc_safe_seh(), rethrows a Slic3r::HardCrash exception based on SEH exception
 	// returned by thread_proc_safe_seh() and lets wxApp::OnUnhandledException() display it.
@@ -202,7 +202,7 @@ private:
 
 #ifdef _WIN32
 	// Wrapper for Win32 structured exceptions. Win32 structured exception blocks and C++ exception blocks cannot be mixed in the same function.
-	// Catch a SEH exception and return its ID or zero if no SEH exception has been catched.
+	// Catch a SEH exception and return its ID or zero if no SEH exception has been caught.
 	unsigned long call_process_seh(std::exception_ptr &ex) throw();
 	// Calls call_process_seh(), rethrows a Slic3r::HardCrash exception based on SEH exception
 	// returned by call_process_seh().
@@ -237,7 +237,7 @@ private:
 	State 						m_state = STATE_INITIAL;
 
 	// For executing tasks from the background thread on UI thread synchronously (waiting for result) using wxWidgets CallAfter().
-	// When the background proces is canceled, the UITask has to be invalidated as well, so that it will not be
+	// When the background process is canceled, the UITask has to be invalidated as well, so that it will not be
 	// executed on the UI thread referencing invalid data.
     struct UITask {
         enum State {

--- a/src/slic3r/GUI/BedShapeDialog.hpp
+++ b/src/slic3r/GUI/BedShapeDialog.hpp
@@ -1,7 +1,7 @@
 #ifndef slic3r_BedShapeDialog_hpp_
 #define slic3r_BedShapeDialog_hpp_
 // The bed shape dialog.
-// The dialog opens from Print Settins tab->Bed Shape : Set...
+// The dialog opens from Print Settings tab->Bed Shape : Set...
 
 #include "GUI_Utils.hpp"
 #include "2DBed.hpp"

--- a/src/slic3r/GUI/BitmapCache.hpp
+++ b/src/slic3r/GUI/BitmapCache.hpp
@@ -43,7 +43,7 @@ public:
     wxBitmap* 		load_png(const std::string &bitmap_key, unsigned width = 0, unsigned height = 0, const bool grayscale = false);
 
 	// Parses SVG file from a file, returns SVG image as paths.
-	// And makes replases befor parsing
+	// And makes replases before parsing
 	// replace_map containes old_value->new_value
 	static NSVGimage* nsvgParseFromFileWithReplace(const char* filename, const char* units, float dpi, const std::map<std::string, std::string>& replaces);
 	// Gets a data from SVG file and makes replases

--- a/src/slic3r/GUI/BitmapCache.hpp
+++ b/src/slic3r/GUI/BitmapCache.hpp
@@ -43,11 +43,11 @@ public:
     wxBitmap* 		load_png(const std::string &bitmap_key, unsigned width = 0, unsigned height = 0, const bool grayscale = false);
 
 	// Parses SVG file from a file, returns SVG image as paths.
-	// And makes replases before parsing
-	// replace_map containes old_value->new_value
+	// And makes replaces before parsing
+	// replace_map contains old_value->new_value
 	static NSVGimage* nsvgParseFromFileWithReplace(const char* filename, const char* units, float dpi, const std::map<std::string, std::string>& replaces);
-	// Gets a data from SVG file and makes replases
-	// replace_map containes old_value->new_value
+	// Gets a data from SVG file and makes replaces
+	// replace_map contains old_value->new_value
     static void		nsvgGetDataFromFileWithReplace(const char* filename, std::string& data_str, const std::map<std::string, std::string>& replaces);
 	wxBitmapBundle* from_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, const bool dark_mode, const std::string& new_color = "");
 	wxBitmapBundle* from_png(const std::string& bitmap_name, unsigned width, unsigned height);

--- a/src/slic3r/GUI/CameraUtils.hpp
+++ b/src/slic3r/GUI/CameraUtils.hpp
@@ -10,7 +10,7 @@ class GLVolume;
 namespace Slic3r::GUI {
 /// <summary>
 /// Help divide camera data and camera functions
-/// This utility work with camera data by static funtions
+/// This utility work with camera data by static functions
 /// </summary>
 class CameraUtils
 {

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -138,7 +138,7 @@ BundleMap BundleMap::load()
 
     // Load the other bundles in the datadir/vendor directory
     // and then additionally from datadir/cache/vendor (archive) and resources/profiles.
-    // Should we concider case where archive has older profiles than resources (shouldnt happen)?
+    // Should we consider case where archive has older profiles than resources (shouldn't happen)?
     typedef std::pair<const fs::path&, BundleLocation> DirData;
     std::vector<DirData> dir_list { {vendor_dir, BundleLocation::IN_VENDOR},  {archive_dir, BundleLocation::IN_ARCHIVE},  {rsrc_vendor_dir, BundleLocation::IN_RESOURCES} };
     for ( auto dir : dir_list) {
@@ -1428,7 +1428,7 @@ PageDownloader::PageDownloader(ConfigWizard* parent)
     append_text(format_wxstr(_L(
         "If enabled, %1% registers to start on custom URL on www.printables.com."
         " You will be able to use button with %1% logo to open models in this %1%."
-        " The model will be downloaded into folder you choose bellow."
+        " The model will be downloaded into folder you choose below."
     ), SLIC3R_APP_NAME));
 
 #ifdef __linux__
@@ -2313,7 +2313,7 @@ void ConfigWizard::priv::load_pages()
     index->go_to(former_active);   // Will restore the active item/page if possible
 
     q->Layout();
-// This Refresh() is needed to avoid ugly artifacts after printer selection, when no one vendor was selected from the very beginnig
+// This Refresh() is needed to avoid ugly artifacts after printer selection, when no one vendor was selected from the very beginning
     q->Refresh();
 }
 
@@ -2497,7 +2497,7 @@ void ConfigWizard::priv::update_materials(Technology technology)
         for (const auto &pair : bundles) {
             for (const auto &filament : pair.second.preset_bundle->filaments) {
                 // Check if filament is already added
-                if (filaments.containts(&filament))
+                if (filaments.contains(&filament))
 					continue;
                 // Iterate printers in all bundles
                 for (const auto &printer : pair.second.preset_bundle->printers) {
@@ -2505,7 +2505,7 @@ void ConfigWizard::priv::update_materials(Technology technology)
 						continue;
                     // Filter out inapplicable printers
 					if (is_compatible_with_printer(PresetWithVendorProfile(filament, filament.vendor), PresetWithVendorProfile(printer, printer.vendor))) {
-						if (!filaments.containts(&filament)) {
+						if (!filaments.contains(&filament)) {
 							filaments.push(&filament);
 							if (!filament.alias.empty())
 								aliases_fff[filament.alias].insert(filament.name); 
@@ -2516,7 +2516,7 @@ void ConfigWizard::priv::update_materials(Technology technology)
                 // template filament bundle has no printers - filament would be never added
                 if(pair.second.vendor_profile&& pair.second.vendor_profile->templates_profile && pair.second.preset_bundle->printers.begin() == pair.second.preset_bundle->printers.end())
                 {
-                    if (!filaments.containts(&filament)) {
+                    if (!filaments.contains(&filament)) {
                         filaments.push(&filament);
                         if (!filament.alias.empty())
                             aliases_fff[filament.alias].insert(filament.name);
@@ -2572,7 +2572,7 @@ void ConfigWizard::priv::update_materials(Technology technology)
         for (const auto &pair : bundles) {
             for (const auto &material : pair.second.preset_bundle->sla_materials) {
                 // Check if material is already added
-                if (sla_materials.containts(&material))
+                if (sla_materials.contains(&material))
                 	continue;
                 // Iterate printers in all bundles
 				// For now, we only allow the profiles to be compatible with another profiles inside the same bundle.
@@ -2582,7 +2582,7 @@ void ConfigWizard::priv::update_materials(Technology technology)
                     // Filter out inapplicable printers
                     if (is_compatible_with_printer(PresetWithVendorProfile(material, nullptr), PresetWithVendorProfile(printer, nullptr))) {
                         // Check if material is already added
-                        if(!sla_materials.containts(&material)) {
+                        if(!sla_materials.contains(&material)) {
                             sla_materials.push(&material);
                             if (!material.alias.empty())
                                 aliases_sla[material.alias].insert(material.name);
@@ -2759,7 +2759,7 @@ bool ConfigWizard::priv::on_bnt_finish()
         return false;
     }
     /* When Filaments or Sla Materials pages are activated, 
-     * materials for this pages are automaticaly updated and presets are reloaded.
+     * materials for this pages are automatically updated and presets are reloaded.
      * 
      * But, if _Finish_ button was clicked without activation of those pages 
      * (for example, just some printers were added/deleted), 
@@ -2772,7 +2772,7 @@ bool ConfigWizard::priv::on_bnt_finish()
     if (any_sla_selected)
         page_sla_materials->reload_presets();
 
-	// theres no need to check that filament is selected if we have only custom printer
+	// there's no need to check that filament is selected if we have only custom printer
     if (custom_printer_selected && !any_fff_selected && !any_sla_selected) return true;
     // check, that there is selected at least one filament/material
     return check_and_install_missing_materials(T_ANY);
@@ -3136,7 +3136,7 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
         }
     }
 
-    // if unsaved changes was not cheched till this moment
+    // if unsaved changes was not checked till this moment
     if (!check_unsaved_preset_changes) {
         if ((check_unsaved_preset_changes = !preferred_model.empty())) {
             header = _L("A new Printer was installed and it will be activated.");
@@ -3161,7 +3161,7 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
     get_first_added_material_preset(AppConfig::SECTION_FILAMENTS, first_added_filament);
     get_first_added_material_preset(AppConfig::SECTION_MATERIALS, first_added_sla_material);
 
-    // if unsaved changes was not cheched till this moment
+    // if unsaved changes was not checked till this moment
     if (!check_unsaved_preset_changes) {
         if ((check_unsaved_preset_changes = !first_added_filament.empty() || !first_added_sla_material.empty())) {
             header = !first_added_filament.empty() ? 
@@ -3219,7 +3219,7 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
                                     {preferred_model, preferred_variant, first_added_filament, first_added_sla_material});
 
     if (!only_sla_mode && page_custom->custom_wanted() && page_custom->is_valid_profile_name()) {
-        // if unsaved changes was not cheched till this moment
+        // if unsaved changes was not checked till this moment
         if (!check_unsaved_preset_changes && 
             !wxGetApp().check_and_keep_current_preset_changes(caption, _L("Custom printer was installed and it will be activated."), act_btns, &apply_keeped_changes))
             return false;
@@ -3236,7 +3236,7 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
         preset_bundle->load_config_from_wizard(profile_name, *custom_config);
     }
 
-    // Update the selections from the compatibilty.
+    // Update the selections from the compatibility.
     preset_bundle->export_selections(*app_config);
 
     return true;

--- a/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -587,8 +587,8 @@ struct ConfigWizard::priv
                                   // PrinterPickers state.
     Materials filaments;          // Holds available filament presets and their types & vendors
     Materials sla_materials;      // Ditto for SLA materials
-    PresetAliases aliases_fff;    // Map of aliase to preset names
-    PresetAliases aliases_sla;    // Map of aliase to preset names
+    PresetAliases aliases_fff;    // Map of aliases to preset names
+    PresetAliases aliases_sla;    // Map of aliases to preset names
     std::unique_ptr<DynamicPrintConfig> custom_config;           // Backing for custom printer definition
     bool any_fff_selected;        // Used to decide whether to display Filaments page
     bool any_sla_selected;        // Used to decide whether to display SLA Materials page

--- a/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -326,7 +326,7 @@ struct Materials
     void push(const Preset* preset);
     void add_printer(const Preset* preset);
     void clear();
-    bool containts(const Preset* preset) const {
+    bool contains(const Preset* preset) const {
         //return std::find(presets.begin(), presets.end(), preset) != presets.end(); 
         return std::find_if(presets.begin(), presets.end(),
             [preset](const Preset* element) { return element == preset; }) != presets.end();
@@ -594,7 +594,7 @@ struct ConfigWizard::priv
     bool any_sla_selected;        // Used to decide whether to display SLA Materials page
     bool custom_printer_selected { false }; // New custom printer is requested
     bool custom_printer_in_bundle { false }; // Older custom printer already exists when wizard starts
-    // Set to true if there are none FFF printers on the main FFF page. If true, only SLA printers are shown (not even custum printers)
+    // Set to true if there are none FFF printers on the main FFF page. If true, only SLA printers are shown (not even custom printers)
     bool only_sla_mode { false };
     bool template_profile_selected { false }; // This bool has one purpose - to tell that template profile should be installed if its not (because it cannot be added to appconfig)
 

--- a/src/slic3r/GUI/DesktopIntegrationDialog.cpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
@@ -137,7 +137,7 @@ bool contains_path_dir(const std::string& p, const std::string& dir_name)
         //BOOST_LOG_TRIVIAL(debug) << path.string() << " " << std::oct << boost::filesystem::status(path).permissions();
         return true; //boost::filesystem::status(path).permissions() & boost::filesystem::owner_write;
     } else
-        BOOST_LOG_TRIVIAL(debug) << path.string() << " doesnt exists";
+        BOOST_LOG_TRIVIAL(debug) << path.string() << " doesn't exists";
     return false;
 }
 // Creates directory in path if not exists yet

--- a/src/slic3r/GUI/DesktopIntegrationDialog.cpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
@@ -200,7 +200,7 @@ bool create_desktop_file(const std::string& path, const std::string& data)
 }
 } // namespace integratec_desktop_internal
 
-// methods that actually do / undo desktop integration. Static to be accesible from anywhere.
+// methods that actually do / undo desktop integration. Static to be accessible from anywhere.
 bool DesktopIntegrationDialog::is_integrated()
 {
     const AppConfig *app_config = wxGetApp().app_config;
@@ -253,7 +253,7 @@ void DesktopIntegrationDialog::perform_desktop_integration()
     // $XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored. 
     // If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used. 
     // $XDG_DATA_DIRS defines the preference-ordered set of base directories to search for data files in addition to the $XDG_DATA_HOME base directory.
-    // The directories in $XDG_DATA_DIRS should be seperated with a colon ':'.
+    // The directories in $XDG_DATA_DIRS should be separated with a colon ':'.
     // If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used. 
     std::vector<std::string>target_candidates;
     resolve_path_from_var("XDG_DATA_HOME", target_candidates);
@@ -494,7 +494,7 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
     // $XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored. 
     // If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used. 
     // $XDG_DATA_DIRS defines the preference-ordered set of base directories to search for data files in addition to the $XDG_DATA_HOME base directory.
-    // The directories in $XDG_DATA_DIRS should be seperated with a colon ':'.
+    // The directories in $XDG_DATA_DIRS should be separated with a colon ':'.
     // If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used. 
     std::vector<std::string>target_candidates;
     resolve_path_from_var("XDG_DATA_HOME", target_candidates);

--- a/src/slic3r/GUI/DesktopIntegrationDialog.hpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.hpp
@@ -16,7 +16,7 @@ public:
 	DesktopIntegrationDialog &operator=(const DesktopIntegrationDialog &) = delete;
 	~DesktopIntegrationDialog();
 
-	// methods that actually do / undo desktop integration. Static to be accesible from anywhere.
+	// methods that actually do / undo desktop integration. Static to be accessible from anywhere.
 
 	// returns true if path to PrusaSlicer.desktop is stored in App Config and existence of desktop file. 
 	// Does not check if desktop file leads to this binary or existence of icons and viewer desktop file.
@@ -28,7 +28,7 @@ public:
 	// Rewrites if files already existed.
 	// if perform_downloader:
     // Creates Destktop files for PrusaSlicer downloader feature
-	// Regiters PrusaSlicer to start on prusaslicer:// URL
+	// Registers PrusaSlicer to start on prusaslicer:// URL
 	static void perform_desktop_integration();
 	// Deletes Desktop files and icons for both PrusaSlicer and GcodeViewer at paths stored in App Config.
 	static void undo_desktop_intgration();

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -742,7 +742,7 @@ wxString Control::get_label(int tick, LabelType label_type/* = ltHeightWithLayer
         return "ErrVal";
 
     // When "Print Settings -> Multiple Extruders -> No sparse layer" is enabled, then "Smart" Wipe Tower is used for wiping.
-    // As a result, each layer with tool changes is splited for min 3 parts: first tool, wiping, second tool ...
+    // As a result, each layer with tool changes is split for min 3 parts: first tool, wiping, second tool ...
     // So, vertical slider have to respect to this case.
     // see https://github.com/prusa3d/PrusaSlicer/issues/6232.
     // m_values contains data for all layer's parts,

--- a/src/slic3r/GUI/DoubleSlider.hpp
+++ b/src/slic3r/GUI/DoubleSlider.hpp
@@ -33,7 +33,7 @@ bool equivalent_areas(const double& bottom_area, const double& top_area);
 // return true if color change was detected
 bool check_color_change(const PrintObject* object, size_t frst_layer_id, size_t layers_cnt, bool check_overhangs,
                         // what to do with detected color change
-                        // and return true when detection have to be desturbed
+                        // and return true when detection have to be disturbed
                         std::function<bool(const Layer*)> break_condition);
 
 // custom message the slider sends to its parent to notify a tick-change:

--- a/src/slic3r/GUI/Downloader.cpp
+++ b/src/slic3r/GUI/Downloader.cpp
@@ -129,7 +129,7 @@ void Downloader::start_download(const std::string& full_url)
 {
 	assert(m_initialized);
 	
-	// TODO: There is a misterious slash appearing in recieved msg on windows
+	// TODO: There is a mysterious slash appearing in received msg on windows
 #ifdef _WIN32
 	if (!boost::starts_with(full_url, "prusaslicer://open/?file=")) {
 #else
@@ -140,7 +140,7 @@ void Downloader::start_download(const std::string& full_url)
 		return;
 	}
     size_t id = get_next_id();
-    // TODO: still same mistery 
+    // TODO: still same mystery 
 #ifdef _WIN32
     std::string escaped_url = FileGet::escape_url(full_url.substr(25));
 #else

--- a/src/slic3r/GUI/DownloaderFileGet.cpp
+++ b/src/slic3r/GUI/DownloaderFileGet.cpp
@@ -137,7 +137,7 @@ void FileGet::priv::get_perform()
 		std::string extension = boost::filesystem::extension(dest_path);
 		std::string just_filename = m_filename.substr(0, m_filename.size() - extension.size());
 		std::string final_filename = just_filename;
-        // Find unsed filename 
+        // Find unused filename 
 		try {
 			size_t version = 0;
 			while (boost::filesystem::exists(m_dest_folder / (final_filename + extension)) || boost::filesystem::exists(m_dest_folder / (final_filename + extension + "." + std::to_string(get_current_pid()) + ".download")))

--- a/src/slic3r/GUI/DownloaderFileGet.cpp
+++ b/src/slic3r/GUI/DownloaderFileGet.cpp
@@ -181,7 +181,7 @@ void FileGet::priv::get_perform()
 	BOOST_LOG_TRIVIAL(info) << GUI::format("Starting download from %1% to %2%. Temp path is %3%",m_url, dest_path, m_tmp_path);
 
 	FILE* file;
-	// open file for writting
+	// open file for writing
 	if (m_written == 0)
 		file = fopen(temp_path_wstring.c_str(), "wb");
 	else 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -36,7 +36,7 @@ wxString double_to_string(double const value, const int max_precision /*= 4*/)
 	wxString s = wxNumberFormatter::ToString(value, std::abs(value) < 0.0001 ? 10 : max_precision, wxNumberFormatter::Style_None);
 
 	// The following code comes from wxNumberFormatter::RemoveTrailingZeroes(wxString& s)
-	// with the exception that here one sets the decimal separator explicitely to dot.
+	// with the exception that here one sets the decimal separator explicitly to dot.
     // If number is in scientific format, trailing zeroes belong to the exponent and cannot be removed.
     if (s.find_first_of("eE") == wxString::npos) {
         char dec_sep = is_decimal_separator_point() ? '.' : ',';
@@ -296,7 +296,7 @@ void Field::get_value_by_opt_type(wxString& str, const bool check_value/* = true
     case coFloatsOrPercents:
     case coFloatOrPercent: {
         if (m_opt.type == coFloatOrPercent && m_opt.opt_key == "first_layer_height" && !str.IsEmpty() && str.Last() == '%') {
-            // Workaroud to avoid of using of the % for first layer height
+            // Workaround to avoid of using of the % for first layer height
             // see https://github.com/prusa3d/PrusaSlicer/issues/7418
             wxString label = m_opt.full_label.empty() ? _(m_opt.label) : _(m_opt.full_label);
             show_error(m_parent, format_wxstr(_L("%s doesn't support percentage"), label));
@@ -825,7 +825,7 @@ void SpinCtrl::BUILD() {
     if (m_opt.height < 0 && parent_is_custom_ctrl)
         opt_height = (double)temp->GetSize().GetHeight() / m_em_unit;
 
-// XXX: On OS X the wxSpinCtrl widget is made up of two subwidgets, unfortunatelly
+// XXX: On OS X the wxSpinCtrl widget is made up of two subwidgets, unfortunately
 // the kill focus event is not propagated to the encompassing widget,
 // so we need to bind it on the inner text widget instead. (Ugh.)
 #ifdef __WXOSX__
@@ -1298,7 +1298,7 @@ void Choice::msw_rescale()
 #ifdef __WXOSX__
     const wxString selection = field->GetValue();// field->GetString(index);
 
-	/* To correct scaling (set new controll size) of a wxBitmapCombobox
+	/* To correct scaling (set new control size) of a wxBitmapCombobox
 	 * we need to refill control with new bitmaps. So, in our case :
 	 * 1. clear control
 	 * 2. add content

--- a/src/slic3r/GUI/FileArchiveDialog.cpp
+++ b/src/slic3r/GUI/FileArchiveDialog.cpp
@@ -116,7 +116,7 @@ bool ArchiveViewModel::SetValue(const wxVariant& variant, const wxDataViewItem& 
     ArchiveViewNode* node = static_cast<ArchiveViewNode*>(item.GetID());
     if (col == 0) {
         node->set_toggle(variant.GetBool());
-        // if folder recursivelly check all children
+        // if folder recursively check all children
         for (std::shared_ptr<ArchiveViewNode> child : node->get_children()) {
             SetValue(variant, wxDataViewItem((void*)child.get()), col);
         }

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -712,7 +712,7 @@ void FirmwareDialog::priv::on_avrdude(const wxCommandEvent &evt)
 		// We try to track overall progress here.
 		// Avrdude performs 3 tasks per one memory operation ("-U" arg),
 		// first of which is reading of status data (very short).
-		// We use the timer_pulse during the very first task to indicate intialization
+		// We use the timer_pulse during the very first task to indicate initialization
 		// and then display overall progress during the latter tasks.
 
 		if (progress_tasks_done > 0) {
@@ -734,7 +734,7 @@ void FirmwareDialog::priv::on_avrdude(const wxCommandEvent &evt)
 
 		// Figure out the exit state
 		if (user_cancelled) { complete_kind = AC_USER_CANCELLED; }
-		else if (avrdude->cancelled()) { complete_kind = AC_NONE; } // Ie. cancelled programatically
+		else if (avrdude->cancelled()) { complete_kind = AC_NONE; } // Ie. cancelled programmatically
 		else { complete_kind = evt.GetInt() == 0 ? AC_SUCCESS : AC_FAILURE; }
 
 		flashing_done(complete_kind);

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -230,7 +230,7 @@ void FirmwareDialog::priv::find_serial_ports()
 
 void FirmwareDialog::priv::fit_no_shrink()
 {
-	// Ensure content fits into window and window is not shrinked
+	// Ensure content fits into window and window is not shrunk
 	const auto old_size = q->GetSize();
 	q->Layout();
 	q->Fit();

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -2080,7 +2080,7 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result)
                 const size_t size_elements = i_buffer.size();
                 const size_t size_bytes = size_elements * sizeof(IBufferType);
 
-                // stores index buffer informations into TBuffer
+                // stores index buffer information into TBuffer
                 t_buffer.indices.push_back(IBuffer());
                 IBuffer& ibuf = t_buffer.indices.back();
                 ibuf.count = size_elements;
@@ -3718,7 +3718,7 @@ void GCodeViewer::render_legend(float& legend_height)
         using Times = std::pair<float, float>;
         using TimesList = std::vector<std::pair<CustomGCode::Type, Times>>;
 
-        // helper structure containig the data needed to render the time items
+        // helper structure containing the data needed to render the time items
         struct PartialTime
         {
             enum class EType : unsigned char

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -113,7 +113,7 @@ class GCodeViewer
     // batched models:   3 floats -> position.x|position.y|position.z
     struct InstanceVBuffer
     {
-        // ranges used to render only subparts of the intances
+        // ranges used to render only subparts of the instances
         struct Ranges
         {
             struct Range

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -138,7 +138,7 @@ void GLCanvas3D::LayersEditing::select_object(const Model &model, int object_id)
 {
     const ModelObject *model_object_new = (object_id >= 0) ? model.objects[object_id] : nullptr;
     // Maximum height of an object changes when the object gets rotated or scaled.
-    // Changing maximum height of an object will invalidate the layer heigth editing profile.
+    // Changing maximum height of an object will invalidate the layer height editing profile.
     // m_model_object->bounding_box() is cached, therefore it is cheap even if this method is called frequently.
     const float new_max_z = (model_object_new == nullptr) ? 0.0f : static_cast<float>(model_object_new->max_z());
     if (m_model_object != model_object_new || this->last_object_id != object_id || m_object_max_z != new_max_z ||
@@ -245,7 +245,7 @@ void GLCanvas3D::LayersEditing::render_overlay(const GLCanvas3D& canvas)
     ImGui::AlignTextToFramePadding();
     imgui.text(_L("Keep min"));
     ImGui::SameLine();
-    if (ImGui::GetCursorPosX() < widget_align)  // because of line lenght after localization
+    if (ImGui::GetCursorPosX() < widget_align)  // because of line length after localization
         ImGui::SetCursorPosX(widget_align);
 
     ImGui::PushItemWidth(imgui.get_style_scaling() * 120.0f);
@@ -2873,7 +2873,7 @@ void GLCanvas3D::on_key(wxKeyEvent& evt)
 void GLCanvas3D::on_mouse_wheel(wxMouseEvent& evt)
 {
 #ifdef WIN32
-    // Try to filter out spurious mouse wheel events comming from 3D mouse.
+    // Try to filter out spurious mouse wheel events coming from 3D mouse.
     if (wxGetApp().plater()->get_mouse3d_controller().process_mouse_wheel())
         return;
 #endif
@@ -2953,14 +2953,14 @@ void GLCanvas3D::on_render_timer(wxTimerEvent& evt)
 }
 
 
-void GLCanvas3D::schedule_extra_frame(int miliseconds)
+void GLCanvas3D::schedule_extra_frame(int milliseconds)
 {
     // Schedule idle event right now
-    if (miliseconds == 0)
+    if (milliseconds == 0)
     {
         // We want to wakeup idle evnt but most likely this is call inside render cycle so we need to wait
         if (m_in_render)
-            miliseconds = 33;
+            milliseconds = 33;
         else {
             m_dirty = true;
             wxWakeUpIdle();
@@ -2970,12 +2970,12 @@ void GLCanvas3D::schedule_extra_frame(int miliseconds)
     int remaining_time = m_render_timer.GetInterval();
     // Timer is not running
     if (!m_render_timer.IsRunning()) {
-        m_render_timer.StartOnce(miliseconds);
-    // Timer is running - restart only if new period is shorter than remaning period
+        m_render_timer.StartOnce(milliseconds);
+    // Timer is running - restart only if new period is shorter than remaining period
     } else {
-        if (miliseconds + 20 < remaining_time) {
+        if (milliseconds + 20 < remaining_time) {
             m_render_timer.Stop(); 
-            m_render_timer.StartOnce(miliseconds);
+            m_render_timer.StartOnce(milliseconds);
         }
     }
 }
@@ -3304,7 +3304,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                     const Linef3 ray = mouse_ray(pos);
                     const Vec3d dir = ray.unit_vector();
                     // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
-                    // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebric form
+                    // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
                     // in our case plane normal and ray direction are the same (orthogonal view)
                     // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal
                     const Vec3d inters = ray.a + (m_mouse.drag.start_position_3D - ray.a).dot(dir) / dir.squaredNorm() * dir;
@@ -3478,7 +3478,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     else
         evt.Skip();
 
-    // Detection of doubleclick on text to open emboss edit window
+    // Detection of double-click on text to open emboss edit window
     auto type = m_gizmos.get_current_type();
     if (evt.LeftDClick() && !m_hover_volume_idxs.empty() && 
         (type == GLGizmosManager::EType::Undefined ||

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3303,7 +3303,7 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                     // side view -> move selected volumes orthogonally to camera view direction
                     const Linef3 ray = mouse_ray(pos);
                     const Vec3d dir = ray.unit_vector();
-                    // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
+                    // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing through the starting position
                     // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
                     // in our case plane normal and ray direction are the same (orthogonal view)
                     // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -886,7 +886,7 @@ public:
 
     void request_extra_frame() { m_extra_frame_requested = true; }
     
-    void schedule_extra_frame(int miliseconds);
+    void schedule_extra_frame(int milliseconds);
 
     float get_main_toolbar_height() { return m_main_toolbar.get_height(); }
     int get_main_toolbar_item_id(const std::string& name) const { return m_main_toolbar.get_item_id(name); }

--- a/src/slic3r/GUI/GLShader.cpp
+++ b/src/slic3r/GUI/GLShader.cpp
@@ -84,8 +84,8 @@ bool GLShaderProgram::init_from_texts(const std::string& name, const ShaderSourc
         case EShaderType::Vertex:         { return "vertex"; }
         case EShaderType::Fragment:       { return "fragment"; }
         case EShaderType::Geometry:       { return "geometry"; }
-        case EShaderType::TessEvaluation: { return "tesselation evaluation"; }
-        case EShaderType::TessControl:    { return "tesselation control"; }
+        case EShaderType::TessEvaluation: { return "tessellation evaluation"; }
+        case EShaderType::TessControl:    { return "tessellation control"; }
         case EShaderType::Compute:        { return "compute"; }
         default:                          { return "unknown"; }
         }

--- a/src/slic3r/GUI/GLShadersManager.cpp
+++ b/src/slic3r/GUI/GLShadersManager.cpp
@@ -25,7 +25,7 @@ std::pair<bool, std::string> GLShadersManager::init()
         m_shaders.push_back(std::make_unique<GLShaderProgram>());
         if (!m_shaders.back()->init_from_files(name, filenames, defines)) {
             error += name + "\n";
-            // if any error happens while initializating the shader, we remove it from the list
+            // if any error happens while initializing the shader, we remove it from the list
             m_shaders.pop_back();
             return false;
         }

--- a/src/slic3r/GUI/GLToolbar.cpp
+++ b/src/slic3r/GUI/GLToolbar.cpp
@@ -447,7 +447,7 @@ bool GLToolbar::on_mouse(wxMouseEvent& evt, GLCanvas3D& parent)
     // mouse anywhere
     if (!evt.Dragging() && !evt.Leaving() && !evt.Entering() && m_mouse_capture.parent != nullptr) {
         if (m_mouse_capture.any() && (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())) {
-            // prevents loosing selection into the scene if mouse down was done inside the toolbar and mouse up was down outside it,
+            // prevents losing selection into the scene if mouse down was done inside the toolbar and mouse up was down outside it,
             // as when switching between views
             m_mouse_capture.reset();
             return true;

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -79,9 +79,9 @@ boost::filesystem::path	into_path(const wxString &str);
 
 // Display an About dialog
 extern void about();
-// Ask the destop to open the datadir using the default file explorer.
+// Ask the desktop to open the datadir using the default file explorer.
 extern void desktop_open_datadir_folder();
-// Ask the destop to open the directory specified by path using the default file explorer.
+// Ask the desktop to open the directory specified by path using the default file explorer.
 void desktop_open_folder(const boost::filesystem::path& path);
 
 #ifdef __linux__
@@ -92,7 +92,7 @@ void desktop_execute_get_result(wxString command, wxArrayString& output);
 #endif // __linux__
 
 #ifdef _WIN32
-// Call CreateProcessW to start external proccess on path
+// Call CreateProcessW to start external process on path
 // returns true on success
 // path should contain path to the process
 // cmd_opt can be empty or contain command line options. Example: L"/silent"

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -612,7 +612,7 @@ static GUID GUID_DEVINTERFACE_HID = { 0x4D1E55B2, 0xF16F, 0x11CF, 0x88, 0xCB, 0x
 static void register_win32_device_notification_event()
 {
     wxWindow::MSWRegisterMessageHandler(WM_DEVICECHANGE, [](wxWindow *win, WXUINT /* nMsg */, WXWPARAM wParam, WXLPARAM lParam) {
-        // Some messages are sent to top level windows by default, some messages are sent to only registered windows, and we explictely register on MainFrame only.
+        // Some messages are sent to top level windows by default, some messages are sent to only registered windows, and we explicitly register on MainFrame only.
         auto main_frame = dynamic_cast<MainFrame*>(win);
         auto plater = (main_frame == nullptr) ? nullptr : main_frame->plater();
         if (plater == nullptr)
@@ -649,7 +649,7 @@ static void register_win32_device_notification_event()
     });
 
     wxWindow::MSWRegisterMessageHandler(MainFrame::WM_USER_MEDIACHANGED, [](wxWindow *win, WXUINT /* nMsg */, WXWPARAM wParam, WXLPARAM lParam) {
-        // Some messages are sent to top level windows by default, some messages are sent to only registered windows, and we explictely register on MainFrame only.
+        // Some messages are sent to top level windows by default, some messages are sent to only registered windows, and we explicitly register on MainFrame only.
         auto main_frame = dynamic_cast<MainFrame*>(win);
         auto plater = (main_frame == nullptr) ? nullptr : main_frame->plater();
         if (plater == nullptr)
@@ -767,7 +767,7 @@ void GUI_App::post_init()
             show_substitutions_info(this->init_params->preset_substitutions);
 
 #if 0
-        // Load the cummulative config over the currently active profiles.
+        // Load the cumulative config over the currently active profiles.
         //FIXME if multiple configs are loaded, only the last one will have an effect.
         // We need to decide what to do about loading of separate presets (just print preset, just filament preset etc).
         // As of now only the full configs are supported here.
@@ -842,7 +842,7 @@ void GUI_App::post_init()
     app_config->set("version", SLIC3R_VERSION);
 
 #ifdef _WIN32
-    // Sets window property to mainframe so other instances can indentify it.
+    // Sets window property to mainframe so other instances can identify it.
     OtherInstanceMessageHandler::init_windows_properties(mainframe, m_instance_hash_int);
 #endif //WIN32
 }
@@ -858,7 +858,7 @@ GUI_App::GUI_App(EAppMode mode)
 	, m_other_instance_message_handler(std::make_unique<OtherInstanceMessageHandler>())
     , m_downloader(std::make_unique<Downloader>())
 {
-	//app config initializes early becasuse it is used in instance checking in PrusaSlicer.cpp
+	//app config initializes early because it is used in instance checking in PrusaSlicer.cpp
 	this->init_app_config();
     // init app downloader after path to datadir is set
     m_app_updater = std::make_unique<AppUpdater>();
@@ -1046,7 +1046,7 @@ std::string GUI_App::check_older_app_config(Semver current_version, bool backup)
                 assert(! snapshot_id.empty());
                 app_config->set("on_snapshot", snapshot_id);
             } else
-                BOOST_LOG_TRIVIAL(error) << "Failed to take congiguration snapshot";
+                BOOST_LOG_TRIVIAL(error) << "Failed to take configuration snapshot";
         }
 
         // load app config from older file
@@ -1373,7 +1373,7 @@ bool GUI_App::on_init_inner()
 
         // An ugly solution to GH #5537 in which GUI_App::init_opengl (normally called from events wxEVT_PAINT
         // and wxEVT_SET_FOCUS before GUI_App::post_init is called) wasn't called before GUI_App::post_init and OpenGL wasn't initialized.
-        // Since issue #9774 Where same problem occured on MacOS Ventura, we decided to have this check on MacOS as well.
+        // Since issue #9774 Where same problem occurred on MacOS Ventura, we decided to have this check on MacOS as well.
 
 #if defined(__linux__) || defined(__APPLE__)
         if (!m_post_initialized && m_opengl_initialized) {
@@ -1922,7 +1922,7 @@ void GUI_App::update_ui_from_settings()
 {
     update_label_colours();
 #ifdef _WIN32
-    // Upadte UI colors before Update UI from settings
+    // Update UI colors before Update UI from settings
     if (m_force_colors_update) {
         m_force_colors_update = false;
         mainframe->force_color_changed();
@@ -2693,7 +2693,7 @@ bool GUI_App::check_and_keep_current_preset_changes(const wxString& caption, con
 
         auto reset_modifications = [this, is_called_from_configwizard]() {
             if (is_called_from_configwizard)
-                return; // no need to discared changes. It will be done fromConfigWizard closing
+                return; // no need to discarded changes. It will be done fromConfigWizard closing
 
             PrinterTechnology printer_technology = preset_bundle->printers.get_edited_preset().printer_technology();
             for (const Tab* const tab : tabs_list) {
@@ -2718,7 +2718,7 @@ bool GUI_App::check_and_keep_current_preset_changes(const wxString& caption, con
 
                 wxString text = dlg.msg_success_saved_modifications(preset_names_and_types.size());
                 if (!is_called_from_configwizard)
-                    text += "\n\n" + _L("For new project all modifications will be reseted");
+                    text += "\n\n" + _L("For new project all modifications will be reset");
 
                 MessageDialog(nullptr, text).ShowModal();
                 reset_modifications();
@@ -2897,7 +2897,7 @@ void GUI_App::MacOpenURL(const wxString& url)
     if (app_config && !app_config->get_bool("downloader_url_registered"))
     {
         notification_manager()->push_notification(NotificationType::URLNotRegistered);
-        BOOST_LOG_TRIVIAL(error) << "Recieved command to open URL, but it is not allowed in app configuration. URL: " << url;
+        BOOST_LOG_TRIVIAL(error) << "Received command to open URL, but it is not allowed in app configuration. URL: " << url;
         return;
     }
     start_download(boost::nowide::narrow(url));
@@ -3267,7 +3267,7 @@ bool GUI_App::check_updates(const bool verbose)
 		updater_result = preset_updater->config_update(app_config->orig_version(), verbose ? PresetUpdater::UpdateParams::SHOW_TEXT_BOX : PresetUpdater::UpdateParams::SHOW_NOTIFICATION);
 		if (updater_result == PresetUpdater::R_INCOMPAT_EXIT) {
 			mainframe->Close();
-            // Applicaiton is closing.
+            // Application is closing.
             return false;
 		}
 		else if (updater_result == PresetUpdater::R_INCOMPAT_CONFIGURED) {
@@ -3281,7 +3281,7 @@ bool GUI_App::check_updates(const bool verbose)
 	catch (const std::exception & ex) {
 		show_error(nullptr, ex.what());
 	}
-    // Applicaiton will continue.
+    // Application will continue.
     return true;
 }
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3289,7 +3289,7 @@ bool GUI_App::open_browser_with_warning_dialog(const wxString& url, wxWindow* pa
 {
     bool launch = true;
 
-    // warning dialog containes a "Remember my choice" checkbox
+    // warning dialog contains a "Remember my choice" checkbox
     std::string option_key = "suppress_hyperlinks";
     if (force_remember_choice || app_config->get(option_key).empty()) {
         if (app_config->get(option_key).empty()) {
@@ -3313,7 +3313,7 @@ bool GUI_App::open_browser_with_warning_dialog(const wxString& url, wxWindow* pa
         if (launch)
             launch = !app_config->get_bool(option_key);
     }
-    // warning dialog doesn't containe a "Remember my choice" checkbox
+    // warning dialog doesn't contain a "Remember my choice" checkbox
     // and will be shown only when "Suppress to open hyperlink in browser" is ON.
     else if (app_config->get_bool(option_key)) {
         MessageDialog dialog(parent, _L("Open hyperlink in default browser?"), _L("PrusaSlicer: Open hyperlink"), wxICON_QUESTION | wxYES_NO);

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -290,7 +290,7 @@ public:
 
     virtual bool OnExceptionInMainLoop() override;
     // Calls wxLaunchDefaultBrowser if user confirms in dialog.
-    // Add "Rememeber my choice" checkbox to question dialog, when it is forced or a "suppress_hyperlinks" option has empty value
+    // Add "Remember my choice" checkbox to question dialog, when it is forced or a "suppress_hyperlinks" option has empty value
     bool            open_browser_with_warning_dialog(const wxString& url, wxWindow* parent = nullptr, bool force_remember_choice = true, int flags = 0);
 #ifdef __APPLE__
     void            OSXStoreOpenFiles(const wxArrayString &files) override;
@@ -387,7 +387,7 @@ private:
     void            on_version_read(wxCommandEvent& evt);
     // if the data from version file are already downloaded, shows dialogs to start download of new version of app
     void            app_updater(bool from_user);
-    // inititate read of version file online in separate thread
+    // initiate read of version file online in separate thread
     void            app_version_check(bool from_user);
 
     bool            m_datadir_redefined { false }; 

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1028,7 +1028,7 @@ void MenuFactory::create_common_object_menu(wxMenu* menu)
     append_menu_items_osx(menu);
 #endif // __WXOSX__
     append_menu_items_instance_manipulation(menu);
-    // Delete menu was moved to be after +/- instace to make it more difficult to be selected by mistake.
+    // Delete menu was moved to be after +/- instance to make it more difficult to be selected by mistake.
     append_menu_item_delete(menu);
     append_menu_item_instance_to_object(menu);
     menu->AppendSeparator();

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -103,7 +103,7 @@ private:
     void        append_menu_item_change_extruder(wxMenu* menu);
     void        append_menu_item_delete(wxMenu* menu);
     void        append_menu_item_scale_selection_to_fit_print_volume(wxMenu* menu);
-    void        append_menu_items_convert_unit(wxMenu* menu, int insert_pos = 1); // Add "Conver/Revert..." menu items (from/to inches/meters) after "Reload From Disk"
+    void        append_menu_items_convert_unit(wxMenu* menu, int insert_pos = 1); // Add "Convert/Revert..." menu items (from/to inches/meters) after "Reload From Disk"
     void        append_menu_item_merge_to_multipart_object(wxMenu *menu);
 //    void        append_menu_item_merge_to_single_object(wxMenu *menu);
     void        append_menu_items_mirror(wxMenu *menu);

--- a/src/slic3r/GUI/GUI_Init.cpp
+++ b/src/slic3r/GUI/GUI_Init.cpp
@@ -64,7 +64,7 @@ int GUI_Run(GUI_InitParams &params)
         wxMessageBox(boost::nowide::widen(ex.what()), _L("PrusaSlicer GUI initialization failed"), wxICON_STOP);
     } catch (const std::exception &ex) {
         boost::nowide::cerr << "PrusaSlicer GUI initialization failed: " << ex.what() << std::endl;
-        wxMessageBox(format_wxstr(_L("Fatal error, exception catched: %1%"), ex.what()), _L("PrusaSlicer GUI initialization failed"), wxICON_STOP);
+        wxMessageBox(format_wxstr(_L("Fatal error, exception caught: %1%"), ex.what()), _L("PrusaSlicer GUI initialization failed"), wxICON_STOP);
     }
 
     // error

--- a/src/slic3r/GUI/GUI_ObjectLayers.hpp
+++ b/src/slic3r/GUI/GUI_ObjectLayers.hpp
@@ -43,7 +43,7 @@ public:
                         const wxString& value = wxEmptyString,
                         EditorType type = etUndef,
                         std::function<void(EditorType)>     set_focus_data_fn   = [](EditorType)      {;},
-                        // callback parameters: new value, from enter, dont't update panel UI (when called from edit field's kill focus handler for the PlusMinusButton)
+                        // callback parameters: new value, from enter, don't update panel UI (when called from edit field's kill focus handler for the PlusMinusButton)
                         std::function<bool(coordf_t, bool, bool)> edit_fn       = [](coordf_t, bool, bool) {return false; }
                         );
     ~LayerRangeEditor() {}

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -3424,7 +3424,7 @@ void ObjectList::add_layer_range_after_current(const t_layer_height_range curren
     auto it_range = ranges.find(current_range);
     assert(it_range != ranges.end());
     if (it_range == ranges.end())
-        // This shoudl not happen.
+        // This should not happen.
         return;
 
     auto it_next_range = it_range;
@@ -3514,7 +3514,7 @@ wxString ObjectList::can_add_new_range_after_current(const t_layer_height_range 
     auto it_range = ranges.find(current_range);
     assert(it_range != ranges.end());
     if (it_range == ranges.end())
-        // This shoudl not happen.
+        // This should not happen.
         return "ObjectList assert";
 
     auto it_next_range = it_range;
@@ -4737,7 +4737,7 @@ void ObjectList::fix_through_netfabb()
         msg += "\n\n";
     }
     if (!failed_models.empty()) {
-        msg += _L_PLURAL("Folowing model repair failed", "Folowing models repair failed", failed_models.size()) + ":\n";
+        msg += _L_PLURAL("Following model repair failed", "Following models repair failed", failed_models.size()) + ":\n";
         for (auto& model : failed_models)
             msg += bullet_suf + from_u8(model.first) + ": " + _(model.second);
     }

--- a/src/slic3r/GUI/GUI_ObjectManipulation.cpp
+++ b/src/slic3r/GUI/GUI_ObjectManipulation.cpp
@@ -67,7 +67,7 @@ void msw_rescale_word_local_combo(choice_ctrl* combo)
 #ifdef __WXOSX__
     const wxString selection = combo->GetString(combo->GetSelection());
 
-    /* To correct scaling (set new controll size) of a wxBitmapCombobox
+    /* To correct scaling (set new control size) of a wxBitmapCombobox
      * we need to refill control with new bitmaps. So, in our case :
      * 1. clear control
      * 2. add content
@@ -179,7 +179,7 @@ ObjectManipulation::ObjectManipulation(wxWindow* parent) :
         height = bmp_btn_height;
 #endif //__WXGTK__
 
-    auto add_label = [this, height](wxStaticText** label, const std::string& name, wxSizer* reciver = nullptr)
+    auto add_label = [this, height](wxStaticText** label, const std::string& name, wxSizer* receiver = nullptr)
     {
         *label = new wxStaticText(m_parent, wxID_ANY, _(name) + ":");
         set_font_and_background_style(*label, wxGetApp().normal_font());
@@ -188,7 +188,7 @@ ObjectManipulation::ObjectManipulation(wxWindow* parent) :
         sizer->SetMinSize(wxSize(-1, height));
         sizer->Add(*label, 0, wxALIGN_CENTER_VERTICAL);
       
-        if (reciver)
+        if (receiver)
             reciver->Add(sizer);
         else
             m_labels_grid_sizer->Add(sizer);
@@ -484,7 +484,7 @@ void ObjectManipulation::Show(const bool show)
     if (show) {
         ECoordinatesType coordinates_type = m_coordinates_type;
 
-        // Show the "World Coordinates" / "Local Coordintes" Combo in Advanced / Expert mode only.
+        // Show the "World Coordinates" / "Local Coordinates" Combo in Advanced / Expert mode only.
         const Selection& selection = wxGetApp().plater()->canvas3D()->get_selection();
         bool show_world_local_combo = wxGetApp().get_mode() != comSimple && (selection.is_single_full_instance() || selection.is_single_volume_or_modifier());
         if (selection.is_single_volume_or_modifier() && m_word_local_combo->GetCount() < 3) {

--- a/src/slic3r/GUI/GUI_ObjectSettings.cpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.cpp
@@ -209,7 +209,7 @@ void ObjectSettings::update_config_values(ModelConfig* config)
 
     auto load_config = [this, config, &main_config]()
     {
-        /* Additional check for overrided options.
+        /* Additional check for overridden options.
          * There is a case, when some options should to be added, 
          * to avoid check loop in the next configuration update
          */

--- a/src/slic3r/GUI/GUI_Preview.cpp
+++ b/src/slic3r/GUI/GUI_Preview.cpp
@@ -590,7 +590,7 @@ void Preview::update_layers_slider(const std::vector<double>& layers_z, bool kee
                 notif_mngr->apply_in_preview();
                 return true;
             }) )
-                // first object with color chnages is found
+                // first object with color changes is found
                 break;
         }
     }

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -165,7 +165,7 @@ bool check_dark_mode() {
 #ifdef _WIN32
 void update_dark_ui(wxWindow* window) 
 {
-    bool is_dark = wxGetApp().app_config->get_bool("dark_color_mode");// ? true : check_dark_mode();// #ysDarkMSW - Allow it when we deside to support the sustem colors for application
+    bool is_dark = wxGetApp().app_config->get_bool("dark_color_mode");// ? true : check_dark_mode();// #ysDarkMSW - Allow it when we decide to support the system colors for application
     window->SetBackgroundColour(is_dark ? wxColour(43,  43,  43)  : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
     window->SetForegroundColour(is_dark ? wxColour(250, 250, 250) : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 }

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -104,7 +104,7 @@ public:
         update_dark_ui(this);
 #endif
 
-        // Linux specific issue : get_dpi_for_window(this) still doesn't responce to the Display's scale in new wxWidgets(3.1.3).
+        // Linux specific issue : get_dpi_for_window(this) still doesn't response to the Display's scale in new wxWidgets(3.1.3).
         // So, calculate the m_em_unit value from the font size, as before
 #if !defined(__WXGTK__)
         m_em_unit = std::max<size_t>(10, 10.0f * m_scale_factor);
@@ -262,7 +262,7 @@ private:
         m_prev_scale_factor = m_scale_factor;
     }
 
-#if 0 //#ifdef _WIN32  // #ysDarkMSW - Allow it when we deside to support the sustem colors for application 
+#if 0 //#ifdef _WIN32  // #ysDarkMSW - Allow it when we decide to support the system colors for application 
     bool HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam) override
     {
         update_dark_ui(this);

--- a/src/slic3r/GUI/GalleryDialog.cpp
+++ b/src/slic3r/GUI/GalleryDialog.cpp
@@ -113,7 +113,7 @@ GalleryDialog::GalleryDialog(wxWindow* parent) :
     size_t btn_pos = 0;
     add_btn(btn_pos++, ID_BTN_ADD_CUSTOM_SHAPE,   _L("Add"),                _L("Add one or more custom shapes"),                                                &GalleryDialog::add_custom_shapes);
     add_btn(btn_pos++, ID_BTN_DEL_CUSTOM_SHAPE,   _L("Delete"),             _L("Delete one or more custom shape. You can't delete system shapes"),              &GalleryDialog::del_custom_shapes,  [this](){ return can_delete();           });
-    //add_btn(btn_pos++, ID_BTN_REPLACE_CUSTOM_PNG, _L("Change thumbnail"),   _L("Replace PNG for custom shape. You can't raplace thimbnail for system shape"),   &GalleryDialog::change_thumbnail, [this](){ return can_change_thumbnail(); });
+    //add_btn(btn_pos++, ID_BTN_REPLACE_CUSTOM_PNG, _L("Change thumbnail"),   _L("Replace PNG for custom shape. You can't replace thimbnail for system shape"),   &GalleryDialog::change_thumbnail, [this](){ return can_change_thumbnail(); });
     buttons->InsertStretchSpacer(btn_pos, 2* BORDER_W);
 
     load_label_icon_list();
@@ -367,7 +367,7 @@ void GalleryDialog::load_label_icon_list()
         model_path.replace_extension("png");
         std::string img_name = model_path.string();
 
-#if 0 // use "1" just in DEBUG mode to the generation of the thumbnails for the sistem shapes
+#if 0 // use "1" just in DEBUG mode to the generation of the thumbnails for the system shapes
         bool can_generate_thumbnail = true;
 #else
         bool can_generate_thumbnail = !item.is_system;

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.hpp
@@ -36,7 +36,7 @@ class GLGizmoBase
 {
 public:
     // Starting value for ids to avoid clashing with ids used by GLVolumes
-    // (254 is choosen to leave some space for forward compatibility)
+    // (254 is chosen to leave some space for forward compatibility)
     static const unsigned int BASE_ID = 255 * 255 * 254;
     static const unsigned int GRABBER_ELEMENTS_MAX_COUNT = 7;
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -370,7 +370,7 @@ void GLGizmoCut3D::put_connectors_on_cut_plane(const Vec3d& cp_normal, double cp
         const Vec3d& instance_offset = mo->instances[m_c->selection_info()->get_active_instance()]->get_offset();
 
         for (auto& connector : connectors) {
-            // convert connetor pos to the world coordinates
+            // convert connector pos to the world coordinates
             Vec3d pos = connector.pos + instance_offset;
             pos[Z] += sla_shift;
             // scalar distance from point to plane along the normal
@@ -1074,7 +1074,7 @@ void GLGizmoCut3D::dragging_grabber_z(const GLGizmoBase::UpdateData &data)
     if (starting_vec.norm() != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
         // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
-        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebric form
+        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal
         const Vec3d inters = data.mouse_ray.a + (starting_drag_position - data.mouse_ray.a).dot(mouse_dir) * mouse_dir;

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -1073,7 +1073,7 @@ void GLGizmoCut3D::dragging_grabber_z(const GLGizmoBase::UpdateData &data)
     Vec3d starting_vec = m_rotation_m * Vec3d::UnitZ();
     if (starting_vec.norm() != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
-        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
+        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing through the starting position
         // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -2949,9 +2949,9 @@ void GLGizmoEmboss::draw_advanced()
     }
     m_imgui->disabled_end();
 
-    // slider for Clock-wise angle in degress
+    // slider for Clock-wise angle in degrees
     // stored angle is optional CCW and in radians
-    // Convert stored value to degress
+    // Convert stored value to degrees
     // minus create clock-wise roation from CCW
     const std::optional<float> &angle_opt = m_style_manager.get_font_prop().angle;
     float angle = angle_opt.has_value() ? *angle_opt: 0.f;

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -260,7 +260,7 @@ void GLGizmoEmboss::create_volume(ModelVolumeType volume_type, const Vec2d& mous
         // Try to cast ray into scene and find object for add volume
         if (!priv::start_create_volume_on_surface_job(emboss_data, volume_type, mouse_pos, gl_volume, m_raycast_manager, m_parent)) {
             // When model is broken. It could appear that hit miss the object.
-            // So add part near by in simmilar manner as right panel do
+            // So add part near by in similar manner as right panel do
             create_volume(volume_type);
         }
     } else {
@@ -301,7 +301,7 @@ void GLGizmoEmboss::create_volume(ModelVolumeType volume_type)
         priv::start_create_object_job(emboss_data, screen_center);
     } else if (!priv::start_create_volume_on_surface_job(emboss_data, volume_type, coor, vol, m_raycast_manager, m_parent)) {
         // in centroid of convex hull is not hit with object
-        // soo create transfomation on border of object
+        // soo create transformation on border of object
         
         // there is no point on surface so no use of surface will be applied
         FontProp &prop = emboss_data.text_configuration.style.prop;
@@ -349,7 +349,7 @@ bool GLGizmoEmboss::on_mouse_for_rotation(const wxMouseEvent &mouse_event)
         // move to range <-M_PI, M_PI>
         priv::to_range_pi_pi(angle);
 
-        // set into activ style
+        // set into active style
         assert(m_style_manager.is_active_font());
         if (m_style_manager.is_active_font()) {
             std::optional<float> angle_opt;
@@ -662,7 +662,7 @@ void GLGizmoEmboss::on_set_state()
             return;
         }
         reset_volume();
-        // Store order and last activ index into app.ini
+        // Store order and last active index into app.ini
         // TODO: what to do when can't store into file?
         m_style_manager.store_styles_to_app_config(false);
         remove_notification_not_valid_font();
@@ -852,7 +852,7 @@ EmbossStyles GLGizmoEmboss::create_default_styles()
         WxFontUtils::create_emboss_style(wx_font_normal, _u8L("NORMAL")), // wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT)
         WxFontUtils::create_emboss_style(*wxSMALL_FONT, _u8L("SMALL")),  // A font using the wxFONTFAMILY_SWISS family and 2 points smaller than wxNORMAL_FONT.
         WxFontUtils::create_emboss_style(*wxITALIC_FONT, _u8L("ITALIC")), // A font using the wxFONTFAMILY_ROMAN family and wxFONTSTYLE_ITALIC style and of the same size of wxNORMAL_FONT.
-        WxFontUtils::create_emboss_style(*wxSWISS_FONT, _u8L("SWISS")),  // A font identic to wxNORMAL_FONT except for the family used which is wxFONTFAMILY_SWISS.
+        WxFontUtils::create_emboss_style(*wxSWISS_FONT, _u8L("SWISS")),  // A font identical to wxNORMAL_FONT except for the family used which is wxFONTFAMILY_SWISS.
         WxFontUtils::create_emboss_style(wxFont(10, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD), _u8L("MODERN")),        
     };
 
@@ -877,7 +877,7 @@ EmbossStyles GLGizmoEmboss::create_default_styles()
     if (!styles.empty())
         return styles;
 
-    // No valid style in defult list
+    // No valid style in default list
     // at least one style must contain loadable font
     wxFont wx_font;
     for (const wxString &face : facenames) {
@@ -920,7 +920,7 @@ void GLGizmoEmboss::set_volume_by_selection()
     // for changed volume notification is NOT valid
     remove_notification_not_valid_font();
 
-    // Do not use focused input value when switch volume(it must swith value)
+    // Do not use focused input value when switch volume(it must switch value)
     if (m_volume != nullptr && 
         m_volume != volume) // when update volume it changed id BUT not pointer
         ImGuiWrapper::left_inputs();
@@ -1049,7 +1049,7 @@ void GLGizmoEmboss::set_volume_by_selection()
 void GLGizmoEmboss::reset_volume()
 {
     if (m_volume == nullptr)
-        return; // already reseted
+        return; // already reset
 
     m_volume = nullptr;
     m_volume_id.id = 0;
@@ -1163,7 +1163,7 @@ bool GLGizmoEmboss::process()
     priv::execute_job(std::move(job));
 #endif // EXECUTE_PROCESS_ON_MAIN_THREAD
 
-    // notification is removed befor object is changed by job
+    // notification is removed before object is changed by job
     remove_notification_not_valid_font();
     return true;
 }
@@ -1202,7 +1202,7 @@ void GLGizmoEmboss::draw_window()
     if (ImGui::Button("add svg")) choose_svg_file();
 #endif //  ALLOW_DEBUG_MODE
 
-    // Setter of indent must be befor disable !!!
+    // Setter of indent must be before disable !!!
     ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, m_gui_cfg->indent);
     ScopeGuard indent_sc([](){ ImGui::PopStyleVar(/*ImGuiStyleVar_IndentSpacing*/); });
 
@@ -1263,7 +1263,7 @@ void GLGizmoEmboss::draw_window()
             ss << fix.matrix();            
             std::string filename = (m_volume->source.input_file.empty())? "unknown.3mf" :
                                    m_volume->source.input_file + ".3mf";
-            ImGui::SetTooltip("Text configuation contain \n"
+            ImGui::SetTooltip("Text configuration contain \n"
                               "Fix Transformation Matrix \n"
                               "%s\n"
                               "loaded from \"%s\" file.",
@@ -1353,8 +1353,8 @@ void GLGizmoEmboss::draw_text_input()
             append_warning(_u8L("Too small, enlarged font height inside text input."));
     }
     
-    // flag for extend font ranges if neccessary
-    // ranges can't be extend during font is activ(pushed)
+    // flag for extend font ranges if necessary
+    // ranges can't be extend during font is active(pushed)
     std::string range_text;
     float  window_height  = ImGui::GetWindowHeight();
     float  minimal_height = get_minimal_window_size().y;
@@ -1819,7 +1819,7 @@ void GLGizmoEmboss::draw_font_list()
         ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyleColorVec4(ImGuiCol_Text));
 
         // Fix clearance of search input,
-        // Sometime happens that search text not disapear after font select
+        // Sometime happens that search text not disappear after font select
         m_face_names.search.clear();
     }
 
@@ -2027,7 +2027,7 @@ void GLGizmoEmboss::draw_model_type()
         if (!sel.IsEmpty()) obj_list->select_item(sel.front());       
 
         // NOTE: on linux, function reorder_volumes_and_get_selection call GLCanvas3D::reload_scene(refresh_immediately = false)
-        // which discard m_volume pointer and set it to nullptr also selection is cleared so gizmo is automaticaly closed
+        // which discard m_volume pointer and set it to nullptr also selection is cleared so gizmo is automatically closed
         auto &mng = m_parent.get_gizmos_manager();
         if (mng.get_current_type() != GLGizmosManager::Emboss)
             mng.open_gizmo(GLGizmosManager::Emboss);
@@ -2212,13 +2212,13 @@ void GLGizmoEmboss::draw_delete_style_button() {
         Plater *plater = wxGetApp().plater();
         bool exist_change = false;
         while (true) {
-            // NOTE: can't use previous loaded activ index -> erase could change index
+            // NOTE: can't use previous loaded active index -> erase could change index
             size_t active_index = m_style_manager.get_style_index();
             next_style_index = (active_index > 0) ? active_index - 1 :
                                                    active_index + 1;
             
             if (next_style_index >= m_style_manager.get_styles().size()) {
-                MessageDialog msg(plater, _L("Can't remove the last exising style."), dialog_title, wxICON_ERROR | wxOK);
+                MessageDialog msg(plater, _L("Can't remove the last existing style."), dialog_title, wxICON_ERROR | wxOK);
                 msg.ShowModal();
                 break;
             }
@@ -2258,7 +2258,7 @@ void GLGizmoEmboss::draw_delete_style_button() {
     }
 }
 
-// FIX IT: it should not change volume position before successfull change
+// FIX IT: it should not change volume position before successful change
 void GLGizmoEmboss::fix_transformation(const FontProp &from,
                                        const FontProp &to)
 {
@@ -2558,7 +2558,7 @@ bool GLGizmoEmboss::rev_input(const std::string  &name,
                               const char         *format,
                               ImGuiInputTextFlags flags)
 {
-    // draw offseted input
+    // draw offsetted input
     auto draw_offseted_input = [&]()->bool{
         float input_offset = m_gui_cfg->input_offset;
         float input_width  = m_gui_cfg->input_width;
@@ -2613,7 +2613,7 @@ bool GLGizmoEmboss::rev_checkbox(const std::string &name,
                                  const bool        *default_value,
                                  const std::string &undo_tooltip)
 {
-    // draw offseted input
+    // draw offsetted input
     auto draw_offseted_input = [&]() -> bool {
         ImGui::SameLine(m_gui_cfg->advanced_input_offset);
         return ImGui::Checkbox(("##" + name).c_str(), &value);
@@ -2875,7 +2875,7 @@ void GLGizmoEmboss::draw_advanced()
         if (!priv::Limits::apply(font_prop.line_gap, priv::limits.line_gap) ||
             !m_volume->text_configuration->style.prop.line_gap.has_value() ||
             m_volume->text_configuration->style.prop.line_gap != font_prop.line_gap) {        
-            // line gap is planed to be stored inside of imgui font atlas
+            // line gap is planned to be stored inside of imgui font atlas
             m_style_manager.clear_imgui_font();
             exist_change = true;
         }
@@ -2952,7 +2952,7 @@ void GLGizmoEmboss::draw_advanced()
     // slider for Clock-wise angle in degrees
     // stored angle is optional CCW and in radians
     // Convert stored value to degrees
-    // minus create clock-wise roation from CCW
+    // minus create clock-wise rotation from CCW
     const std::optional<float> &angle_opt = m_style_manager.get_font_prop().angle;
     float angle = angle_opt.has_value() ? *angle_opt: 0.f;
     float angle_deg = static_cast<float>(-angle * 180 / M_PI);
@@ -3237,14 +3237,14 @@ void GLGizmoEmboss::create_notification_not_valid_font(
     const std::string &face_name = face_name_opt.value_or(face_name_by_wx.value_or(es.path));
     std::string text =
         GUI::format(_L("Can't load exactly same font(\"%1%\"). "
-                       "Aplication selected a similar one(\"%2%\"). "
+                       "Application selected a similar one(\"%2%\"). "
                        "You have to specify font for enable edit text."),
                     face_name_3mf, face_name);
     create_notification_not_valid_font(text);
 }
 
 void GLGizmoEmboss::create_notification_not_valid_font(const std::string &text) {
-    // not neccessary, but for sure that old notification doesnt exist
+    // not necessary, but for sure that old notification doesnt exist
     if (m_is_unknown_font)
         remove_notification_not_valid_font();
     m_is_unknown_font = true;

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -242,7 +242,7 @@ static bool draw_button(const IconManager::VIcons& icons, IconType type, bool di
 /// Apply camera direction for emboss direction
 /// </summary>
 /// <param name="camera">Define view vector</param>
-/// <param name="canvas">Containe Selected Model to modify</param>
+/// <param name="canvas">Contain Selected Model to modify</param>
 /// <returns>True when apply change otherwise false</returns>
 static bool apply_camera_dir(const Camera &camera, GLCanvas3D &canvas);
 
@@ -535,7 +535,7 @@ void GLGizmoEmboss::on_render_input_window(float x, float y, float bottom_limit)
         return;
     }
 
-    // Not known situation when could happend this is only for sure
+    // Not known situation when could happened this is only for sure
     if (!m_is_unknown_font && !m_style_manager.is_active_font())
         create_notification_not_valid_font("No active font in style. Select correct one.");
     else if (!m_is_unknown_font && !m_style_manager.get_wx_font().IsOk())
@@ -868,7 +868,7 @@ EmbossStyles GLGizmoEmboss::create_default_styles()
                 return true;        
         }
 
-        // Check that exsit valid TrueType Font for wx font
+        // Check that exist valid TrueType Font for wx font
         return WxFontUtils::create_font_file(wx_font) == nullptr;
         }),styles.end()
     );
@@ -1572,7 +1572,7 @@ void GLGizmoEmboss::init_face_names(Facenames &face_names)
 
         wxFont wx_font(wxFontInfo().FaceName(name).Encoding(encoding));
         //*
-        // Faster chech if wx_font is loadable but not 100%
+        // Faster check if wx_font is loadable but not 100%
         // names could contain not loadable font
         if (!WxFontUtils::can_load(wx_font)) return false;
 
@@ -3244,7 +3244,7 @@ void GLGizmoEmboss::create_notification_not_valid_font(
 }
 
 void GLGizmoEmboss::create_notification_not_valid_font(const std::string &text) {
-    // not necessary, but for sure that old notification doesnt exist
+    // not necessary, but for sure that old notification doesn't exist
     if (m_is_unknown_font)
         remove_notification_not_valid_font();
     m_is_unknown_font = true;
@@ -3544,7 +3544,7 @@ bool priv::apply_camera_dir(const Camera &camera, GLCanvas3D &canvas) {
 
     Vec3d emboss_dir(0., 0., -1.);
 
-    // check wether cam_dir is already used
+    // check whether cam_dir is already used
     if (is_approx(cam_dir_tr, emboss_dir)) return false;
 
     assert(sel.get_volume_idxs().size() == 1);

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
@@ -69,7 +69,7 @@ protected:
     /// Rotate by text on dragging rotate grabers
     /// </summary>
     /// <param name="mouse_event">Information about mouse</param>
-    /// <returns>Propagete normaly return false.</returns>
+    /// <returns>Propagete normally return false.</returns>
     bool on_mouse(const wxMouseEvent &mouse_event) override;
 
     bool wants_enter_leave_snapshots() const override { return true; }
@@ -125,7 +125,7 @@ private:
         bool use_inch, const std::optional<float>& scale);
 
     /// <summary>
-    /// Reversible input float with option to restor default value
+    /// Reversible input float with option to restore default value
     /// TODO: make more general, static and move to ImGuiWrapper 
     /// </summary>
     /// <returns>True when value changed otherwise FALSE.</returns>
@@ -223,7 +223,7 @@ private:
     // when true window will appear near to text volume when open
     // When false it opens on last position
     bool m_allow_open_near_volume = false;
-    // setted only when wanted to use - not all the time
+    // set only when wanted to use - not all the time
     std::optional<ImVec2> m_set_window_offset;
 
     // Keep information about stored styles and loaded actual style to compare with

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.hpp
@@ -293,7 +293,7 @@ private:
     bool m_keep_up = true;
 
     // current selected volume 
-    // NOTE: Be carefull could be uninitialized (removed from Model)
+    // NOTE: Be careful could be uninitialized (removed from Model)
     ModelVolume *m_volume;
 
     // When work with undo redo stack there could be situation that 

--- a/src/slic3r/GUI/Gizmos/GLGizmoFlatten.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFlatten.cpp
@@ -307,7 +307,7 @@ void GLGizmoFlatten::update_planes()
         // In next iterations, the neighbours are not always taken at the middle (to increase the
         // rounding effect at the corners, where we need it most).
         const unsigned int k = 10; // number of iterations
-        const float aggressivity = 0.2f;  // agressivity
+        const float aggressivity = 0.2f;  // aggressivity
         const unsigned int N = polygon.size();
         std::vector<std::pair<unsigned int, unsigned int>> neighbours;
         if (k != 0) {

--- a/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoHollow.cpp
@@ -708,7 +708,7 @@ RENDER_AGAIN:
 
     // Following is a nasty way to:
     //  - save the initial value of the slider before one starts messing with it
-    //  - keep updating the head radius during sliding so it is continuosly refreshed in 3D scene
+    //  - keep updating the head radius during sliding so it is continuously refreshed in 3D scene
     //  - take correct undo/redo snapshot after the user is done with moving the slider
     if (! m_selection_empty) {
         if (clicked) {

--- a/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
@@ -258,7 +258,7 @@ double GLGizmoMove3D::calc_projection(const UpdateData& data) const
     const double len_starting_vec = starting_vec.norm();
     if (len_starting_vec != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
-        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
+        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing through the starting position
         // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal

--- a/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMove.cpp
@@ -259,7 +259,7 @@ double GLGizmoMove3D::calc_projection(const UpdateData& data) const
     if (len_starting_vec != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
         // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
-        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebric form
+        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal
         const Vec3d inters = data.mouse_ray.a + (m_starting_drag_position - data.mouse_ray.a).dot(mouse_dir) * mouse_dir;

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -81,7 +81,7 @@ bool GLGizmoScale3D::on_mouse(const wxMouseEvent &mouse_event)
             if (m_starting.ctrl_down) {
                 // constrained scale:
                 // uses the performed scale to calculate the new position of the constrained grabber
-                // and from that calculates the offset (in world coordinates) to be applied to fullfill the constraint
+                // and from that calculates the offset (in world coordinates) to be applied to fulfill the constraint
                 update_render_data();
                 const Vec3d constraint_position = m_grabbers_transform * m_grabbers[constraint_id(m_hover_id)].center;
                 // re-apply the scale because the selection always applies the transformations with respect to the initial state 
@@ -408,7 +408,7 @@ double GLGizmoScale3D::calc_ratio(const UpdateData& data) const
 
     if (len_starting_vec != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
-        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
+        // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing through the starting position
         // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -409,7 +409,7 @@ double GLGizmoScale3D::calc_ratio(const UpdateData& data) const
     if (len_starting_vec != 0.0) {
         const Vec3d mouse_dir = data.mouse_ray.unit_vector();
         // finds the intersection of the mouse ray with the plane parallel to the camera viewport and passing throught the starting position
-        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebric form
+        // use ray-plane intersection see i.e. https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection algebraic form
         // in our case plane normal and ray direction are the same (orthogonal view)
         // when moving to perspective camera the negative z unit axis of the camera needs to be transformed in world space and used as plane normal
         const Vec3d inters = data.mouse_ray.a + (m_starting.drag_position - data.mouse_ray.a).dot(mouse_dir) * mouse_dir;

--- a/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSimplify.cpp
@@ -31,7 +31,7 @@ static void call_after_if_active(std::function<void()> fn, GUI_App* app = &wxGet
         const GLCanvas3D *canvas = plater->canvas3D();
         if (canvas == nullptr) return;
         const GLGizmosManager &mng = canvas->get_gizmos_manager();
-        // check if simplify is still activ gizmo
+        // check if simplify is still active gizmo
         if (mng.get_current_type() != GLGizmosManager::Simplify) return;
         fn();
     });
@@ -368,7 +368,7 @@ void GLGizmoSimplify::on_render_input_window(float x, float y, float bottom_limi
     if (m_imgui->button(_L("Apply"))) {
         apply_simplify();
     } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && is_worker_running)
-        ImGui::SetTooltip("%s", _u8L("Can't apply when proccess preview.").c_str());
+        ImGui::SetTooltip("%s", _u8L("Can't apply when process preview.").c_str());
     m_imgui->disabled_end(); // state !settings
 
     // draw progress bar

--- a/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSlaSupports.cpp
@@ -190,7 +190,7 @@ void GLGizmoSlaSupports::render_points(const Selection& selection)
         // First decide about the color of the point.
         if (size_t(m_hover_id) == i && m_editing_mode) // ignore hover state unless editing mode is active
             render_color = { 0.f, 1.f, 1.f, 1.f };
-        else { // neigher hover nor picking
+        else { // neither hover nor picking
             bool supports_new_island = m_lock_unique_islands && support_point.is_new_island;
             if (m_editing_mode) {
                 if (point_selected)
@@ -601,7 +601,7 @@ RENDER_AGAIN:
 
         // Following is a nasty way to:
         //  - save the initial value of the slider before one starts messing with it
-        //  - keep updating the head radius during sliding so it is continuosly refreshed in 3D scene
+        //  - keep updating the head radius during sliding so it is continuously refreshed in 3D scene
         //  - take correct undo/redo snapshot after the user is done with moving the slider
         float initial_value = m_new_point_head_diameter;
         m_imgui->slider_float("##head_diameter", &m_new_point_head_diameter, 0.1f, diameter_upper_cap, "%.1f");

--- a/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosCommon.hpp
@@ -53,7 +53,7 @@ namespace CommonGizmosDataObjects {
     class SupportsClipper;
 }
 
-// Some of the gizmos use the same data that need to be updated ocassionally.
+// Some of the gizmos use the same data that need to be updated occasionally.
 // It is also desirable that the data are not recalculated when the gizmos
 // are just switched, but on the other hand, they should be released when
 // they are not in use by any gizmo anymore.

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -392,7 +392,7 @@ bool GLGizmosManager::gizmos_toolbar_on_mouse(const wxMouseEvent &mouse_event) {
             mc.exist_tooltip = true;
             update_hover_state(gizmo);
             // at this moment is enebled to process mouse move under gizmo
-            // tools bar e.g. Do not interupt dragging. 
+            // tools bar e.g. Do not interrupt dragging. 
             return false;
         }
         else if (mc.exist_tooltip) {
@@ -425,11 +425,11 @@ bool GLGizmosManager::gizmos_toolbar_on_mouse(const wxMouseEvent &mouse_event) {
         // Check if exist release of event started above toolbar?
         if (mouse_event.Dragging()) {
             if (!selected_gizmo && mc.exist_tooltip) {
-                // dragging out of gizmo let tooltip disapear
+                // dragging out of gizmo let tooltip disappear
                 mc.exist_tooltip = false;
                 update_hover_state(Undefined);
             }
-            // draging start on toolbar so no propagation into scene
+            // dragging start on toolbar so no propagation into scene
             return true;
         }
         else if (mc.left && mouse_event.LeftUp()) {
@@ -817,7 +817,7 @@ void GLGizmosManager::do_render_overlay() const
     for (size_t idx : selectable_idxs) {
         GLGizmoBase* gizmo = m_gizmos[idx].get();
         const unsigned int sprite_id = gizmo->get_sprite_id();
-        // higlighted state needs to be decided first so its highlighting in every other state
+        // highlighted state needs to be decided first so its highlighting in every other state
         const int icon_idx = (m_highlight.first == idx ? (m_highlight.second ? 4 : 5) : (m_current == idx) ? 2 : ((m_hover == idx) ? 1 : (gizmo->is_activable() ? 0 : 3)));
 
         const float u_left   = u_offset + icon_idx * du;
@@ -971,7 +971,7 @@ bool GLGizmosManager::activate_gizmo(EType type)
 
     new_gizmo.register_raycasters_for_picking();
 
-    // sucessful activation of gizmo
+    // successful activation of gizmo
     return true;
 }
 

--- a/src/slic3r/GUI/HintNotification.cpp
+++ b/src/slic3r/GUI/HintNotification.cpp
@@ -709,7 +709,7 @@ void NotificationManager::HintNotification::count_lines()
 			}
 			if (size_of_last_line == 0) // if first line is continuation of previous text, do not add to line count.
 				m_lines_count++;
-			size_of_last_line = 0; // should countain value only for first line (with hypertext) 
+			size_of_last_line = 0; // should contain value only for first line (with hypertext) 
 			
 		}
 	}
@@ -939,7 +939,7 @@ void NotificationManager::HintNotification::render_preferences_button(ImGuiWrapp
 }
 void NotificationManager::HintNotification::render_right_arrow_button(ImGuiWrapper& imgui, const float win_size_x, const float win_size_y, const float win_pos_x, const float win_pos_y)
 {
-	// Used for debuging
+	// Used for debugging
 
 	ImVec2 win_size(win_size_x, win_size_y);
 	ImVec2 win_pos(win_pos_x, win_pos_y);

--- a/src/slic3r/GUI/HintNotification.hpp
+++ b/src/slic3r/GUI/HintNotification.hpp
@@ -56,7 +56,7 @@ private:
 	bool    is_used(const std::string& id);
 	void    set_used(const std::string& id);
 	void    clear_used();
-	// Returns position in m_loaded_hints with next hint chosed randomly with weights
+	// Returns position in m_loaded_hints with next hint chose randomly with weights
 	size_t  get_next();
 	size_t						m_hint_id;
 	bool						m_initialized { false };

--- a/src/slic3r/GUI/IconManager.cpp
+++ b/src/slic3r/GUI/IconManager.cpp
@@ -192,13 +192,13 @@ bool clickable(const IconManager::Icon &icon, const IconManager::Icon &icon_hove
     return ImGui::IsItemClicked();
 }
 
-bool button(const IconManager::Icon &activ, const IconManager::Icon &hover, const IconManager::Icon &disable, bool disabled)
+bool button(const IconManager::Icon &active, const IconManager::Icon &hover, const IconManager::Icon &disable, bool disabled)
 {
     if (disabled) {
         draw(disable);
         return false;
     }
-    return clickable(activ, hover);
+    return clickable(active, hover);
 }
 
 } // namespace Slic3r::GUI

--- a/src/slic3r/GUI/IconManager.hpp
+++ b/src/slic3r/GUI/IconManager.hpp
@@ -120,13 +120,13 @@ void draw(const IconManager::Icon &icon,
 bool clickable(const IconManager::Icon &icon, const IconManager::Icon &icon_hover);
 
 /// <summary>
-/// Use icon as button with 3 states activ hover and disabled 
+/// Use icon as button with 3 states active hover and disabled 
 /// </summary>
-/// <param name="activ">Not disabled not hovered image</param>
+/// <param name="active">Not disabled not hovered image</param>
 /// <param name="hover">Hovered image</param>
 /// <param name="disable">Disabled image</param>
 /// <returns>True when click on enabled, otherwise False</returns>
-bool button(const IconManager::Icon &activ, const IconManager::Icon &hover, const IconManager::Icon &disable, bool disabled = false);
+bool button(const IconManager::Icon &active, const IconManager::Icon &hover, const IconManager::Icon &disable, bool disabled = false);
 
 } // namespace Slic3r::GUI
 #endif // slic3r_IconManager_hpp_

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -282,7 +282,7 @@ bool ImGuiWrapper::update_key_data(wxKeyEvent &evt)
         const auto   key   = evt.GetUnicodeKey();
 
         // Release BackSpace, Delete, ... when miss wxEVT_KEY_UP event
-        // Already Fixed at begining of new frame
+        // Already Fixed at beginning of new frame
         // unsigned int key_u = static_cast<unsigned int>(key);
         //if (key_u >= 0 && key_u < IM_ARRAYSIZE(io.KeysDown) && io.KeysDown[key_u]) { 
         //    io.KeysDown[key_u] = false;
@@ -333,7 +333,7 @@ void ImGuiWrapper::new_frame()
             io.KeyMods &= ~key.first;
     }
 
-    // Not sure if it is neccessary
+    // Not sure if it is necessary
     // values from 33 to 126 are reserved for the standard ASCII characters
     for (size_t i = 33; i <= 126; ++i) { 
         wxKeyCode keycode = static_cast<wxKeyCode>(i);
@@ -1641,7 +1641,7 @@ void ImGuiWrapper::init_font(bool compress)
     if (font == nullptr) {
         font = io.Fonts->AddFontDefault();
         if (font == nullptr) {
-            throw Slic3r::RuntimeError("ImGui: Could not load deafult font");
+            throw Slic3r::RuntimeError("ImGui: Could not load default font");
         }
     }
 

--- a/src/slic3r/GUI/ImGuiWrapper.hpp
+++ b/src/slic3r/GUI/ImGuiWrapper.hpp
@@ -148,14 +148,14 @@ public:
 
     /// <summary>
     /// Use ImGui internals to unactivate (lose focus) in input.
-    /// When input is activ it can't change value by application.
+    /// When input is active it can't change value by application.
     /// </summary>
     static void left_inputs();
 
     /// <summary>
     /// Truncate text by ImGui draw function to specific width
     /// NOTE 1: ImGui must be initialized
-    /// NOTE 2: Calculation for actual acive imgui font
+    /// NOTE 2: Calculation for actual active imgui font
     /// </summary>
     /// <param name="text">Text to be truncated</param>
     /// <param name="width">Maximal width before truncate</param>
@@ -173,7 +173,7 @@ public:
     static void escape_double_hash(std::string &text);
 
     /// <summary>
-    /// Suggest loacation of dialog window,
+    /// Suggest location of dialog window,
     /// dependent on actual visible thing on platter
     /// like Gizmo menu size, notifications, ...
     /// To be near of polygon interest and not over it.
@@ -182,7 +182,7 @@ public:
     /// <param name="dialog_size">Define width and height of diaog window</param>
     /// <param name="interest">Area of interest. Result should be close to it</param>
     /// <param name="canvas_size">Available space a.k.a GLCanvas3D::get_current_canvas3D()</param>
-    /// <returns>Suggestion for dialog offest</returns>
+    /// <returns>Suggestion for dialog offset</returns>
     static ImVec2 suggest_location(const ImVec2          &dialog_size,
                                    const Slic3r::Polygon &interest,
                                    const ImVec2          &canvas_size);

--- a/src/slic3r/GUI/ImGuiWrapper.hpp
+++ b/src/slic3r/GUI/ImGuiWrapper.hpp
@@ -205,7 +205,7 @@ public:
     /// <param name="position">Center of cross hair</param>
     /// <param name="radius">Circle radius</param>
     /// <param name="color">Color of symbol</param>
-    /// <param name="num_segments">Precission of circle</param>
+    /// <param name="num_segments">Precision of circle</param>
     /// <param name="thickness">Thickness of Line in symbol</param>
     static void draw_cross_hair(const ImVec2 &position,
                                 float         radius       = 16.f,

--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -190,7 +190,7 @@ namespace instance_check_internal
 	// On OSX message is passed to other instances to create a new lockfile after deletition.
 	static void delete_lockfile()
 	{
-		//BOOST_LOG_TRIVIAL(debug) << "shuting down with lockfile: " << l_created_lockfile;
+		//BOOST_LOG_TRIVIAL(debug) << "shutting down with lockfile: " << l_created_lockfile;
 		if (s_created_lockfile)
 		{
 			std::string path = data_dir() + "/cache/" + GUI::wxGetApp().get_instance_hash_string() + ".lock";
@@ -509,7 +509,7 @@ void OtherInstanceMessageHandler::handle_message(const std::string& message)
 		boost::filesystem::path p = MessageHandlerInternal::get_path(*it);
 		if (! p.string().empty())
 			paths.emplace_back(p);
-// TODO: There is a misterious slash appearing in recieved msg on windows
+// TODO: There is a mysterious slash appearing in received msg on windows
 #ifdef _WIN32
 		else if (it->rfind("prusaslicer://open/?file=", 0) == 0)
 #else
@@ -654,7 +654,7 @@ void OtherInstanceMessageHandler::listen()
 	    return;
 	}
 
-	// Set callbacks. Unregister function should not be nessary.
+	// Set callbacks. Unregister function should not be necessary.
 	vtable.message_function = MessageHandlerDBusInternal::handle_dbus_object_message;
     vtable.unregister_function = NULL;
 
@@ -682,7 +682,7 @@ void OtherInstanceMessageHandler::listen()
 
 			break;
 		//dispatch should do all the work with incoming messages
-		//second parameter is blocking time that funciton waits for new messages
+		//second parameter is blocking time that function waits for new messages
 		//that is handled here with our own event loop above
 		dbus_connection_read_write_dispatch(conn, 0);
      }

--- a/src/slic3r/GUI/InstanceCheck.hpp
+++ b/src/slic3r/GUI/InstanceCheck.hpp
@@ -64,7 +64,7 @@ public:
 
 	//finds paths to models in message(= command line arguments, first should be prusaSlicer executable)
 	//and sends them to plater via LoadFromOtherInstanceEvent
-	//security of messages: from message all existing paths are proccesed to load model 
+	//security of messages: from message all existing paths are processed to load model 
 	//						win32 - anybody who has hwnd can send message.
 	//						mac - anybody who posts notification with name:@"OtherPrusaSlicerTerminating"
 	//						linux - instrospectable on dbus

--- a/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
+++ b/src/slic3r/GUI/Jobs/CreateFontNameImageJob.hpp
@@ -59,7 +59,7 @@ public:
     /// <summary>
     /// Rasterize text into image (result)
     /// </summary>
-    /// <param name="ctl">Check for cancelation</param>
+    /// <param name="ctl">Check for cancellation</param>
     void process(Ctl &ctl) override;
 
     /// <summary>

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -630,7 +630,7 @@ void priv::create_volume(
 
     plater->take_snapshot(_L("Add Emboss text Volume"));
 
-    // NOTE: be carefull add volume also center mesh !!!
+    // NOTE: be careful add volume also center mesh !!!
     // So first add simple shape(convex hull is also calculated)
     ModelVolume *volume = obj->add_volume(make_cube(1., 1., 1.), type);
 

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -57,7 +57,7 @@ template<typename Fnc> static TriangleMesh create_mesh(DataBase &input, Fnc was_
 /// <summary>
 /// Create default mesh for embossed text
 /// </summary>
-/// <returns>Not empty model(index trinagle set - its)</returns>
+/// <returns>Not empty model(index triangle set - its)</returns>
 static TriangleMesh create_default_mesh();
 
 /// <summary>
@@ -91,13 +91,13 @@ static ModelVolume *get_volume(ModelObjectPtrs &objects, const ObjectID &volume_
 /// Create projection for cut surface from mesh
 /// </summary>
 /// <param name="tr">Volume transformation in object</param>
-/// <param name="shape_scale">Convert shape to milimeters</param>
+/// <param name="shape_scale">Convert shape to millimeters</param>
 /// <param name="z_range">Bounding box 3d of model volume for projection ranges</param> 
 /// <returns>Orthogonal cut_projection</returns>
 static OrthoProject create_projection_for_cut(Transform3d tr, double shape_scale, const std::pair<float, float> &z_range);
 
 /// <summary>
-/// Create tranformation for emboss Cutted surface
+/// Create transformation for emboss Cutted surface
 /// </summary>
 /// <param name="is_outside">True .. raise, False .. engrave</param>
 /// <param name="emboss">Depth of embossing</param>
@@ -111,7 +111,7 @@ static OrthoProject3d create_emboss_projection(bool is_outside, float emboss, Tr
 /// </summary>
 /// <param name="input1">(can't be const - cache of font)</param>
 /// <param name="input2">SurfaceVolume data</param>
-/// <param name="was_canceled">Check to interupt execution</param>
+/// <param name="was_canceled">Check to interrupt execution</param>
 /// <returns>Extruded object from cuted surace</returns>
 static TriangleMesh cut_surface(/*const*/ DataBase &input1, const SurfaceVolumeData &input2, std::function<bool()> was_canceled);
 
@@ -299,7 +299,7 @@ CreateSurfaceVolumeJob::CreateSurfaceVolumeJob(CreateSurfaceVolumeData &&input)
 void CreateSurfaceVolumeJob::process(Ctl &ctl) {
     if (!priv::check(m_input)) 
         throw std::runtime_error("Bad input data for CreateSurfaceVolumeJob.");
-    // check cancelation of process
+    // check cancellation of process
     auto was_canceled = [&ctl]() -> bool { return ctl.was_canceled(); };
     m_result = priv::cut_surface(m_input, m_input, was_canceled);
 }
@@ -324,7 +324,7 @@ void UpdateSurfaceVolumeJob::process(Ctl &ctl)
     if (!priv::check(m_input)) 
         throw std::runtime_error("Bad input data for UseSurfaceJob.");
     
-    // check cancelation of process
+    // check cancellation of process
     auto was_canceled = [&ctl, &cancel = m_input.cancel]()->bool {
         if (cancel->load()) return true;
         return ctl.was_canceled();
@@ -338,7 +338,7 @@ void UpdateSurfaceVolumeJob::finalize(bool canceled, std::exception_ptr &eptr)
         return;
 
     // when start using surface it is wanted to move text origin on surface of model
-    // also when repeteadly move above surface result position should match
+    // also when repeatedly move above surface result position should match
     Transform3d *tr = &m_input.text_tr;
     priv::update_volume(std::move(m_result), m_input, tr);
 }
@@ -449,7 +449,7 @@ TriangleMesh priv::try_create_mesh(DataBase &input, Fnc was_canceled)
 template<typename Fnc>
 TriangleMesh priv::create_mesh(DataBase &input, Fnc was_canceled, Job::Ctl& ctl)
 {
-    // It is neccessary to create some shape
+    // It is necessary to create some shape
     // Emboss text window is opened by creation new emboss text object
     TriangleMesh result;
     if (input.font_file.has_value()) {
@@ -620,7 +620,7 @@ void priv::create_volume(
         }   
     }
 
-    // Parent object for text volume was propably removed.
+    // Parent object for text volume was probably removed.
     // Assumption: User know what he does, so text volume is no more needed.
     if (obj == nullptr) 
         return priv::create_message("Bad object to create volume.");
@@ -634,7 +634,7 @@ void priv::create_volume(
     // So first add simple shape(convex hull is also calculated)
     ModelVolume *volume = obj->add_volume(make_cube(1., 1., 1.), type);
 
-    // TODO: Refactor to create better way to not set cube at begining
+    // TODO: Refactor to create better way to not set cube at beginning
     // Revert mesh centering by set mesh after add cube
     volume->set_mesh(std::move(mesh));
     volume->calculate_convex_hull();
@@ -718,7 +718,7 @@ OrthoProject priv::create_projection_for_cut(
 OrthoProject3d priv::create_emboss_projection(
     bool is_outside, float emboss, Transform3d tr, SurfaceCut &cut)
 {
-    // Offset of clossed side to model
+    // Offset of closed side to model
     const float surface_offset = 0.015f; // [in mm]
     float 
         front_move = (is_outside) ? emboss : surface_offset,

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -112,7 +112,7 @@ static OrthoProject3d create_emboss_projection(bool is_outside, float emboss, Tr
 /// <param name="input1">(can't be const - cache of font)</param>
 /// <param name="input2">SurfaceVolume data</param>
 /// <param name="was_canceled">Check to interrupt execution</param>
-/// <returns>Extruded object from cuted surace</returns>
+/// <returns>Extruded object from cut surface</returns>
 static TriangleMesh cut_surface(/*const*/ DataBase &input1, const SurfaceVolumeData &input2, std::function<bool()> was_canceled);
 
 static void create_message(const std::string &message); // only in finalize

--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -97,12 +97,12 @@ static ModelVolume *get_volume(ModelObjectPtrs &objects, const ObjectID &volume_
 static OrthoProject create_projection_for_cut(Transform3d tr, double shape_scale, const std::pair<float, float> &z_range);
 
 /// <summary>
-/// Create transformation for emboss Cutted surface
+/// Create transformation for emboss Cut surface
 /// </summary>
 /// <param name="is_outside">True .. raise, False .. engrave</param>
 /// <param name="emboss">Depth of embossing</param>
 /// <param name="tr">Text voliume transformation inside object</param>
-/// <param name="cut">Cutted surface from model</param>
+/// <param name="cut">Cut surface from model</param>
 /// <returns>Projection</returns>
 static OrthoProject3d create_emboss_projection(bool is_outside, float emboss, Transform3d tr, SurfaceCut &cut);
 

--- a/src/slic3r/GUI/Jobs/EmbossJob.hpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.hpp
@@ -34,7 +34,7 @@ struct DataBase
 };
 
 /// <summary>
-/// Hold neccessary data to create ModelVolume in job
+/// Hold necessary data to create ModelVolume in job
 /// Volume is created on the surface of existing volume in object.
 /// NOTE: EmbossDataBase::font_file doesn't have to be valid !!!
 /// </summary>
@@ -67,7 +67,7 @@ public:
 };
 
 /// <summary>
-/// Hold neccessary data to create ModelObject in job
+/// Hold necessary data to create ModelObject in job
 /// Object is placed on bed under screen coor
 /// OR to center of scene when it is out of bed shape
 /// </summary>
@@ -99,7 +99,7 @@ public:
 };
 
 /// <summary>
-/// Hold neccessary data to update embossed text object in job
+/// Hold necessary data to update embossed text object in job
 /// </summary>
 struct DataUpdate : public DataBase
 {
@@ -109,7 +109,7 @@ struct DataUpdate : public DataBase
 
 /// <summary>
 /// Update text shape in existing text volume
-/// Predict that there is only one runnig(not canceled) instance of it
+/// Predict that there is only one running(not canceled) instance of it
 /// </summary>
 class UpdateJob : public Job
 {
@@ -170,7 +170,7 @@ struct SurfaceVolumeData
 };
 
 /// <summary>
-/// Hold neccessary data to create(cut) volume from surface object in job
+/// Hold necessary data to create(cut) volume from surface object in job
 /// </summary>
 struct CreateSurfaceVolumeData : public DataBase, public SurfaceVolumeData{    
     // define embossed volume type
@@ -196,7 +196,7 @@ public:
 };
 
 /// <summary>
-/// Hold neccessary data to update embossed text object in job
+/// Hold necessary data to update embossed text object in job
 /// </summary>
 struct UpdateSurfaceVolumeData : public DataUpdate, public SurfaceVolumeData{};
 

--- a/src/slic3r/GUI/Jobs/EmbossJob.hpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.hpp
@@ -130,7 +130,7 @@ public:
     /// Update volume - change object_id
     /// </summary>
     /// <param name="canceled">Was process canceled.
-    /// NOTE: Be carefull it doesn't care about
+    /// NOTE: Be careful it doesn't care about
     /// time between finished process and started finalize part.</param>
     /// <param name="">unused</param>
     void finalize(bool canceled, std::exception_ptr &eptr) override;

--- a/src/slic3r/GUI/Jobs/EmbossJob.hpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.hpp
@@ -181,7 +181,7 @@ struct CreateSurfaceVolumeData : public DataBase, public SurfaceVolumeData{
 };
 
 /// <summary>
-/// Cut surface from object and create cutted volume
+/// Cut surface from object and create cut volume
 /// Should not be stopped
 /// </summary>
 class CreateSurfaceVolumeJob : public Job

--- a/src/slic3r/GUI/Jobs/Job.hpp
+++ b/src/slic3r/GUI/Jobs/Job.hpp
@@ -44,7 +44,7 @@ public:
 
     // Launched when the job is finished on the UI thread.
     // If the job was cancelled, the first parameter will have a true value.
-    // Exceptions occuring in process() are redirected from the worker thread
+    // Exceptions occurring in process() are redirected from the worker thread
     // into the main (UI) thread. This method receives the exception and can
     // handle it properly. Assign nullptr to this second argument before
     // function return to prevent further action. Leaving it with a non-null

--- a/src/slic3r/GUI/Jobs/PlaterWorker.hpp
+++ b/src/slic3r/GUI/Jobs/PlaterWorker.hpp
@@ -82,7 +82,7 @@ class PlaterWorker: public Worker {
             if (eptr) try {
                 std::rethrow_exception(eptr);
             }  catch (std::exception &e) {
-                show_error(m_plater, _L("An unexpected error occured: ") + e.what());
+                show_error(m_plater, _L("An unexpected error occurred: ") + e.what());
                 eptr = nullptr;
             }
         }

--- a/src/slic3r/GUI/Jobs/SLAImportDialog.hpp
+++ b/src/slic3r/GUI/Jobs/SLAImportDialog.hpp
@@ -165,7 +165,7 @@ public:
 
     std::string get_archive_format() const override
     {
-        // TODO: the choosen format is inside the file dialog which is not
+        // TODO: the chosen format is inside the file dialog which is not
         // accessible from the file picker object. The file picker could be
         // changed to a custom file dialog.
         return {};

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -367,7 +367,7 @@ static void add_tabs_as_menu(wxMenuBar* bar, MainFrame* main_frame, wxWindow* ba
         if (!menu || menu->GetMenuItemCount() > 0) {
             // If we are here it means that we open regular menu and not a tab used as a menu
             event.Skip(); // event.Skip() is very important to next processing of the wxEVT_UPDATE_UI by this menu items.
-                          // If wxEVT_MENU_OPEN will not be pocessed in next event queue then MenuItems of this menu will never caught wxEVT_UPDATE_UI 
+                          // If wxEVT_MENU_OPEN will not be processed in next event queue then MenuItems of this menu will never caught wxEVT_UPDATE_UI 
                           // and, as a result, "check/radio value" will not be updated
             return;
         }
@@ -1973,7 +1973,7 @@ void MainFrame::load_configbundle(wxString file/* = wxEmptyString, const bool re
     Slic3r::GUI::show_info(this, message, wxString("Info"));
 }
 
-// Load a provied DynamicConfig into the Print / Filament / Printer tabs, thus modifying the active preset.
+// Load a provided DynamicConfig into the Print / Filament / Printer tabs, thus modifying the active preset.
 // Also update the plater with the new presets.
 void MainFrame::load_config(const DynamicPrintConfig& config)
 {

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -366,7 +366,7 @@ static void add_tabs_as_menu(wxMenuBar* bar, MainFrame* main_frame, wxWindow* ba
         wxMenu* const menu = event.GetMenu();
         if (!menu || menu->GetMenuItemCount() > 0) {
             // If we are here it means that we open regular menu and not a tab used as a menu
-            event.Skip(); // event.Skip() is verry important to next processing of the wxEVT_UPDATE_UI by this menu items.
+            event.Skip(); // event.Skip() is very important to next processing of the wxEVT_UPDATE_UI by this menu items.
                           // If wxEVT_MENU_OPEN will not be pocessed in next event queue then MenuItems of this menu will never caught wxEVT_UPDATE_UI 
                           // and, as a result, "check/radio value" will not be updated
             return;
@@ -1847,9 +1847,9 @@ void MainFrame::repair_stl()
 
 void MainFrame::export_config()
 {
-    // Generate a cummulative configuration for the selected print, filaments and printer.
+    // Generate a cumulative configuration for the selected print, filaments and printer.
     auto config = wxGetApp().preset_bundle->full_config();
-    // Validate the cummulative configuration.
+    // Validate the cumulative configuration.
     auto valid = config.validate();
     if (! valid.empty()) {
         show_error(this, valid);

--- a/src/slic3r/GUI/MeshUtils.hpp
+++ b/src/slic3r/GUI/MeshUtils.hpp
@@ -168,7 +168,7 @@ public:
         : MeshRaycaster(std::make_unique<TriangleMesh>(mesh))
     {}
 
-    // DEPRICATED - use CameraUtils::ray_from_screen_pos
+    // DEPRECATED - use CameraUtils::ray_from_screen_pos
     static void line_from_mouse_pos(const Vec2d& mouse_pos, const Transform3d& trafo, const Camera& camera,
         Vec3d& point, Vec3d& direction);
 

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -356,7 +356,7 @@ bool Mouse3DController::State::apply(const Mouse3DController::Params &params, Ca
 // Load the device parameter database from appconfig. To be called on application startup.
 void Mouse3DController::load_config(const AppConfig &appconfig)
 {
-	// We do not synchronize m_params_by_device with the background thread explicitely 
+	// We do not synchronize m_params_by_device with the background thread explicitly 
 	// as there should be a full memory barrier executed once the background thread is started.
 	m_params_by_device.clear();
 
@@ -388,7 +388,7 @@ void Mouse3DController::load_config(const AppConfig &appconfig)
 // Store the device parameter database back to appconfig. To be called on application closeup.
 void Mouse3DController::save_config(AppConfig &appconfig) const
 {
-	// We do not synchronize m_params_by_device with the background thread explicitely 
+	// We do not synchronize m_params_by_device with the background thread explicitly 
 	// as there should be a full memory barrier executed once the background thread is stopped.
 
     for (const auto &key_value_pair : m_params_by_device) {
@@ -820,7 +820,7 @@ bool Mouse3DController::connect_device()
     // When using 3Dconnexion universal receiver, multiple devices are detected sharing the same vendor_id and product_id.
     // To choose from them the right one we use:
     // On Windows and Mac: usage_page == 1 and usage == 8
-    // On Linux: as usage_page and usage are not defined (see hidapi.h) we try all detected devices until one is succesfully open
+    // On Linux: as usage_page and usage are not defined (see hidapi.h) we try all detected devices until one is successfully open
     // When only a single device is detected, as for wired connections, vendor_id and product_id are enough
 
     // First we count all the valid devices from the enumerated list,
@@ -831,7 +831,7 @@ bool Mouse3DController::connect_device()
     typedef std::map<DeviceIds, DeviceDataList> DetectedDevices;
     DetectedDevices detected_devices;
 #if ENABLE_3DCONNEXION_DEVICES_DEBUG_OUTPUT
-    std::cout << std::endl << "Detected 3D connexion devices:" << std::endl;
+    std::cout << std::endl << "Detected 3D connection devices:" << std::endl;
 #endif // ENABLE_3DCONNEXION_DEVICES_DEBUG_OUTPUT
     while (current != nullptr) {
         unsigned short vendor_id = 0;

--- a/src/slic3r/GUI/Mouse3DController.hpp
+++ b/src/slic3r/GUI/Mouse3DController.hpp
@@ -137,7 +137,7 @@ class Mouse3DController
     bool 	            m_params_ui_changed { false };
     mutable std::mutex	m_params_ui_mutex;
 
-    // This is a database of parametes of all 3DConnexion devices ever connected.
+    // This is a database of parameters of all 3DConnexion devices ever connected.
     // This database is loaded from AppConfig on application start and it is stored to AppConfig on application exit.
     // We need to do that as the AppConfig is not thread safe and we need read the parameters on device connect / disconnect,
     // which is now done by a background thread.

--- a/src/slic3r/GUI/Mouse3DHandlerMac.mm
+++ b/src/slic3r/GUI/Mouse3DHandlerMac.mm
@@ -200,8 +200,8 @@ void Mouse3DController::init()
 
     if (! error) {
       // Registration is done either by 4letter constant (CFBundleSignature - obsolete
-      //and we dont have that) or Executable name in pascal string(first byte is string lenght).
-      //If no packets are recieved the name might be different - check cmake. If debugging try commenting
+      //and we dont have that) or Executable name in pascal string(first byte is string length).
+      //If no packets are received the name might be different - check cmake. If debugging try commenting
       // set_target_properties(PrusaSlicer PROPERTIES OUTPUT_NAME "prusa-slicer")
       clientID = RegisterConnexionClient(
           0, "\013PrusaSlicer", kConnexionClientModeTakeOver, kConnexionMaskAxis);

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -178,7 +178,7 @@ static void add_msg_content(wxWindow* parent, wxBoxSizer* content_sizer, wxStrin
 #endif // __WXGTK__
     }
 
-    // if message containes the table
+    // if message contains the table
     if (msg.Contains("<tr>")) {
         int lines = msg.Freq('\n') + 1;
         int pos = 0;

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -78,7 +78,7 @@ wxButton* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, c
     wxButton* btn = new wxButton(this, btn_id, label);
     if (set_focus) {
         btn->SetFocus();
-        // For non-MSW platforms SetFocus is not enought to use it as default, when the dialog is closed by ENTER
+        // For non-MSW platforms SetFocus is not enough to use it as default, when the dialog is closed by ENTER
         // We have to set this button as the (permanently) default one in its dialog
         // See https://twitter.com/ZMelmed/status/1472678454168539146
         btn->SetDefault();
@@ -169,7 +169,7 @@ static void add_msg_content(wxWindow* parent, wxBoxSizer* content_sizer, wxStrin
         // And as a result the em_unit value wasn't created yet
         // So, calculate it from the scale factor of Dialog
 #if defined(__WXGTK__)
-        // Linux specific issue : get_dpi_for_window(this) still doesn't responce to the Display's scale in new wxWidgets(3.1.3).
+        // Linux specific issue : get_dpi_for_window(this) still doesn't response to the Display's scale in new wxWidgets(3.1.3).
         // So, initialize default width_unit according to the width of the one symbol ("m") of the currently active font of this window.
         em = std::max<size_t>(10, parent->GetTextExtent("m").x - 1);
 #else

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -92,7 +92,7 @@ public:
 wxString get_wraped_wxString(const wxString& text_in, size_t line_len = 80);
 
 #ifdef _WIN32
-// Generic static line, used intead of wxStaticLine
+// Generic static line, used instead of wxStaticLine
 class StaticLine: public wxTextCtrl
 {
 public:
@@ -109,7 +109,7 @@ public:
 	~StaticLine() {}
 };
 
-// Generic message dialog, used intead of wxMessageDialog
+// Generic message dialog, used instead of wxMessageDialog
 class MessageDialog : public MsgDialog
 {
 public:
@@ -125,7 +125,7 @@ public:
 	virtual ~MessageDialog() = default;
 };
 
-// Generic rich message dialog, used intead of wxRichMessageDialog
+// Generic rich message dialog, used instead of wxRichMessageDialog
 class RichMessageDialog : public MsgDialog
 {
 	wxCheckBox* m_checkBox{ nullptr };

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -23,7 +23,7 @@
 static constexpr float GAP_WIDTH = 10.0f;
 static constexpr float SPACE_RIGHT_PANEL = 10.0f;
 static constexpr float FADING_OUT_DURATION = 2.0f;
-// Time in Miliseconds after next render when fading out is requested
+// Time in Milliseconds after next render when fading out is requested
 static constexpr int   FADING_OUT_TIMEOUT = 100;
 
 namespace Slic3r {
@@ -198,7 +198,7 @@ void NotificationManager::PopNotification::render(GLCanvas3D& canvas, float init
 	bool bgrnd_color_pop = push_background_color();
 	
 	
-	// name of window indentifies window - has to be unique string
+	// name of window identifies window - has to be unique string
 	if (m_id == 0)
 		m_id = m_id_provider.allocate_id();
 	std::string name = "!!Ntfctn" + std::to_string(m_id);
@@ -407,7 +407,7 @@ void NotificationManager::PopNotification::count_lines()
 			}
 			if (size_of_last_line == 0) // if first line is continuation of previous text, do not add to line count.
 				m_lines_count++;
-			size_of_last_line = 0; // should countain value only for first line (with hypertext) 
+			size_of_last_line = 0; // should contain value only for first line (with hypertext) 
 
 		}
 	}
@@ -1561,7 +1561,7 @@ void NotificationManager::PrintHostUploadNotification::render_cancel_button(ImGu
 	}
 	ImGui::PopStyleColor(5);
 
-	// bellow is version where both close and stop button are rendered next to each other
+	// below is version where both close and stop button are rendered next to each other
 
 	/*
 	ImVec2 win_size(win_size_x, win_size_y);
@@ -1658,7 +1658,7 @@ void NotificationManager::UpdatedItemsInfoNotification::add_type(InfoItemType ty
 	NotificationData data { get_data().type, get_data().level , get_data().duration, text };
 	update(data);
 }
-// Uncomment to have different icon for every type of info, otherwise it will have standart cube with i.
+// Uncomment to have different icon for every type of info, otherwise it will have standard cube with i.
 /*
 void NotificationManager::UpdatedItemsInfoNotification::render_left_sign(ImGuiWrapper& imgui)
 {
@@ -2149,7 +2149,7 @@ void NotificationManager::push_plater_warning_notification(const std::string& te
 
 	auto notification = std::make_unique<NotificationManager::PlaterWarningNotification>(data, m_id_provider, m_evt_handler);
 	push_notification_data(std::move(notification), 0);
-	// dissaper if in preview
+	// disappear if in preview
 	apply_in_preview();
 }
 
@@ -2844,7 +2844,7 @@ bool NotificationManager::update_notifications(GLCanvas3D& canvas)
 
 	// delayed notifications
 	for (auto it = m_waiting_notifications.begin(); it != m_waiting_notifications.end();) {
-		// substract time
+		// subtract time
 		if ((*it).remaining_time > 0)
 			(*it).remaining_time -= time_since_render;
 		if ((*it).remaining_time <= 0) {

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -811,7 +811,7 @@ void NotificationManager::ExportFinishedNotification::render_eject_button(ImGuiW
 			imgui.text(_u8L("Eject drive") + " " + GUI::shortkey_ctrl_prefix() + "T");
 			ImGui::EndTooltip();
 			ImGui::PopStyleColor();
-			// somehow the tooltip wont show if the render doesnt run twice
+			// somehow the tooltip wont show if the render doesn't run twice
 			if (m_hover_once) {
 				wxGetApp().plater()->get_current_canvas3D()->schedule_extra_frame(0);
 				m_hover_once = false;
@@ -902,7 +902,7 @@ void NotificationManager::ProgressBarNotification::render_text(ImGuiWrapper& img
 		assert(m_text1.size() >= m_endlines[0]  || m_text1.size() >= m_endlines[1]);
 		if(m_endlines[0] > m_text1.size() || m_endlines[1] > m_text1.size())
 			return;
-		// two lines text (what doesnt fit, wont show), one line bar
+		// two lines text (what doesn't fit, wont show), one line bar
 		ImGui::SetCursorPosX(m_left_indentation);
 		ImGui::SetCursorPosY(m_line_height / 4);
 		imgui.text(m_text1.substr(0, m_endlines[0]).c_str());
@@ -1410,7 +1410,7 @@ void NotificationManager::PrintHostUploadNotification::complete_with_warning()
 
 void NotificationManager::PrintHostUploadNotification::render_text(ImGuiWrapper& imgui,const float win_size_x, const float win_size_y,const float win_pos_x, const float win_pos_y) 
 {
-	// If not completed, the text rendering is very similar to progressbar notification except it doesnt use m_multiline to decide.
+	// If not completed, the text rendering is very similar to progressbar notification except it doesn't use m_multiline to decide.
 	// If completed, whole text is part of m_text_1 and is rendered by PopNotification function.
 
 	if (m_uj_state != UploadJobState::PB_COMPLETED && m_uj_state != UploadJobState::PB_COMPLETED_WITH_WARNING) {
@@ -1420,7 +1420,7 @@ void NotificationManager::PrintHostUploadNotification::render_text(ImGuiWrapper&
 			assert(m_text1.size() >= m_endlines[0] || m_text1.size() >= m_endlines[1]);
 			if (m_endlines[0] > m_text1.size() || m_endlines[1] > m_text1.size())
 				return;
-			// two lines text (what doesnt fit, wont show), one line bar
+			// two lines text (what doesn't fit, wont show), one line bar
 			ImGui::SetCursorPosX(m_left_indentation);
 			ImGui::SetCursorPosY(m_line_height / 4);
 			imgui.text(m_text1.substr(0, m_endlines[0]).c_str());
@@ -2658,7 +2658,7 @@ void NotificationManager::progress_indicator_set_progress(int pr)
 	for (std::unique_ptr<PopNotification>& notification : m_pop_notifications) {
 		if (notification->get_type() == NotificationType::ProgressIndicator) {
 			dynamic_cast<ProgressIndicatorNotification*>(notification.get())->set_progress(pr);
-			// Ask for rendering - needs to be done on every progress. Calls to here doesnt trigger IDLE event or rendering. 
+			// Ask for rendering - needs to be done on every progress. Calls to here doesn't trigger IDLE event or rendering. 
 			wxGetApp().plater()->get_current_canvas3D()->schedule_extra_frame(100);
 			return;
 		}

--- a/src/slic3r/GUI/NotificationManager.hpp
+++ b/src/slic3r/GUI/NotificationManager.hpp
@@ -61,7 +61,7 @@ enum class NotificationType
 	// Contains a hyperlink to execute installation of the new system profiles.
 	PresetUpdateAvailable,
 //	LoadingFailed,
-	// Errors emmited by Print::validate
+	// Errors emitted by Print::validate
 	// difference from Slicing error is that they disappear not grey out at update_background_process
 	ValidateError,
 	// Notification emitted by Print::validate
@@ -115,7 +115,7 @@ enum class NotificationType
 	SimplifySuggestion,
 	// Change of text will change font to similar one on.
 	UnknownFont,
-	// information about netfabb is finished repairing model (blocking proccess)
+	// information about netfabb is finished repairing model (blocking process)
 	NetfabbFinished,
 	// Short meesage to fill space between start and finish of export
 	ExportOngoing,
@@ -138,7 +138,7 @@ public:
 		HintNotificationLevel,
 		// "Good to know" notification, usually but not always with a quick fade-out.		
 		RegularNotificationLevel,
-		// Regular level notifiaction containing info about objects or print. Has Icon.
+		// Regular level notification containing info about objects or print. Has Icon.
 		PrintInfoNotificationLevel,
 		// PrintInfoNotificationLevel with shorter time
 		PrintInfoShortNotificationLevel,
@@ -175,7 +175,7 @@ public:
 	void push_slicing_warning_notification(const std::string& text, bool gray, ObjectID oid, int warning_step);
 	// marks slicing errors as gray
 	void set_all_slicing_errors_gray(bool g);
-	// marks slicing warings as gray
+	// marks slicing warnings as gray
 	void set_all_slicing_warnings_gray(bool g);
 //	void set_slicing_warning_gray(const std::string& text, bool g);
 	// immediately stops showing slicing errors
@@ -267,16 +267,16 @@ public:
 	void close_notification_of_type(const NotificationType type);
 	// Hides warnings in G-code preview. Should be called from plater only when 3d view/ preview is changed
     void set_in_preview(bool preview);
-	// Calls set_in_preview to apply appearing or disappearing of some notificatons;
+	// Calls set_in_preview to apply appearing or disappearing of some notifications;
 	void apply_in_preview() { set_in_preview(m_in_preview); }
-	// Move to left to avoid colision with variable layer height gizmo.
+	// Move to left to avoid collision with variable layer height gizmo.
 	void set_move_from_overlay(bool move) { m_move_from_overlay = move; }
 	// perform update_state on each notification and ask for more frames if needed, return true for render needed
 	bool update_notifications(GLCanvas3D& canvas);
 	// returns number of all notifications shown
 	size_t get_notification_count() const;
 private:
-	// duration 0 means not disapearing
+	// duration 0 means not disappearing
 	struct NotificationData {
 		NotificationType         type;
 		NotificationLevel        level;
@@ -326,7 +326,7 @@ private:
 		PopNotification(const NotificationData &n, NotificationIDProvider &id_provider, wxEvtHandler* evt_handler);
 		virtual ~PopNotification() { if (m_id) m_id_provider.release_id(m_id); }
 		virtual void           render(GLCanvas3D& canvas, float initial_y, bool move_from_overlay, float overlay_width);
-		// close will dissapear notification on next render
+		// close will disappear notification on next render
 		virtual void           close() { m_state = EState::ClosePending; wxGetApp().plater()->get_current_canvas3D()->schedule_extra_frame(0);}
 		// data from newer notification of same type
 		void                   update(const NotificationData& n);
@@ -394,7 +394,7 @@ private:
 
 		int64_t		 	 m_fading_start{ 0LL };
 
-		// first appereance of notification or last hover;
+		// first appearance of notification or last hover;
 		int64_t		 	 m_notification_start;
 		// time to next must-do render
 		int64_t          m_next_render{ std::numeric_limits<int64_t>::max() };
@@ -406,7 +406,7 @@ private:
 		std::string      m_text1;
 		// Clickable text
 		std::string      m_hypertext;
-		// Aditional text after hypertext - currently not used
+		// Additional text after hypertext - currently not used
 		std::string      m_text2;
 
 		// inner variables to position notification window, texts and buttons correctly
@@ -426,7 +426,7 @@ private:
         std::vector<size_t> m_endlines;
 		// endlines for text2
 		std::vector<size_t> m_endlines2;
-		// Gray are f.e. eorrors when its uknown if they are still valid
+		// Gray are f.e. eorrors when its unknown if they are still valid
 		bool             m_is_gray              { false };
 		//if multiline = true, notification is showing all lines(>2)
 		bool             m_multiline            { false };
@@ -650,7 +650,7 @@ private:
 	class SlicingProgressNotification : public ProgressBarNotification
 	{
 	public:
-		// Inner state of notification, Each state changes bahaviour of the notification
+		// Inner state of notification, Each state changes behaviour of the notification
 		enum class SlicingProgressState
 		{
 			SP_NO_SLICING, // hidden
@@ -672,9 +672,9 @@ private:
 		// sets cancel button callback
 		void			    set_cancel_callback(std::function<bool()> callback) { m_cancel_callback = callback; }
 		bool                has_cancel_callback() const { return m_cancel_callback != nullptr; }
-		// sets SlicingProgressState, negative percent means canceled, returns true if state was set succesfully.
+		// sets SlicingProgressState, negative percent means canceled, returns true if state was set successfully.
 		bool				set_progress_state(float percent);
-		// sets SlicingProgressState, percent is used only at progress state. Returns true if state was set succesfully.
+		// sets SlicingProgressState, percent is used only at progress state. Returns true if state was set successfully.
 		bool				set_progress_state(SlicingProgressState state,float percent = 0.f);
 		// sets additional string of print info and puts notification into Completed state.
 		void			    set_print_info(const std::string& info);
@@ -921,7 +921,7 @@ private:
     {NotificationType::URLNotRegistered
 		, NotificationLevel::RegularNotificationLevel
 		, 10
-		, _u8L("PrusaSlicer recieved a download request from Printables.com, but it's not allowed. You can allow it")
+		, _u8L("PrusaSlicer received a download request from Printables.com, but it's not allowed. You can allow it")
 		, _u8L("here.")
 		,  [](wxEvtHandler* evnthndlr) {
 			wxGetApp().open_preferences("downloader_url_registered", "Other");
@@ -930,9 +930,9 @@ private:
 
 			//{NotificationType::NewAppAvailable, NotificationLevel::ImportantNotificationLevel, 20,  _u8L("New version is available."),  _u8L("See Releases page."), [](wxEvtHandler* evnthndlr) {
 			//	wxGetApp().open_browser_with_warning_dialog("https://github.com/prusa3d/PrusaSlicer/releases"); return true; }},
-			//{NotificationType::NewAppAvailable, NotificationLevel::ImportantNotificationLevel, 20,  _u8L("New vesion of PrusaSlicer is available.",  _u8L("Download page.") },
+			//{NotificationType::NewAppAvailable, NotificationLevel::ImportantNotificationLevel, 20,  _u8L("New version of PrusaSlicer is available.",  _u8L("Download page.") },
 			//{NotificationType::LoadingFailed, NotificationLevel::RegularNotificationLevel, 20,  _u8L("Loading of model has Failed") },
-			//{NotificationType::DeviceEjected, NotificationLevel::RegularNotificationLevel, 10,  _u8L("Removable device has been safely ejected")} // if we want changeble text (like here name of device), we need to do it as CustomNotification
+			//{NotificationType::DeviceEjected, NotificationLevel::RegularNotificationLevel, 10,  _u8L("Removable device has been safely ejected")} // if we want changeable text (like here name of device), we need to do it as CustomNotification
 	};
 	
 };

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -208,7 +208,7 @@ wxPoint OG_CustomCtrl::get_pos(const Line& line, Field* field_in/* = nullptr*/)
                 if (!option.sidetext.empty() || opt_group->sidetext_width > 0)
                     h_pos += opt_group->sidetext_width * m_em_unit + m_h_gap;
 
-                if (opt.opt_id != option_set.back().opt_id) //! istead of (opt != option_set.back())
+                if (opt.opt_id != option_set.back().opt_id) //! instead of (opt != option_set.back())
                     h_pos += lround(0.6 * m_em_unit);
             }
             break;
@@ -223,7 +223,7 @@ wxPoint OG_CustomCtrl::get_pos(const Line& line, Field* field_in/* = nullptr*/)
 
 void OG_CustomCtrl::OnPaint(wxPaintEvent&)
 {
-    // case, when custom controll is destroyed but doesn't deleted from the evet loop
+    // case, when custom control is destroyed but doesn't deleted from the evet loop
     if(!this->opt_group->custom_ctrl)
         return;
 
@@ -655,7 +655,7 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord v_pos)
         if (!option.sidetext.empty() || ctrl->opt_group->sidetext_width > 0)
             h_pos = draw_text(dc, wxPoint(h_pos, v_pos), _(option.sidetext), nullptr, ctrl->opt_group->sidetext_width * ctrl->m_em_unit);
 
-        if (opt.opt_id != option_set.back().opt_id) //! istead of (opt != option_set.back())
+        if (opt.opt_id != option_set.back().opt_id) //! instead of (opt != option_set.back())
             h_pos += lround(0.6 * ctrl->m_em_unit);
     }
 }

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -485,7 +485,7 @@ wxDataViewItem ObjectDataViewModel::AddSettingsChild(const wxDataViewItem &paren
 
 /* return values:
  * true     => root_node is created and added to the parent_root
- * false    => root node alredy exists
+ * false    => root node already exists
 */
 static bool append_root_node(ObjectDataViewModelNode *parent_node, 
                              ObjectDataViewModelNode **root_node, 

--- a/src/slic3r/GUI/ObjectDataViewModel.hpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.hpp
@@ -199,7 +199,7 @@ public:
     PrintIndicator  IsPrintable() const             { return m_printable; }
     void            UpdateExtruderAndColorIcon(wxString extruder = "");
 
-    // use this function only for childrens
+    // use this function only for children
     void AssignAllVal(ObjectDataViewModelNode& from_node)
     {
         // ! Don't overwrite other values because of equality of this values for all children --

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -423,7 +423,7 @@ void OptionsGroup::activate_line(Line& line)
                 h_sizer->Add(opt.side_widget(this->ctrl_parent())/*!.target<wxWindow>()*/, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 1);    //! requires verification
             }
 
-            if (opt.opt_id != option_set.back().opt_id) //! istead of (opt != option_set.back())
+            if (opt.opt_id != option_set.back().opt_id) //! instead of (opt != option_set.back())
                 h_sizer->AddSpacer(6);
         }
     }
@@ -1077,7 +1077,7 @@ void ogStaticText::SetPathEnd(const std::string& link)
 #else
 
     // Workaround: On Linux wxStaticText doesn't receive wxEVT_ENTER(LEAVE)_WINDOW events,
-    // so implement this behaviour trough wxEVT_MOTION events for this control and it's parent
+    // so implement this behaviour through wxEVT_MOTION events for this control and it's parent
     Bind(wxEVT_MOTION, [link, this](wxMouseEvent& event) {
         SetToolTip(OptionsGroup::get_url(!get_app_config()->get_bool("suppress_hyperlinks") ? link : std::string()));
         FocusText(true);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -832,7 +832,7 @@ Sidebar::Sidebar(Plater *parent)
                 wxRIGHT, margin_5);
 #else
                 wxBOTTOM, 1);
-                (void)margin_5; // supress unused capture warning
+                (void)margin_5; // suppress unused capture warning
 #endif // __WXGTK3__
         } else {
             sizer_filaments->Add(combo_and_btn_sizer, 0, wxEXPAND |
@@ -1305,7 +1305,7 @@ void Sidebar::show_info_sizer()
         std::vector<int> obj_idxs, vol_idxs;
         wxGetApp().obj_list()->get_selection_indexes(obj_idxs, vol_idxs);
         if (vol_idxs.size() != 1)
-            // Case when this fuction is called between update selection in ObjectList and on Canvas
+            // Case when this function is called between update selection in ObjectList and on Canvas
             // Like after try to delete last solid part in object, the object is selected in ObjectLIst when just a part is still selected on Canvas
             // see https://github.com/prusa3d/PrusaSlicer/issues/7408
             return;
@@ -2483,7 +2483,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
     for (size_t i = 0; i < input_files_size; ++i) {
 #ifdef _WIN32
         auto path = input_files[i];
-        // On Windows, we swap slashes to back slashes, see GH #6803 as read_from_file() does not understand slashes on Windows thus it assignes full path to names of loaded objects.
+        // On Windows, we swap slashes to back slashes, see GH #6803 as read_from_file() does not understand slashes on Windows thus it assigns full path to names of loaded objects.
         path.make_preferred();
 #else // _WIN32
         // Don't make a copy on Posix. Slash is a path separator, back slashes are not accepted as a substitute.
@@ -3028,7 +3028,7 @@ void Plater::priv::remove(size_t obj_idx)
 bool Plater::priv::delete_object_from_model(size_t obj_idx)
 {
     // check if object isn't cut
-    // show warning message that "cut consistancy" will not be supported any more
+    // show warning message that "cut consistency" will not be supported any more
     ModelObject* obj = model.objects[obj_idx];
     if (obj->is_cut()) {
         InfoDialog dialog(q, _L("Delete object which is a part of cut object"), 
@@ -3145,7 +3145,7 @@ void Plater::priv::split_object()
         Slic3r::GUI::warning_catcher(q, _L("The selected object couldn't be split because it contains only one solid part."));
     else
     {
-        // If we splited object which is contain some parts/modifiers then all non-solid parts (modifiers) were deleted
+        // If we split object which is contain some parts/modifiers then all non-solid parts (modifiers) were deleted
         if (current_model_object->volumes.size() > 1 && current_model_object->volumes.size() != new_objects.size())
             notification_manager->push_notification(NotificationType::CustomNotification,
                 NotificationManager::NotificationLevel::PrintInfoNotificationLevel,
@@ -5103,7 +5103,7 @@ void Plater::priv::bring_instance_forward() const
     return;
 #endif //__APPLE__
     if (main_frame == nullptr) {
-        BOOST_LOG_TRIVIAL(debug) << "Couldnt bring instance forward - mainframe is null";
+        BOOST_LOG_TRIVIAL(debug) << "Couldn't bring instance forward - mainframe is null";
         return;
     }
     BOOST_LOG_TRIVIAL(debug) << "prusaslicer window going forward";
@@ -5637,7 +5637,7 @@ bool Plater::preview_zip_archive(const boost::filesystem::path& archive_path)
             }
             close_zip_reader(&archive);
             if (non_project_paths.size() + project_paths.size() != selected_paths.size())
-                BOOST_LOG_TRIVIAL(error) << "Decompresing of archive did not retrieve all files. Expected files: " 
+                BOOST_LOG_TRIVIAL(error) << "Decompressing of archive did not retrieve all files. Expected files: " 
                                          << selected_paths.size() 
                                          << " Decopressed files: " 
                                          << non_project_paths.size() + project_paths.size();
@@ -6190,7 +6190,7 @@ void Plater::convert_unit(ConversionType conv_type)
     if (obj_idxs.empty() && volume_idxs.empty())
         return;
 
-    // We will remove object indexes after convertion 
+    // We will remove object indexes after conversion 
     // So, resort object indexes descending to avoid the crash after remove 
     std::sort(obj_idxs.begin(), obj_idxs.end(), std::greater<int>());
 
@@ -6272,7 +6272,7 @@ void Plater::export_gcode(bool prefer_removable)
     // This function is useful for generating file names to be processed by legacy firmwares.
     fs::path default_output_file;
     try {
-        // Update the background processing, so that the placeholder parser will get the correct values for the ouput file template.
+        // Update the background processing, so that the placeholder parser will get the correct values for the output file template.
         // Also if there is something wrong with the current configuration, a pop-up dialog will be shown and the export will not be performed.
         unsigned int state = this->p->update_restart_background_process(false, false);
         if (state & priv::UPDATE_BACKGROUND_PROCESS_INVALID)
@@ -6292,7 +6292,7 @@ void Plater::export_gcode(bool prefer_removable)
     // Get a last save path, either to removable media or to an internal media.
     std::string      		 start_dir 				 = appconfig.get_last_output_dir(default_output_file.parent_path().string(), prefer_removable);
 	if (prefer_removable) {
-		// Returns a path to a removable media if it exists, prefering start_dir. Update the internal removable drives database.
+		// Returns a path to a removable media if it exists, preferring start_dir. Update the internal removable drives database.
 		start_dir = removable_drive_manager.get_removable_drive_path(start_dir);
 		if (start_dir.empty())
 			// Direct user to the last internal media.
@@ -6723,7 +6723,7 @@ void Plater::send_gcode()
     // Obtain default output path
     fs::path default_output_file;
     try {
-        // Update the background processing, so that the placeholder parser will get the correct values for the ouput file template.
+        // Update the background processing, so that the placeholder parser will get the correct values for the output file template.
         // Also if there is something wrong with the current configuration, a pop-up dialog will be shown and the export will not be performed.
         unsigned int state = this->p->update_restart_background_process(false, false);
         if (state & priv::UPDATE_BACKGROUND_PROCESS_INVALID)

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -522,7 +522,7 @@ void PreferencesDialog::build()
 
 		append_enum_option<NotifyReleaseMode>(m_optgroup_gui, "notify_release",
 			L("Notify about new releases"),
-			L("You will be notified about new release after startup acordingly: All = Regular release and alpha / beta releases. Release only = regular release."),
+			L("You will be notified about new release after startup accordingly: All = Regular release and alpha / beta releases. Release only = regular release."),
 			new ConfigOptionEnum<NotifyReleaseMode>(static_cast<NotifyReleaseMode>(s_keys_map_NotifyReleaseMode.at(app_config->get("notify_release")))),
 			{ { "all", L("All") },
 			  { "release", L("Release only") },
@@ -737,7 +737,7 @@ void PreferencesDialog::accept(wxEvent&)
 	    }
 	}
 
-#if 0 //#ifdef _WIN32 // #ysDarkMSW - Allow it when we deside to support the sustem colors for application
+#if 0 //#ifdef _WIN32 // #ysDarkMSW - Allow it when we decide to support the system colors for application
 	if (m_values.find("always_dark_color_mode") != m_values.end())
 		wxGetApp().force_sys_colors_update();
 #endif

--- a/src/slic3r/GUI/PresetHints.hpp
+++ b/src/slic3r/GUI/PresetHints.hpp
@@ -14,7 +14,7 @@ public:
     // Produce a textual description of the cooling logic of a currently active filament.
     static std::string cooling_description(const Preset &preset);
     
-    // Produce a textual description of the maximum flow achived for the current configuration
+    // Produce a textual description of the maximum flow achieved for the current configuration
     // (the current printer, filament and print settings).
     // This description will be useful for getting a gut feeling for the maximum volumetric
     // print speed achievable with the extruder.

--- a/src/slic3r/GUI/PresetHints.hpp
+++ b/src/slic3r/GUI/PresetHints.hpp
@@ -15,7 +15,7 @@ public:
     static std::string cooling_description(const Preset &preset);
     
     // Produce a textual description of the maximum flow achived for the current configuration
-    // (the current printer, filament and print settigns).
+    // (the current printer, filament and print settings).
     // This description will be useful for getting a gut feeling for the maximum volumetric
     // print speed achievable with the extruder.
     static std::string maximum_volumetric_flow_description(const PresetBundle &preset_bundle);

--- a/src/slic3r/GUI/PrintHostDialogs.cpp
+++ b/src/slic3r/GUI/PrintHostDialogs.cpp
@@ -427,7 +427,7 @@ void PrintHostQueueDialog::set_state(int idx, JobState state)
         case ST_CANCELLED:  job_list->SetValue(_L("Cancelled"), idx, COL_STATUS); break;
         case ST_COMPLETED:  job_list->SetValue(_L("Completed"), idx, COL_STATUS); break;
     }
-    // This might be ambigous call, but user data needs to be saved time to time
+    // This might be ambiguous call, but user data needs to be saved time to time
     save_user_data(UDT_SIZE | UDT_POSITION | UDT_COLS);
 }
 

--- a/src/slic3r/GUI/PrintHostDialogs.hpp
+++ b/src/slic3r/GUI/PrintHostDialogs.hpp
@@ -123,7 +123,7 @@ private:
     void on_error(Event&);
     void on_cancel(Event&);
     void on_info(Event&);
-    // This vector keep adress and filename of uploads. It is used when checking for running uploads during exit.
+    // This vector keep address and filename of uploads. It is used when checking for running uploads during exit.
     std::vector<std::pair<std::string, std::string>> upload_names;
     void save_user_data(int);
     bool load_user_data(int, std::vector<int>&);

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -264,7 +264,7 @@ bool get_handle_from_devinst(DEVINST devinst, HANDLE& handle)
 	dev_id_wstr = std::regex_replace(dev_id_wstr, std::wregex(L"$"), L"#", std::regex_constants::format_first_only);
 	
 	// guid
-	wchar_t			guid_wchar[64];//guid is 32 chars+4 hyphens+2 paranthesis+null => 64 should be more than enough
+	wchar_t			guid_wchar[64];//guid is 32 chars+4 hyphens+2 parenthesis+null => 64 should be more than enough
 	StringFromGUID2(GUID_DEVINTERFACE_USB_HUB, guid_wchar, 64);
 	dev_id_wstr.append(guid_wchar);
 
@@ -344,7 +344,7 @@ bool is_card_reader(HDEVINFO h_dev_info, SP_DEVINFO_DATA& spdd)
 	}
 	num_language_IDs			= (supported_languages_string->StringDescriptor->bLength - 2) / 2;
 	language_IDs				= (USHORT*)&supported_languages_string->StringDescriptor->bString[0];
-	// Get configration string.
+	// Get configuration string.
 	if (GetStringDescriptors(handle, usb_port_number, configuration_descriptor->iConfiguration, num_language_IDs, language_IDs, supported_languages_string, configuration_string) == E_FAIL) {
 		BOOST_LOG_TRIVIAL(warning) << "is_card_reader failed: Couldn't get configuration string descriptor.";
 		return false;
@@ -470,7 +470,7 @@ int eject_inner(const std::string& path)
 		return 1;
 	}
 
-	// get the drive type which is required to match the device numbers correctely
+	// get the drive type which is required to match the device numbers correctly
 	UINT drive_type = GetDriveTypeW(root_path.c_str());
 
 	// get the dos device name (like \device\floppy0) to decide if it's a floppy or not
@@ -794,7 +794,7 @@ void RemovableDriveManager::eject_drive()
 	{
 		//std::cout<<"Ejecting "<<(*it).name<<" from "<< correct_path<<"\n";
 		// there is no usable command in c++ so terminal command is used instead
-		// but neither triggers "succesful safe removal messege"
+		// but neither triggers "successful safe removal messege"
 		
 		BOOST_LOG_TRIVIAL(info) << "Ejecting started";
 		boost::process::ipstream istd_err;
@@ -802,7 +802,7 @@ void RemovableDriveManager::eject_drive()
 #if __APPLE__		
 			boost::process::search_path("diskutil"), "eject", correct_path.c_str(), (boost::process::std_out & boost::process::std_err) > istd_err);
 		//Another option how to eject at mac. Currently not working.
-		//used insted of system() command;
+		//used instead of system() command;
 		//this->eject_device(correct_path);
 #else
     		boost::process::search_path("umount"), correct_path.c_str(), (boost::process::std_out & boost::process::std_err) > istd_err);
@@ -817,7 +817,7 @@ void RemovableDriveManager::eject_drive()
 		bool success = false;
 		if (ec) {
             // The wait call can fail, as it did in https://github.com/prusa3d/PrusaSlicer/issues/5507
-            // It can happen even in cases where the eject is sucessful, but better report it as failed.
+            // It can happen even in cases where the eject is successful, but better report it as failed.
             // We did not find a way to reliably retrieve the exit code of the process.
 			BOOST_LOG_TRIVIAL(error) << "boost::process::child::wait() failed during Ejection. State of Ejection is unknown. Error code: " << ec.value();
 		} else {

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -86,7 +86,7 @@ int eject_alt(const std::wstring& volume_access_path)
 		return 1;
 	}
 	DWORD deviceControlRetVal(0);
-	//these 3 commands should eject device safely but they dont, the device does disappear from file explorer but the "device was safely remove" notification doesnt trigger.
+	//these 3 commands should eject device safely but they dont, the device does disappear from file explorer but the "device was safely remove" notification doesn't trigger.
 	//sd cards does  trigger WM_DEVICECHANGE messege, usb drives dont
 	BOOL e1 = DeviceIoControl(handle, FSCTL_LOCK_VOLUME, nullptr, 0, nullptr, 0, &deviceControlRetVal, nullptr);
 	BOOST_LOG_TRIVIAL(debug) << "FSCTL_LOCK_VOLUME " << e1 << " ; " << deviceControlRetVal << " ; " << GetLastError();
@@ -592,7 +592,7 @@ void RemovableDriveManager::eject_drive()
 			return;
 		}
 		DWORD deviceControlRetVal(0);
-		//these 3 commands should eject device safely but they dont, the device does disappear from file explorer but the "device was safely remove" notification doesnt trigger.
+		//these 3 commands should eject device safely but they dont, the device does disappear from file explorer but the "device was safely remove" notification doesn't trigger.
 		//sd cards does  trigger WM_DEVICECHANGE messege, usb drives dont
 		BOOL e1 = DeviceIoControl(handle, FSCTL_LOCK_VOLUME, nullptr, 0, nullptr, 0, &deviceControlRetVal, nullptr);
 		BOOST_LOG_TRIVIAL(error) << "FSCTL_LOCK_VOLUME " << e1 << " ; " << deviceControlRetVal << " ; " << GetLastError();
@@ -711,7 +711,7 @@ namespace search_for_drives_internal
 			for (size_t i = 0; i < globbuf.gl_pathc; ++ i)
 				inspect_file(globbuf.gl_pathv[i], parent_path, out);
 		} else {
-			//if error - path probably doesnt exists so function just exits
+			//if error - path probably doesn't exists so function just exits
 			//std::cout<<"glob error "<< error<< "\n";
 		}
 		globfree(&globbuf);

--- a/src/slic3r/GUI/RemovableDriveManager.hpp
+++ b/src/slic3r/GUI/RemovableDriveManager.hpp
@@ -58,7 +58,7 @@ public:
 	// Deregister OSX notifications.
 	void 		shutdown();
 
-	// Returns path to a removable media if it exists, prefering the input path.
+	// Returns path to a removable media if it exists, preferring the input path.
 	std::string get_removable_drive_path(const std::string &path);
 	bool        is_path_on_removable_drive(const std::string &path) { return this->get_removable_drive_path(path) == path; }
 

--- a/src/slic3r/GUI/RemovableDriveManagerMM.mm
+++ b/src/slic3r/GUI/RemovableDriveManagerMM.mm
@@ -6,7 +6,7 @@
 
 static void eject_callback(DADiskRef disk, DADissenterRef dissenter, void *context)
 {
-    NSLog(@"eject successfull");
+    NSLog(@"eject successful");
 }
 
 static void unmount_callback(DADiskRef disk, DADissenterRef dissenter, void *context)
@@ -42,7 +42,7 @@ static void unmount_callback(DADiskRef disk, DADissenterRef dissenter, void *con
 
 -(NSArray*) list_dev
 {
-    // DEPRICATED:
+    // DEPRECATED:
     //NSArray* devices = [[NSWorkspace sharedWorkspace] mountedRemovableMedia];
 	//return devices;
     

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -447,7 +447,7 @@ void Selection::clear()
     if (m_list.empty())
         return;
 
-    // ensure that the volumes get the proper color before next call to render (expecially needed for transparent volumes)
+    // ensure that the volumes get the proper color before next call to render (especially needed for transparent volumes)
     for (unsigned int i : m_list) {
         GLVolume& volume = *(*m_volumes)[i];
         volume.selected = false;
@@ -1020,7 +1020,7 @@ void Selection::flattening_rotate(const Vec3d& normal)
 
 #if !DISABLE_INSTANCES_SYNCH
     // Apply the same transformation also to other instances,
-    // but respect their possibly diffrent z-rotation.
+    // but respect their possibly different z-rotation.
     if (m_mode == Instance)
         synchronize_unselected_instances(SyncRotationType::GENERAL);
 #endif // !DISABLE_INSTANCES_SYNCH

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -2321,7 +2321,7 @@ void Selection::render_sidebar_layers_hints(const std::string& sidebar_field, GL
 
     const BoundingBoxf3& box = get_bounding_box();
 
-    // view dependend order of rendering to keep correct transparency
+    // view dependent order of rendering to keep correct transparency
     const bool camera_on_top = wxGetApp().plater()->get_camera().is_looking_downward();
     const float z1 = camera_on_top ? min_z : max_z;
     const float z2 = camera_on_top ? max_z : min_z;

--- a/src/slic3r/GUI/SendSystemInfoDialog.cpp
+++ b/src/slic3r/GUI/SendSystemInfoDialog.cpp
@@ -188,7 +188,7 @@ static bool should_dialog_be_shown()
     // We might want to check that the internet connection is ready so we don't open the dialog
     // if it cannot really send any data. Using a dummy HTTP GET request led to
     // https://forum.prusaprinters.org/forum/prusaslicer/prusaslicer-2-4-0-beta1-is-out/#post-518488.
-    // It might also trigger security softwares, which would look bad and would lead to questions
+    // It might also trigger security software, which would look bad and would lead to questions
     // about what PS is doing. We better use some less intrusive way of checking the connection.
 
     // As of now, this is only implemented on Win. The other platforms do not check beforehand.

--- a/src/slic3r/GUI/SurfaceDrag.cpp
+++ b/src/slic3r/GUI/SurfaceDrag.cpp
@@ -269,7 +269,7 @@ std::optional<Vec3d> calc_surface_offset(const Selection &selection, RaycastMana
         if (!close_point_opt.has_value())
             return {};
 
-        // It is no neccesary to move with origin by very small value
+        // It is no necessary to move with origin by very small value
         if (close_point_opt->squared_distance < EPSILON)
             return {};
 
@@ -281,7 +281,7 @@ std::optional<Vec3d> calc_surface_offset(const Selection &selection, RaycastMana
         return offset_volume;
     }
 
-    // It is no neccesary to move with origin by very small value
+    // It is no necessary to move with origin by very small value
     const RaycastManager::Hit &hit = *hit_opt;
     if (hit.squared_distance < EPSILON)
         return {};

--- a/src/slic3r/GUI/SurfaceDrag.hpp
+++ b/src/slic3r/GUI/SurfaceDrag.hpp
@@ -24,7 +24,7 @@ struct SurfaceDrag
     // Start dragging text transformations to world
     Transform3d world;
 
-    // Invers transformation of text volume instance
+    // Inverse transformation of text volume instance
     // Help convert world transformation to instance space
     Transform3d instance_inv;
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -462,7 +462,7 @@ void Tab::OnActivate()
 #ifdef _MSW_DARK_MODE
     // Because of DarkMode we use our own Notebook (inherited from wxSiplebook) instead of wxNotebook
     // And it looks like first Layout of the page doesn't update a size of the m_presets_choice
-    // So we have to set correct size explicitely
+    // So we have to set correct size explicitly
     if (wxSize ok_sz = wxSize(35 * m_em_unit, m_presets_choice->GetBestSize().y);
         ok_sz != m_presets_choice->GetSize()) {
         m_presets_choice->SetMinSize(ok_sz);
@@ -1731,7 +1731,7 @@ void TabPrint::update_description_lines()
                 _L("Post processing scripts shall modify G-code file in place."));
             m_post_process_explanation->SetPathEnd("post-processing-scripts_283913");
         }
-        // upadte G-code substitutions from the current configuration
+        // update G-code substitutions from the current configuration
         {
             m_subst_manager.update_from_config();
             if (m_del_all_substitutions_btn)
@@ -3626,7 +3626,7 @@ void Tab::clear_pages()
     // invalidated highlighter, if any exists
     m_highlighter.invalidate();
     m_page_sizer->Clear(true);
-    // clear pages from the controlls
+    // clear pages from the controls
     for (auto p : m_pages)
         p->clear();
 
@@ -3692,7 +3692,7 @@ bool Tab::tree_sel_change_delayed()
 {
     // There is a bug related to Ubuntu overlay scrollbars, see https://github.com/prusa3d/PrusaSlicer/issues/898 and https://github.com/prusa3d/PrusaSlicer/issues/952.
     // The issue apparently manifests when Show()ing a window with overlay scrollbars while the UI is frozen. For this reason,
-    // we will Thaw the UI prematurely on Linux. This means destroing the no_updates object prematurely.
+    // we will Thaw the UI prematurely on Linux. This means destroying the no_updates object prematurely.
 #ifdef __linux__
     std::unique_ptr<wxWindowUpdateLocker> no_updates(new wxWindowUpdateLocker(this));
 #else
@@ -3880,7 +3880,7 @@ void Tab::save_preset(std::string name /*= ""*/, bool detach)
         wxGetApp().plater()->force_filament_colors_update();
 
     {
-        // Profile compatiblity is updated first when the profile is saved.
+        // Profile compatibility is updated first when the profile is saved.
         // Update profile selection combo boxes at the depending tabs to reflect modifications in profile compatibility.
         std::vector<Preset::Type> dependent;
         switch (m_type) {
@@ -4692,7 +4692,7 @@ void Page::update_visibility(ConfigOptionMode mode, bool update_contolls_visibil
     bool ret_val = false;
     for (auto group : m_optgroups) {
         ret_val = (update_contolls_visibility     ? 
-                   group->update_visibility(mode) :  // update visibility for all controlls in group
+                   group->update_visibility(mode) :  // update visibility for all controls in group
                    group->is_visible(mode)           // just detect visibility for the group
                    ) || ret_val;
     }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -410,7 +410,7 @@ Slic3r::GUI::PageShp Tab::add_options_page(const wxString& title, const std::str
 
 // Names of categories is save in English always. We translate them only for UI.
 // But category "Extruder n" can't be translated regularly (using _()), so
-// just for this category we should splite the title and translate "Extruder" word separately
+// just for this category we should split the title and translate "Extruder" word separately
 wxString Tab::translate_category(const wxString& title, Preset::Type preset_type)
 {
     if (preset_type == Preset::TYPE_PRINTER && title.Contains("Extruder ")) {
@@ -858,7 +858,7 @@ void Tab::update_tab_ui()
     m_presets_choice->update();
 }
 
-// Load a provied DynamicConfig into the tab, modifying the active preset.
+// Load a provided DynamicConfig into the tab, modifying the active preset.
 // This could be used for example by setting a Wipe Tower position by interactive manipulation in the 3D view.
 void Tab::load_config(const DynamicPrintConfig& config)
 {

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -529,7 +529,7 @@ public:
 class TabSLAPrint : public Tab
 {
     // Methods are a vector of method prefix -> method label pairs
-    // method prefix is the prefix whith which all the config values are prefixed
+    // method prefix is the prefix with which all the config values are prefixed
     // for a particular method. The label is the friendly name for the method
     void build_sla_support_params(const std::vector<SamePair<std::string>> &methods,
                                   const Slic3r::GUI::PageShp &page);

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -488,7 +488,7 @@ wxDataViewItem DiffModel::GetParent(const wxDataViewItem& item) const
 
 bool DiffModel::IsContainer(const wxDataViewItem& item) const
 {
-    // the invisble root node can have children
+    // the invisible root node can have children
     if (!item.IsOk())
         return true;
 

--- a/src/slic3r/GUI/UpdateDialogs.cpp
+++ b/src/slic3r/GUI/UpdateDialogs.cpp
@@ -354,7 +354,7 @@ MsgUpdateForced::MsgUpdateForced(const std::vector<Update>& updates) :
 		versions->Add(new wxStaticText(this, wxID_ANY, update.version.to_string()));
 
 		if (!update.comment.empty()) {
-			versions->Add(new wxStaticText(this, wxID_ANY, _(L("Comment:")))/*, 0, wxALIGN_RIGHT*/);//uncoment if align to right (might not look good if 1  vedor name is longer than other names)
+			versions->Add(new wxStaticText(this, wxID_ANY, _(L("Comment:")))/*, 0, wxALIGN_RIGHT*/);//uncomment if align to right (might not look good if 1  vedor name is longer than other names)
 			auto* update_comment = new wxStaticText(this, wxID_ANY, from_u8(update.comment));
 			update_comment->Wrap(CONTENT_WIDTH * wxGetApp().em_unit());
 			versions->Add(update_comment);

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -26,7 +26,7 @@ RammingDialog::RammingDialog(wxWindow* parent,const std::string& parameters)
     m_panel_ramming  = new RammingPanel(this,parameters);
 
     // Not found another way of getting the background colours of RammingDialog, RammingPanel and Chart correct than setting
-    // them all explicitely. Reading the parent colour yielded colour that didn't really match it, no wxSYS_COLOUR_... matched
+    // them all explicitly. Reading the parent colour yielded colour that didn't really match it, no wxSYS_COLOUR_... matched
     // colour used for the dialog. Same issue (and "solution") here : https://forums.wxwidgets.org/viewtopic.php?f=1&t=39608
     // Whoever can fix this, feel free to do so.
 #ifndef _WIN32

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -195,8 +195,8 @@ wxString wxCheckListBoxComboPopup::GetStringValue() const
 
 wxSize wxCheckListBoxComboPopup::GetAdjustedSize(int minWidth, int prefHeight, int maxHeight)
 {
-    // set width dinamically in dependence of items text
-    // and set height dinamically in dependence of items count
+    // set width dynamically in dependence of items text
+    // and set height dynamically in dependence of items count
 
     wxComboCtrl* cmb = GetComboCtrl();
     if (cmb != nullptr) {
@@ -316,7 +316,7 @@ bool wxDataViewTreeCtrlComboPopup::Create(wxWindow* parent)
 wxSize wxDataViewTreeCtrlComboPopup::GetAdjustedSize(int minWidth, int prefHeight, int maxHeight)
 {
 	// matches owner wxComboCtrl's width
-	// and sets height dinamically in dependence of contained items count
+	// and sets height dynamically in dependence of contained items count
 	wxComboCtrl* cmb = GetComboCtrl();
 	if (cmb != nullptr)
 	{

--- a/src/slic3r/Utils/AppUpdater.cpp
+++ b/src/slic3r/Utils/AppUpdater.cpp
@@ -39,8 +39,8 @@ namespace {
 		std::string msg;
 		bool res = GUI::create_process(path, std::wstring(), msg);
 		if (!res) {
-			std::string full_message = GUI::format(_u8L("Running downloaded instaler of %1% has failed:\n%2%"), SLIC3R_APP_NAME, msg);
-			BOOST_LOG_TRIVIAL(error) << full_message; // lm: maybe UI error msg?  // dk: bellow. (maybe some general show error evt would be better?)
+			std::string full_message = GUI::format(_u8L("Running downloaded installer of %1% has failed:\n%2%"), SLIC3R_APP_NAME, msg);
+			BOOST_LOG_TRIVIAL(error) << full_message; // lm: maybe UI error msg?  // dk: below. (maybe some general show error evt would be better?)
 			wxCommandEvent* evt = new wxCommandEvent(EVT_SLIC3R_APP_DOWNLOAD_FAILED);
 			evt->SetString(full_message);
 			GUI::wxGetApp().QueueEvent(evt);
@@ -461,7 +461,7 @@ void AppUpdater::priv::parse_version_string(const std::string& body)
 	GUI::wxGetApp().QueueEvent(evt);
 }
 
-#if 0 //lm:is this meant to be ressurected? //dk: it is code that parses PrusaSlicer.version2 in 2.4.0, It was deleted from PresetUpdater.cpp and I would keep it here for possible reference.
+#if 0 //lm:is this meant to be resurrected? //dk: it is code that parses PrusaSlicer.version2 in 2.4.0, It was deleted from PresetUpdater.cpp and I would keep it here for possible reference.
 void AppUpdater::priv::parse_version_string_old(const std::string& body) const
 {
 

--- a/src/slic3r/Utils/AppUpdater.hpp
+++ b/src/slic3r/Utils/AppUpdater.hpp
@@ -11,7 +11,7 @@
 namespace Slic3r {
 
 #ifdef __APPLE__
-// implmented at MacUtils.mm
+// implemented at MacUtils.mm
 std::string get_downloads_path_mac();
 #endif //__APPLE__
 

--- a/src/slic3r/Utils/Bonjour.cpp
+++ b/src/slic3r/Utils/Bonjour.cpp
@@ -884,7 +884,7 @@ void Bonjour::priv::lookup_perform()
 			interfaces.emplace_back(std::move(addr));
 		}
 		// create ipv4 socket for each interface
-		// each will send to querry to for both ipv4 and ipv6
+		// each will send to query to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces) 		
 			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP4, intrfc, io_service));
 	} else {
@@ -904,7 +904,7 @@ void Bonjour::priv::lookup_perform()
 			interfaces.emplace_back(std::move(addr));
 		}
 		// create ipv6 socket for each interface
-		// each will send to querry to for both ipv4 and ipv6
+		// each will send to query to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces)
 			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP6, intrfc, io_service));
 		if (interfaces.empty())
@@ -978,7 +978,7 @@ void Bonjour::priv::resolve_perform()
 			interfaces.emplace_back(addr);
 		}
 		// create ipv4 socket for each interface
-		// each will send to querry to for both ipv4 and ipv6
+		// each will send to query to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces)
 			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP4, intrfc, io_service));
 	} else {
@@ -997,7 +997,7 @@ void Bonjour::priv::resolve_perform()
 			interfaces.emplace_back(addr);
 		}
 		// create ipv6 socket for each interface
-		// each will send to querry to for both ipv4 and ipv6
+		// each will send to query to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces) 
 			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP6, intrfc, io_service));
 		if (interfaces.empty())

--- a/src/slic3r/Utils/Bonjour.hpp
+++ b/src/slic3r/Utils/Bonjour.hpp
@@ -81,7 +81,7 @@ public:
 	// lookup all devices by given TxtKeys
 	// each correct reply is passed back in ReplyFn, finishes with CompleteFn
 	Ptr lookup();
-	// performs resolving of hostname into vector of ip adresses passed back by ResolveFn
+	// performs resolving of hostname into vector of ip addresses passed back by ResolveFn
 	// needs set_hostname and on_resolve to be called before.
 	Ptr resolve();
 	// resolve on the current thread
@@ -265,7 +265,7 @@ protected:
 	{
 		requests.clear();
 		// BonjourRequest::make_A / AAAA is now implemented to add .local correctly after the hostname.
-			// If that is unsufficient, we need to change make_A / AAAA and pass full hostname.
+			// If that is insufficient, we need to change make_A / AAAA and pass full hostname.
 		std::string trimmed_hostname = hostname;
 		if (size_t dot_pos = trimmed_hostname.find_first_of('.'); dot_pos != std::string::npos)
 			trimmed_hostname = trimmed_hostname.substr(0, dot_pos);

--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -84,7 +84,7 @@ bool Duet::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn e
 			int err_code = dsf ? (status == 201 ? 0 : 1) : get_err_code_from_body(body);
 			if (err_code != 0) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("Duet: Request completed but error code was received: %1%") % err_code;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 				res = false;
 			} else if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
 				wxString errormsg;
@@ -153,7 +153,7 @@ Duet::ConnectionType Duet::connect(wxString &msg) const
 					msg = format_error(body, L("Could not get resources to create a new connection"), 0);
 					break;
 				default:
-					msg = format_error(body, L("Unknown error occured"), 0);
+					msg = format_error(body, L("Unknown error occurred"), 0);
 					break;
 			}
 

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -405,7 +405,7 @@ void StyleManager::init_style_images(const Vec2i &max_size,
     auto mf = wxGetApp().mainframe;
     // dot per inch for monitor
     int dpi = get_dpi_for_window(mf);
-    // pixel per milimeter
+    // pixel per millimeter
     double ppm = dpi / ObjectManipulation::in_to_mm;
 
     auto &worker = wxGetApp().plater()->get_ui_job_worker();
@@ -433,7 +433,7 @@ float StyleManager::get_imgui_font_size(const FontProp &prop, const FontFile &fi
     const auto  &cn = prop.collection_number;
     unsigned int font_index = (cn.has_value()) ? *cn : 0;
     const auto  &font_info  = file.infos[font_index];
-    // coeficient for convert line height to font size
+    // coefficient for convert line height to font size
     float c1 = (font_info.ascent - font_info.descent + font_info.linegap) /
                (float) font_info.unit_per_em;
 

--- a/src/slic3r/Utils/EmbossStyleManager.hpp
+++ b/src/slic3r/Utils/EmbossStyleManager.hpp
@@ -35,7 +35,7 @@ public:
 
     /// <summary>
     /// Load font style list from config
-    /// Also select actual activ font
+    /// Also select actual active font
     /// </summary>
     /// <param name="app_config">Application configuration loaded from file "PrusaSlicer.ini"
     /// + cfg is stored to privat variable</param>
@@ -46,8 +46,8 @@ public:
     /// </summary>
     /// <param name="item_to_store">Configuration</param>
     /// <param name="use_modification">When true cache state will be used for store</param>
-    /// <param name="use_modification">When true store activ index into configuration</param>
-    /// <returns>True on succes otherwise False.</returns>
+    /// <param name="use_modification">When true store active index into configuration</param>
+    /// <returns>True on success otherwise False.</returns>
     bool store_styles_to_app_config(bool use_modification = true, bool store_active_index = true);
 
     /// <summary>
@@ -65,8 +65,8 @@ public:
     void swap(size_t i1, size_t i2);
 
     /// <summary>
-    /// Discard changes in activ style
-    /// When no activ style use last used OR first loadable
+    /// Discard changes in active style
+    /// When no active style use last used OR first loadable
     /// </summary>
     void discard_style_changes();
 
@@ -90,10 +90,10 @@ public:
 
     /// <summary>
     /// Change active font
-    /// When font not loaded roll back activ font
+    /// When font not loaded roll back active font
     /// </summary>
     /// <param name="font_index">New font index(from m_style_items range)</param>
-    /// <returns>True on succes. False on fail load font</returns>
+    /// <returns>True on success. False on fail load font</returns>
     bool load_style(size_t font_index);
     // load font style not stored in list
     bool load_style(const EmbossStyle &style);
@@ -122,7 +122,7 @@ public:
     bool has_collections() const { return m_style_cache.font_file.font_file != nullptr && 
                                           m_style_cache.font_file.font_file->infos.size() > 1; }
 
-    // True when activ style has same name as some of stored style
+    // True when active style has same name as some of stored style
     bool exist_stored_style() const { return m_style_cache.style_index != std::numeric_limits<size_t>::max(); }
     
     /// <summary>
@@ -147,7 +147,7 @@ public:
     /// <returns>True on success otherwise false</returns>
     bool set_wx_font(const wxFont &wx_font, std::unique_ptr<Slic3r::Emboss::FontFile> font_file);
 
-    // Getter on acitve font pointer for imgui
+    // Getter on active font pointer for imgui
     // Initialize imgui font(generate texture) when doesn't exist yet.
     // Extend font atlas when not in glyph range
     ImFont *get_imgui_font();
@@ -284,7 +284,7 @@ private:
         // place to store result in main thread in Finalize
         std::shared_ptr<StyleImages> result;
                 
-        // pixel per milimeter (scaled DPI)
+        // pixel per millimeter (scaled DPI)
         double ppm;
     };
     std::shared_ptr<StyleImagesData::StyleImages> m_temp_style_images;

--- a/src/slic3r/Utils/FixModelByWin10.cpp
+++ b/src/slic3r/Utils/FixModelByWin10.cpp
@@ -343,7 +343,7 @@ bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, wxPro
 		volumes.emplace_back(model_object.volumes[volume_idx]);
 
 	// Executing the calculation in a background thread, so that the COM context could be created with its own threading model.
-	// (It seems like wxWidgets initialize the COM contex as single threaded and we need a multi-threaded context).
+	// (It seems like wxWidgets initialize the COM context as single threaded and we need a multi-threaded context).
 	bool   success = false;
 	size_t ivolume = 0;
 	auto on_progress = [&mtx, &condition, &ivolume, &volumes, &progress](const char *msg, unsigned prcnt) {

--- a/src/slic3r/Utils/FixModelByWin10.cpp
+++ b/src/slic3r/Utils/FixModelByWin10.cpp
@@ -323,7 +323,7 @@ public:
 
 // returt FALSE, if fixing was canceled
 // fix_result is empty, if fixing finished successfully
-// fix_result containes a message if fixing failed 
+// fix_result contains a message if fixing failed 
 bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, wxProgressDialog& progress_dialog, const wxString& msg_header, std::string& fix_result)
 {
     std::mutex mtx;

--- a/src/slic3r/Utils/FlashAir.cpp
+++ b/src/slic3r/Utils/FlashAir.cpp
@@ -120,7 +120,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
 			res = boost::icontains(body, "SUCCESS");
 			if (! res) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 			}
 		})
 		.perform_sync();
@@ -141,7 +141,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
             res = boost::icontains(body, "SUCCESS");
             if (! res) {
                 BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-                error_fn(format_error(body, L("Unknown error occured"), 0));
+                error_fn(format_error(body, L("Unknown error occurred"), 0));
             }
         })
         .perform_sync();
@@ -157,7 +157,7 @@ bool FlashAir::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Error
 			res = boost::icontains(body, "SUCCESS");
 			if (! res) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("%1%: Request completed but no SUCCESS message was received.") % name;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				error_fn(format_error(body, L("Unknown error occurred"), 0));
 			}
 		})
 		.on_error([&](std::string body, std::string error, unsigned status) {

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -195,7 +195,7 @@ bool Http::priv::ca_file_supported(::CURL *curl)
 	if (::curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &tls) == CURLE_OK) {
 		if (tls->backend == CURLSSLBACKEND_SCHANNEL || tls->backend == CURLSSLBACKEND_DARWINSSL) {
 			// With Windows and OS X native SSL support, cert files cannot be set
-            // DK: OSX is now not building CURL and links system one, thus we do not know which backend is installed. Still, false will be returned since the ifdef at the begining if this function.
+            // DK: OSX is now not building CURL and links system one, thus we do not know which backend is installed. Still, false will be returned since the ifdef at the beginning if this function.
 			res = false;
 		}
 	}
@@ -375,7 +375,7 @@ void Http::priv::http_perform()
 	if (res != CURLE_OK) {
 		if (res == CURLE_ABORTED_BY_CALLBACK) {
 			if (cancel) {
-				// The abort comes from the request being cancelled programatically
+				// The abort comes from the request being cancelled programmatically
 				Progress dummyprogress(0, 0, 0, 0, std::string());
 				bool cancel = true;
 				if (progressfn) { progressfn(dummyprogress, cancel); }

--- a/src/slic3r/Utils/Http.hpp
+++ b/src/slic3r/Utils/Http.hpp
@@ -110,7 +110,7 @@ public:
 
 	// Callback called on HTTP request complete
 	Http& on_complete(CompleteFn fn);
-	// Callback called on an error occuring at any stage of the requests: Url parsing, DNS lookup,
+	// Callback called on an error occurring at any stage of the requests: Url parsing, DNS lookup,
 	// TCP connection, HTTP transfer, and finally also when the response indicates an error (status >= 400).
 	// Therefore, a response body may or may not be present.
 	Http& on_error(ErrorFn fn);
@@ -118,7 +118,7 @@ public:
 	// See the `Progress` structure for description of the data passed.
 	// Writing a true-ish value into the cancel reference parameter cancels the request.
 	Http& on_progress(ProgressFn fn);
-	// Callback called after succesful HTTP request (after on_complete callback)
+	// Callback called after successful HTTP request (after on_complete callback)
 	// Called if curl_easy_getinfo resolved just used IP address.
 	Http& on_ip_resolve(IPResolveFn fn);
 
@@ -129,7 +129,7 @@ public:
 	// Cancels a request in progress
 	void cancel();
 
-	// Tells whether current backend supports seting up a CA file using ca_file()
+	// Tells whether current backend supports setting up a CA file using ca_file()
 	static bool ca_file_supported();
 
     // Return empty string on success or error message on fail.

--- a/src/slic3r/Utils/MKS.cpp
+++ b/src/slic3r/Utils/MKS.cpp
@@ -81,7 +81,7 @@ bool MKS::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn er
 		int err_code = get_err_code_from_body(body);
 		if (err_code != 0) {
 			BOOST_LOG_TRIVIAL(error) << boost::format("MKS: Request completed but error code was received: %1%") % err_code;
-			error_fn(format_error(body, L("Unknown error occured"), 0));
+			error_fn(format_error(body, L("Unknown error occurred"), 0));
 			res = false;
 		}
 		else if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -78,7 +78,7 @@ std::string substitute_host(const std::string& orig_addr, std::string sub_addr)
             // Replace the address.
             rc = curl_url_set(hurl, CURLUPART_HOST, sub_addr.c_str(), 0);
             if (rc == CURLUE_OK) {
-                // Extract a string fromt the CURL URL handle.
+                // Extract a string from the CURL URL handle.
                 char *url;
                 rc = curl_url_get(hurl, CURLUPART_URL, &url, 0);
                 if (rc == CURLUE_OK) {

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -353,7 +353,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 
 	// Download profiles archive zip
 	// dk: Do we want to return here on error? Or skip archive dwnld and unzip and work with previous run state cache / vendor? I think return.
-	// Any error here also doesnt show any info in UI. Do we want maybe notification?
+	// Any error here also doesn't show any info in UI. Do we want maybe notification?
 	fs::path archive_path(cache_path / "vendor_indices.zip");
 	if (index_archive_url.empty()) {
 		BOOST_LOG_TRIVIAL(error) << "Downloading profile archive failed - url has no value.";
@@ -507,7 +507,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 
 		if (vendor.config_version >= recommended) { continue; }
 
-		// vendors that are checked here, doesnt need to be checked again later
+		// vendors that are checked here, doesn't need to be checked again later
 		if (archive_it != vendors_with_status.end())
 			archive_it->second = VendorStatus::NEW_VERSION;
 
@@ -810,7 +810,7 @@ Updates PresetUpdater::priv::get_config_updates(const Semver &old_slic3r_version
 		auto bundle_path_idx = vendor_path / idx.path().filename();
 
 		if (! fs::exists(bundle_path)) {
-			BOOST_LOG_TRIVIAL(info) << format("Confing bundle not installed for vendor %1%, skipping: ", idx.vendor());
+			BOOST_LOG_TRIVIAL(info) << format("Config bundle not installed for vendor %1%, skipping: ", idx.vendor());
 			continue;
 		}
 

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -197,7 +197,7 @@ PresetUpdater::priv::priv()
 	, cancel(false)
 {
 	set_download_prefs(GUI::wxGetApp().app_config);
-	// Install indicies from resources. Only installs those that are either missing or older than in resources.
+	// Install indices from resources. Only installs those that are either missing or older than in resources.
 	check_install_indices();
 	// Load indices from the cache directory.
 	index_db = Index::load_db();
@@ -251,7 +251,7 @@ bool PresetUpdater::priv::get_file(const std::string &url, const fs::path &targe
 	return res;
 }
 
-// Remove leftover paritally downloaded files, if any.
+// Remove leftover partially downloaded files, if any.
 void PresetUpdater::priv::prune_tmps() const
 {
     for (auto &dir_entry : boost::filesystem::directory_iterator(cache_path))
@@ -339,7 +339,7 @@ void PresetUpdater::priv::get_or_copy_missing_resource(const std::string& vendor
 	if (!fs::exists(file_in_vendor.parent_path())) // create vendor_name dir in vendor 
 		fs::create_directory(file_in_vendor.parent_path());
 
-	BOOST_LOG_TRIVIAL(debug) << "Copiing: " << file_in_cache << " to " << file_in_vendor;
+	BOOST_LOG_TRIVIAL(debug) << "Copying: " << file_in_cache << " to " << file_in_vendor;
 	copy_file_fix(file_in_cache, file_in_vendor);
 }
 
@@ -430,7 +430,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 					// TODO: what if unexpected happens here (folder inside zip) - crash! 
 
 					if (name.substr(name.size() - 3) == "idx")
-						vendors_with_status.emplace_back(name.substr(0, name.size() - 4), VendorStatus::IN_ARCHIVE); // asume for now its only in archive - if not, it will change later.
+						vendors_with_status.emplace_back(name.substr(0, name.size() - 4), VendorStatus::IN_ARCHIVE); // assume for now its only in archive - if not, it will change later.
 				}
 			}
 		}
@@ -511,7 +511,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 		if (archive_it != vendors_with_status.end())
 			archive_it->second = VendorStatus::NEW_VERSION;
 
-		// Download recomended ini to cache
+		// Download recommended ini to cache
 		const auto path_in_cache = cache_path / (vendor.id + ".ini");
 		BOOST_LOG_TRIVIAL(info) << "Downloading new bundle for vendor: " << vendor.name;
 		const auto bundle_url = format("%1%/%2%.ini", vendor.config_update_url, recommended.to_string());
@@ -573,14 +573,14 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 			}
 			const auto recommended = recommended_it->config_version;
 			if (!fs::exists(ini_path_in_archive)){
-				// Download recommneded to vendor - we do not have any existing ini file so we have to use hardcoded url.
+				// Download recommended to vendor - we do not have any existing ini file so we have to use hardcoded url.
 				const std::string fixed_url = GUI::wxGetApp().app_config->profile_folder_url();
 				const auto bundle_url = format("%1%/%2%/%3%.ini", fixed_url, vendor.first, recommended.to_string());
 				if (!get_file(bundle_url, ini_path_in_archive))
 					continue;
 			} else {
 				// check existing ini version
-				// then download recommneded to vendor if needed
+				// then download recommended to vendor if needed
 				VendorProfile vp;
 				try {
 					vp = VendorProfile::from_ini(ini_path_in_archive, true);
@@ -659,7 +659,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 			const auto recommended_archive = recommended_it_archive->config_version;
 			
 			if (recommended_archive <= recommended_cache) {
-				// There isn't  more recent recomended version online. This vendor is also not istalled.
+				// There isn't  more recent recommended version online. This vendor is also not istalled.
 				// Thus only .ini is in resources and came with installation.
 				// And we expect all resources are present.
 				continue;
@@ -667,7 +667,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 			
 			// Download new .ini if needed. So next time user runs Wizard, most recent profiles are shown & installed.
 			if (!fs::exists(ini_path_in_archive) || fs::is_empty(ini_path_in_archive)) {
-				// download recommneded to vendor 
+				// download recommended to vendor 
 				const fs::path ini_path_in_rsrc = rsrc_path / (vendor.first + ".ini");
 				if (!fs::exists(ini_path_in_rsrc)) {
 					// THIS SHOULD NOT HAPPEN
@@ -689,7 +689,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 				}
 			} else {
 				// Check existing ini version.
-				// Then download recommneded to vendor if needed.
+				// Then download recommended to vendor if needed.
 				VendorProfile vp;
 				try {
 					vp = VendorProfile::from_ini(ini_path_in_archive, false);
@@ -735,7 +735,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 					return;
 			}
 		} else if (vendor.second == VendorStatus::INSTALLED || vendor.second == VendorStatus::NEW_VERSION) {
-			// Installed vendors need to check that no resource is missing. Do this only for files in vendor folder (not in resorces)
+			// Installed vendors need to check that no resource is missing. Do this only for files in vendor folder (not in resources)
 			// VendorStatus::NEW_VERSION might seem like a mistake here since files are downloaded when preparing update higher in this function. 
 			// But this is a check for ini file in vendor where resources might be still missing since last update.
 			const auto path_in_vendor = vendor_path / (vendor.first + ".ini");
@@ -769,7 +769,7 @@ void PresetUpdater::priv::sync_config(const VendorMap vendors, const std::string
 	}
 }
 
-// Install indicies from resources. Only installs those that are either missing or older than in resources.
+// Install indices from resources. Only installs those that are either missing or older than in resources.
 void PresetUpdater::priv::check_install_indices() const
 {
 	BOOST_LOG_TRIVIAL(info) << "Checking if indices need to be installed from resources...";
@@ -1059,7 +1059,7 @@ bool PresetUpdater::priv::perform_updates(Updates &&updates, bool snapshot) cons
 			for (const auto &name : bundle.obsolete_presets.sla_materials/*filaments*/) { obsolete_remover("sla_material", name); } 
 			for (const auto &name : bundle.obsolete_presets.printers)  { obsolete_remover("printer", name); }
 			
-			// check if any resorces of installed bundle are missing. If so, new ones should be already downloaded at cache/vendor_id/
+			// check if any resources of installed bundle are missing. If so, new ones should be already downloaded at cache/vendor_id/
 			VendorProfile vp;
 			try {
 				vp = VendorProfile::from_ini(update.target, true);
@@ -1121,7 +1121,7 @@ void PresetUpdater::sync(const PresetBundle *preset_bundle)
 	if (!p->enabled_version_check && !p->enabled_config_update) { return; }
 
 	// Copy the whole vendors data for use in the background thread
-	// Unfortunatelly as of C++11, it needs to be copied again
+	// Unfortunately as of C++11, it needs to be copied again
 	// into the closure (but perhaps the compiler can elide this).
 	VendorMap vendors = preset_bundle->vendors;
 	std::string index_archive_url = GUI::wxGetApp().app_config->index_archive_url();

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -246,7 +246,7 @@ void PrintHostJobQueue::priv::progress_fn(Http::Progress progress, bool &cancel)
 
 void PrintHostJobQueue::priv::error_fn(wxString error)
 {
-    // check if transfer was not canceled before error occured - than do not show the error
+    // check if transfer was not canceled before error occurred - than do not show the error
     bool do_emit_err = true;
     if (channel_cancels.size_hint() > 0) {
         // Lock both queues

--- a/src/slic3r/Utils/RaycastManager.hpp
+++ b/src/slic3r/Utils/RaycastManager.hpp
@@ -114,7 +114,7 @@ public:
     /// <param name="point">Position in space</param>
     /// <param name="direction">Casted ray direction</param>
     /// <param name="skip">Define which caster will be skipped, null mean no skip</param>
-    /// <returns>Position on surface, normal direction in world coorinate
+    /// <returns>Position on surface, normal direction in world coordinate
     /// + key, to know hitted instance and volume</returns>
     std::optional<Hit> first_hit(const Vec3d &point, const Vec3d &direction, const ISkip *skip = nullptr) const;
 
@@ -160,7 +160,7 @@ struct Camera;
 /// <param name="mouse_pos">Position of mouse on screen</param>
 /// <param name="camera">Projection params</param>
 /// <param name="skip">Define which caster will be skipped, null mean no skip</param>
-/// <returns>Position on surface, normal direction in world coorinate
+/// <returns>Position on surface, normal direction in world coordinate
 /// + key, to know hitted instance and volume</returns>
 std::optional<RaycastManager::Hit> ray_from_camera(const RaycastManager        &raycaster,
                                                    const Vec2d                 &mouse_pos,

--- a/src/slic3r/Utils/Serial.hpp
+++ b/src/slic3r/Utils/Serial.hpp
@@ -71,7 +71,7 @@ public:
 	// Write data from a string
 	size_t write_string(const std::string &str);
 
-	// Attempts to reset the line numer and waits until the printer says "ok"
+	// Attempts to reset the line number and waits until the printer says "ok"
 	bool printer_ready_wait(unsigned retries, unsigned timeout);
 
 	// Write Marlin-formatted line, with a line number and a checksum

--- a/src/slic3r/Utils/UndoRedo.cpp
+++ b/src/slic3r/Utils/UndoRedo.cpp
@@ -1166,7 +1166,7 @@ void StackImpl::release_least_recently_used()
 #else
 			// Rather don't release the last snapshot as it will be very confusing to the user
 			// as of why he cannot jump to the top most state. The Undo / Redo stack maximum size
-			// should be set low enough to accomodate for the top most snapshot.
+			// should be set low enough to accommodate for the top most snapshot.
 			break;
 #endif
 		} else {

--- a/src/slic3r/Utils/UndoRedo.hpp
+++ b/src/slic3r/Utils/UndoRedo.hpp
@@ -120,7 +120,7 @@ public:
 
 	// Store the current application state onto the Undo / Redo stack, remove all snapshots after m_active_snapshot_time.
     void take_snapshot(const std::string& snapshot_name, const Slic3r::Model& model, const Slic3r::GUI::Selection& selection, const Slic3r::GUI::GLGizmosManager& gizmos, const SnapshotData &snapshot_data);
-    // To be called just after take_snapshot() when leaving a gizmo, inside which small edits like support point add / remove events or paiting actions were allowed.
+    // To be called just after take_snapshot() when leaving a gizmo, inside which small edits like support point add / remove events or painting actions were allowed.
     // Remove all but the last edit between the gizmo enter / leave snapshots.
     void reduce_noisy_snapshots(const std::string& new_name);
 

--- a/src/slic3r/Utils/UndoRedo.hpp
+++ b/src/slic3r/Utils/UndoRedo.hpp
@@ -146,7 +146,7 @@ public:
 
 	// Timestamp of the active snapshot. One of the snapshots of this->snapshots() shall have Snapshot::timestamp equal to this->active_snapshot_time().
 	// The active snapshot may be a special placeholder "@@@ Topmost @@@" indicating an uncaptured current state,
-	// or the active snapshot may be an active state to which the application state was undoed or redoed.
+	// or the active snapshot may be an active state to which the application state was undone or redone.
 	size_t active_snapshot_time() const;
 	const Snapshot& active_snapshot() const { return this->snapshot(this->active_snapshot_time()); }
 	// Temporary snapshot is active if the topmost snapshot is active and it has not been captured yet.

--- a/src/slic3r/Utils/WxFontUtils.cpp
+++ b/src/slic3r/Utils/WxFontUtils.cpp
@@ -74,7 +74,7 @@ bool WxFontUtils::can_load(const wxFont &font)
     //return is_valid_ttf(get_file_path(font));
 #elif defined(__linux__)
     return true;
-    // font config check file path take about 4000ms for chech them all
+    // font config check file path take about 4000ms for check them all
     //std::string font_path = Slic3r::GUI::get_font_path(font);
     //return !font_path.empty();
 #endif

--- a/tests/libslic3r/test_emboss.cpp
+++ b/tests/libslic3r/test_emboss.cpp
@@ -747,7 +747,7 @@ namespace Slic3r::MeshBoolean::cgal2 {
 /// <param name="source">Input source mesh</param>
 /// <param name="shape">Input 2d shape to cut from surface</param>
 /// <param name="projection">Define transformation from 2d to 3d</param>
-/// <returns>Cutted surface, Its do not represent Volume</returns>
+/// <returns>Cut surface, Its do not represent Volume</returns>
 indexed_triangle_set cut_shape(const indexed_triangle_set &source,
                                const ExPolygon            &shape,
                                const Emboss::IProjection  &projection)
@@ -762,7 +762,7 @@ indexed_triangle_set cut_shape(const indexed_triangle_set &source,
 /// <param name="source">Input source mesh</param>
 /// <param name="shapes">Input 2d shape to cut from surface</param>
 /// <param name="projection">Define transformation from 2d to 3d</param>
-/// <returns>Cutted surface, Its do not represent Volume</returns>
+/// <returns>Cut surface, Its do not represent Volume</returns>
 indexed_triangle_set cut_shape(const indexed_triangle_set &source,
                                const ExPolygons           &shapes,
                                const Emboss::IProjection  &projection)


### PR DESCRIPTION
As I pretty much pledged to myself to try to introduce codespell and fix typos it detects in any FOSS project I consciously touch (e.g. use), I looked into prusa-slicer. Well -- there is lots of work ahead if I get blessing to proceed. For now I just looked primarily at `src/slic3r/`.  Some possible next steps if decided to proceed:

- [ ] make sure no side-effects from changed API or ABI if such changes introduced (some typos seems might be present in the interfaces)
- [ ] ideally - see to proceed in stages, e.g. finalize this PR and then go to the next in a follow up to avoid amassing conflicts:
- [ ] decide to either include extra paths to check/fix or exclude vendored code (I would need to get a list of that one).  If to "include" -- what should be next -- `src/libslic3r/` ?