### PR TITLE
[FEATURE] Per filament chamber temperature config option

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -490,7 +490,9 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_retract_layer_change", "filament_wipe", "filament_retract_before_wipe", "filament_retract_length_toolchange", "filament_retract_restart_extra_toolchange", "filament_travel_ramping_lift",
     "filament_travel_slope", "filament_travel_max_lift", "filament_travel_lift_before_obstacle",
     // Profile compatibility
-    "filament_vendor", "compatible_prints", "compatible_prints_condition", "compatible_printers", "compatible_printers_condition", "inherits"
+    "filament_vendor", "compatible_prints", "compatible_prints_condition", "compatible_printers", "compatible_printers_condition", "inherits",
+    // SuperSlicer
+    "chamber_temperature",
 };
 
 static std::vector<std::string> s_Preset_machine_limits_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -94,6 +94,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "overhang_fan_speed_1",
         "overhang_fan_speed_2",
         "overhang_fan_speed_3",
+        "chamber_temperature",
         "colorprint_heights",
         "cooling",
         "default_acceleration",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -486,6 +486,16 @@ void PrintConfigDef::init_fff_params()
     def->max = 300;
     def->set_default_value(new ConfigOptionInts { 0 });
 
+    def = this->add("chamber_temperature", coInts);
+    def->label = L("Chamber");
+    def->full_label = L("Chamber temperature");
+    def->tooltip = L("Chamber temperature. Note that this setting doesn't do anything, but you can access it in Start G-code, Tool change G-code and the other ones, like for other temperature settings.");
+    def->sidetext = L("°C");
+    def->min = 0;
+    def->max = 300;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionInts{ 0 });
+
     def = this->add("before_layer_gcode", coString);
     def->label = L("Before layer change G-code");
     def->tooltip = L("This custom code is inserted at every layer change, right before the Z move. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -879,6 +879,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,             wiping_volumes_matrix))
     ((ConfigOptionFloats,             wiping_volumes_extruders))
     ((ConfigOptionFloat,              z_offset))
+    ((ConfigOptionInts,               chamber_temperature))
 )
 
 PRINT_CONFIG_CLASS_DERIVED_DEFINE0(

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2190,6 +2190,7 @@ void TabFilament::build()
         optgroup = page->new_optgroup(L("Temperature"));
 
         create_line_with_near_label_widget(optgroup, "idle_temperature");
+        optgroup->append_single_option_line("chamber_temperature");
 
         Line line = { L("Nozzle"), "" };
         line.append_option(optgroup->get_option("first_layer_temperature"));


### PR DESCRIPTION
Backport the option to set a (minimal) chamber temperature per filament. This option is useful on enclosed printers with a chamber thermistor to have an optimal printing environment . This option doesn't affect gcode generation at all and is only used in placeholders so that it can be use in custom g-code.

Backport from SuperSlicer, all credit belongs to @supermerill  and the SuperSlicer contributors.