### PR TITLE
[FEATURE] Only one perimeter on top/first layer

### DIFF
--- a/src/libslic3r/ClipperUtils.cpp
+++ b/src/libslic3r/ClipperUtils.cpp
@@ -183,6 +183,18 @@ namespace ClipperUtils {
             out.end());
         return out;
     }
+    [[nodiscard]] Polygons clip_clipper_polygons_with_subject_bbox(const ExPolygons &src, const BoundingBox &bbox)
+    {
+        Polygons out;
+        out.reserve(number_polygons(src));
+        for (const ExPolygon &p : src) {
+            Polygons temp = clip_clipper_polygons_with_subject_bbox(p, bbox);
+            out.insert(out.end(), temp.begin(), temp.end());
+        }
+
+        out.erase(std::remove_if(out.begin(), out.end(), [](const Polygon &polygon) {return polygon.empty(); }), out.end());
+        return out;
+    }
 }
 
 static ExPolygons PolyTreeToExPolygons(ClipperLib::PolyTree &&polytree)

--- a/src/libslic3r/ClipperUtils.hpp
+++ b/src/libslic3r/ClipperUtils.hpp
@@ -335,6 +335,7 @@ namespace ClipperUtils {
     [[nodiscard]] Polygon   clip_clipper_polygon_with_subject_bbox(const Polygon &src, const BoundingBox &bbox);
     [[nodiscard]] Polygons  clip_clipper_polygons_with_subject_bbox(const Polygons &src, const BoundingBox &bbox);
     [[nodiscard]] Polygons  clip_clipper_polygons_with_subject_bbox(const ExPolygon &src, const BoundingBox &bbox);
+    [[nodiscard]] Polygons  clip_clipper_polygons_with_subject_bbox(const ExPolygons &src, const BoundingBox &bbox);
 }
 
 // offset Polygons

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -111,6 +111,7 @@ void LayerRegion::make_perimeters(
 
     // Cummulative sum of polygons over all the regions.
     const ExPolygons *lower_slices = this->layer()->lower_layer ? &this->layer()->lower_layer->lslices : nullptr;
+    const ExPolygons *upper_slices = this->layer()->upper_layer ? &this->layer()->upper_layer->lslices : nullptr;
     // Cache for offsetted lower_slices
     Polygons          lower_layer_polygons_cache;
 
@@ -124,6 +125,7 @@ void LayerRegion::make_perimeters(
                 params,
                 surface,
                 lower_slices,
+                upper_slices,
                 lower_layer_polygons_cache,
                 // output:
                 m_perimeters,
@@ -135,6 +137,7 @@ void LayerRegion::make_perimeters(
                 params,
                 surface,
                 lower_slices,
+                upper_slices,
                 lower_layer_polygons_cache,
                 // output:
                 m_perimeters,

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1116,6 +1116,9 @@ void PerimeterGenerator::process_arachne(
     // extra perimeters for each one
     // detect how many perimeters must be generated for this island
     int        loop_number = params.config.perimeters + surface.extra_perimeters - 1; // 0-indexed loops
+    // SuperSlicer: set the bottommost layer to be one perimeter
+    if (params.layer_id == 0 && params.config.only_one_perimeter_first_layer)
+        loop_number = 0;
     // SuperSlicer: set the topmost layer to be one perimeter
     if (loop_number > 0 && params.config.only_one_perimeter_top && upper_slices == nullptr)
         loop_number = 0;
@@ -1441,7 +1444,7 @@ void PerimeterGenerator::process_classic(
     int        loop_number = params.config.perimeters + surface.extra_perimeters - 1;  // 0-indexed loops
 
     // SuperSlicer: set the topmost layer to be one perimeter
-    if (loop_number > 0 && params.config.only_one_perimeter_top && upper_slices == nullptr)
+    if ((params.layer_id == 0 && params.config.only_one_perimeter_first_layer) || (loop_number > 0 && params.config.only_one_perimeter_top && upper_slices == nullptr))
         loop_number = 0;
 
     ExPolygons last        = union_ex(surface.expolygon.simplify_p(params.scaled_resolution));

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -76,6 +76,7 @@ void process_classic(
     const Parameters           &params,
     const Surface              &surface,
     const ExPolygons           *lower_slices,
+    const ExPolygons           *upper_slices,
     // Cache:
     Polygons                   &lower_slices_polygons_cache,
     // Output:
@@ -91,6 +92,7 @@ void process_arachne(
     const Parameters           &params,
     const Surface              &surface,
     const ExPolygons           *lower_slices,
+    const ExPolygons           *upper_slices,
     // Cache:
     Polygons                   &lower_slices_polygons_cache,
     // Output:

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -105,6 +105,9 @@ void process_arachne(
 
 ExtrusionMultiPath thick_polyline_to_multi_path(const ThickPolyline &thick_polyline, ExtrusionRole role, const Flow &flow, float tolerance, float merge_tolerance);
 
+void split_top_surfaces(const Parameters &params, const ExPolygons           *lower_slices,const ExPolygons  *upper_slices, const ExPolygons &orig_polygons, ExPolygons &top_fills,
+                                            ExPolygons &non_top_polygons, ExPolygons &fill_clip);
+
 } // namespace PerimeterGenerator
 } // namespace Slic3r
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -474,7 +474,7 @@ static std::vector<std::string> s_Preset_print_options {
     "perimeter_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
     "wall_distribution_count", "min_feature_size", "min_bead_width",
     // SuperSlicer
-    "only_one_perimeter_top", "min_width_top_surface",
+    "only_one_perimeter_first_layer", "only_one_perimeter_top", "min_width_top_surface",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -472,7 +472,9 @@ static std::vector<std::string> s_Preset_print_options {
     "wipe_tower_width", "wipe_tower_cone_angle", "wipe_tower_rotation_angle", "wipe_tower_brim_width", "wipe_tower_bridging", "single_extruder_multi_material_priming", "mmu_segmented_region_max_width",
     "mmu_segmented_region_interlocking_depth", "wipe_tower_extruder", "wipe_tower_no_sparse_layers", "wipe_tower_extra_spacing", "compatible_printers", "compatible_printers_condition", "inherits",
     "perimeter_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
-    "wall_distribution_count", "min_feature_size", "min_bead_width"
+    "wall_distribution_count", "min_feature_size", "min_bead_width",
+    // SuperSlicer
+    "only_one_perimeter_top", "min_width_top_surface",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -566,6 +566,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("only_one_perimeter_first_layer", coBool);
+    def->label = L("On First layer");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("Use only one perimeter on first layer, to give more space to the top infill pattern.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("only_one_perimeter_top", coBool);
     def->label = L("On top surfaces");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -566,6 +566,26 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("only_one_perimeter_top", coBool);
+    def->label = L("On top surfaces");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("Use only one perimeter on flat top surface, to give more space to the top infill pattern");
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("min_width_top_surface", coFloatOrPercent);
+    def->label = L("Minimum top width for infill");
+    def->category =  L("Layers and Perimeters");
+    def->tooltip = L("If a top surface has to be printed and it's partially covered by another layer, it won't be considered at a top layer where its width is below this value."
+        " This can be useful to not let the 'one perimeter on top' trigger on surface that should be covered only by perimeters."
+        " This value can be a mm or a % of the perimeter extrusion width."
+        "\nWarning: If enabled, artifacts can be created is you have some thin features on the next layer, like letters. Set this setting to 0 to remove these artifacts.");
+    def->sidetext = L("mm or %");
+    def->ratio_over = "perimeter_extrusion_width";
+    def->min = 0;
+    def->max_literal = 15;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloatOrPercent(100, true));
+
     def = this->add("bridge_speed", coFloat);
     def->label = L("Bridges");
     def->category = L("Speed");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -662,6 +662,9 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                top_solid_min_thickness))
     ((ConfigOptionFloatOrPercent,       top_solid_infill_speed))
     ((ConfigOptionBool,                 wipe_into_infill))
+    // SuperSlicer
+    ((ConfigOptionBool,                 only_one_perimeter_top))
+    ((ConfigOptionFloatOrPercent,       min_width_top_surface))
 )
 
 PRINT_CONFIG_CLASS_DEFINE(

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -663,6 +663,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatOrPercent,       top_solid_infill_speed))
     ((ConfigOptionBool,                 wipe_into_infill))
     // SuperSlicer
+    ((ConfigOptionBool,                 only_one_perimeter_first_layer))
     ((ConfigOptionBool,                 only_one_perimeter_top))
     ((ConfigOptionFloatOrPercent,       min_width_top_surface))
 )

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -708,6 +708,9 @@ bool PrintObject::invalidate_state_by_config_options(
             // Brim is printed below supports, support invalidates brim and skirt.
             steps.emplace_back(posSupportMaterial);
         } else if (
+               opt_key == "only_one_perimeter_top") {
+            steps.emplace_back(posPerimeters);
+        } else if (
                opt_key == "perimeters"
             || opt_key == "extra_perimeters"
             || opt_key == "extra_perimeters_on_overhangs"

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -708,7 +708,8 @@ bool PrintObject::invalidate_state_by_config_options(
             // Brim is printed below supports, support invalidates brim and skirt.
             steps.emplace_back(posSupportMaterial);
         } else if (
-               opt_key == "only_one_perimeter_top") {
+               opt_key == "only_one_perimeter_first_layer"
+               || opt_key == "only_one_perimeter_top") {
             steps.emplace_back(posPerimeters);
         } else if (
                opt_key == "perimeters"

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -78,9 +78,11 @@ static constexpr double INSET_OVERLAP_TOLERANCE = 0.4;
 // 3mm ring around the top / bottom / bridging areas.
 //FIXME This is quite a lot.
 static constexpr double EXTERNAL_INFILL_MARGIN = 3.;
+static constexpr double BRIDGE_INFILL_MARGIN   = 1.;
 //FIXME Better to use an inline function with an explicit return type.
 //inline coord_t scale_(coordf_t v) { return coord_t(floor(v / SCALING_FACTOR + 0.5f)); }
 #define scale_(val) ((val) / SCALING_FACTOR)
+#define unscale_(val) ((val) * SCALING_FACTOR)
 
 #define SCALED_EPSILON scale_(EPSILON)
 

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -68,6 +68,7 @@ static constexpr double EPSILON = 1e-4;
 // int32_t fits an interval of (-2147.48mm, +2147.48mm)
 // with int64_t we don't have to worry anymore about the size of the int.
 static constexpr double SCALING_FACTOR = 0.000001;
+static constexpr double UNSCALING_FACTOR = 1000000; // 1 / SCALING_FACTOR; <- linux has some problem compiling this constexpr
 static constexpr double PI = 3.141592653589793238;
 // When extruding a closed loop, the loop is interrupted and shortened a bit to reduce the seam.
 static constexpr double LOOP_CLIPPING_LENGTH_OVER_NOZZLE_DIAMETER = 0.15;
@@ -106,6 +107,8 @@ using deque =
 
 template<typename T, typename Q>
 inline T unscale(Q v) { return T(v) * T(SCALING_FACTOR); }
+
+inline coordf_t scale_d(double v) { return coordf_t(v * UNSCALING_FACTOR); }
 
 enum Axis { 
 	X=0,

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -345,6 +345,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("min_feature_size", have_arachne);
     toggle_field("min_bead_width", have_arachne);
     toggle_field("thin_walls", !have_arachne);
+
+    toggle_field("only_one_perimeter_top", !have_arachne);
+    toggle_field("min_width_top_surface", have_perimeters && config->opt_bool("only_one_perimeter_top") && !have_arachne);
 }
 
 void ConfigManipulation::toggle_print_sla_options(DynamicPrintConfig* config)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -346,8 +346,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("min_bead_width", have_arachne);
     toggle_field("thin_walls", !have_arachne);
 
-    toggle_field("only_one_perimeter_top", !have_arachne);
-    toggle_field("min_width_top_surface", have_perimeters && config->opt_bool("only_one_perimeter_top") && !have_arachne);
+    toggle_field("min_width_top_surface", have_perimeters && config->opt_bool("only_one_perimeter_top"));
 }
 
 void ConfigManipulation::toggle_print_sla_options(DynamicPrintConfig* config)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -220,7 +220,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     bool have_perimeters = config->opt_int("perimeters") > 0;
     for (auto el : { "extra_perimeters","extra_perimeters_on_overhangs", "thin_walls", "overhangs",
                     "seam_position","staggered_inner_seams", "external_perimeters_first", "external_perimeter_extrusion_width",
-                    "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "enable_dynamic_overhang_speeds"})
+                    "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "enable_dynamic_overhang_speeds",
+                    "only_one_perimeter_first_layer", "only_one_perimeter_top"})
         toggle_field(el, have_perimeters);
 
     for (size_t i = 0; i < 4; i++) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1474,6 +1474,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Quality (slower slicing)"));
         line = { L("Only one perimeter"), "" };
         line.label_path = category_path + "only-one-perimeter-top-bottom";
+        line.append_option(optgroup->get_option("only_one_perimeter_first_layer"));
         line.append_option(optgroup->get_option("only_one_perimeter_top"));
         line.append_option(optgroup->get_option("min_width_top_surface"));
         optgroup->append_line(line);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1472,6 +1472,11 @@ void TabPrint::build()
 	    optgroup->append_line(line);
 
         optgroup = page->new_optgroup(L("Quality (slower slicing)"));
+        line = { L("Only one perimeter"), "" };
+        line.label_path = category_path + "only-one-perimeter-top-bottom";
+        line.append_option(optgroup->get_option("only_one_perimeter_top"));
+        line.append_option(optgroup->get_option("min_width_top_surface"));
+        optgroup->append_line(line);
         optgroup->append_single_option_line("extra_perimeters", category_path + "extra-perimeters-if-needed");
         optgroup->append_single_option_line("extra_perimeters_on_overhangs", category_path + "extra-perimeters-on-overhangs");
         optgroup->append_single_option_line("avoid_crossing_curled_overhangs", category_path + "avoid-crossing-curled-overhangs");

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -65,6 +65,7 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
                 perimeter_generator_params,
                 surface,
                 nullptr,
+                nullptr,
                 // cache:
                 lower_layer_polygons_cache,
                 // output:


### PR DESCRIPTION
This PR backports the single perimeter on top surfaces feature of SuperSlicer. A single perimeter on the top layers allows more space for the infill to show on the outer surface and results in very clean looking fills. 

All credit belongs to @supermerill and the contributors to SuperSlicer.

Implements the feature request in #7986