### PR TITLE
[FEATURE] Configurable Z-Rotate on import

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -560,7 +560,9 @@ static std::vector<std::string> s_Preset_printer_options {
     "max_print_height", "default_print_profile", "inherits",
     "remaining_times", "silent_mode",
     "machine_limits_usage", "thumbnails", "thumbnails_format",
-    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height"
+    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height",
+    // SuperSlicer
+    "init_z_rotate"
 };
 
 static std::vector<std::string> s_Preset_sla_print_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3967,6 +3967,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
 
+    def = this->add("init_z_rotate", coFloat);
+    def->label = L("Preferred orientation");
+    def->tooltip = L("Rotate objects around Z axis while adding them to the bed.");
+    def->sidetext = L("°");
+    def->min = -360;
+    def->max = 360;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0.0));
+
     def = this->add("perimeter_generator", coEnum);
     def->label = L("Perimeter generator");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1054,6 +1054,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,             wiping_volumes_matrix))
     ((ConfigOptionBool,               wiping_volumes_use_custom_matrix))
     ((ConfigOptionFloat,              z_offset))
+    ((ConfigOptionFloat,              init_z_rotate))
 )
 
 PRINT_CONFIG_CLASS_DERIVED_DEFINE0(

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -694,7 +694,9 @@ Plater::priv::priv(Plater* q, MainFrame* main_frame)
         "layer_height", "first_layer_height", "min_layer_height", "max_layer_height",
         "brim_width", "perimeters", "perimeter_extruder", "fill_density", "infill_extruder", "top_solid_layers",
         "support_material", "support_material_extruder", "support_material_interface_extruder",
-        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers"
+        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers",
+        // SuperSlicer
+        "init_z_rotate",
         }))
     , sidebar(new Sidebar(q))
     , notification_manager(std::make_unique<NotificationManager>(q))
@@ -1461,11 +1463,15 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                 if (type_step) {
                     double linear_precision = string_to_double_decimal_point(wxGetApp().app_config->get("linear_precision"));
                     double angle_precision = string_to_double_decimal_point(wxGetApp().app_config->get("angle_precision"));
-                    model = FileReader::load_model(path.string(), FileReader::LoadAttributes{}, &load_stats, 
+                    model = FileReader::load_model(path.string(), FileReader::LoadAttributes{}, &load_stats,
                                                    std::make_pair(linear_precision, angle_precision));
                 }
                 else
                     model = FileReader::load_model(path.string(), FileReader::LoadAttributes{}, &load_stats);
+
+                // SuperSlicer
+                for (auto obj : model.objects)
+                    obj->rotate(Geometry::deg2rad(this->config->opt_float("init_z_rotate")), Axis::Z);
             }
         } catch (const ConfigurationError &e) {
             std::string message = GUI::format(_L("Failed loading file \"%1%\" due to an invalid configuration."), filename.string()) + "\n\n" + e.what();

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2700,6 +2700,7 @@ void TabPrinter::build_fff()
 
         optgroup->append_single_option_line("max_print_height");
         optgroup->append_single_option_line("z_offset");
+        optgroup->append_single_option_line("init_z_rotate");
 
         optgroup = page->new_optgroup(L("Capabilities"));
         ConfigOptionDef def;


### PR DESCRIPTION
Automatically rotate objects on th Z axis by a configurable amount (typically 45°) on import. 

Rotating objects by 45° often allows better (automatic) seam positioning in combination with the "rear" seam position, improving layer consistency. CoreXY printers might have the additional benefit that 45° movements only utilize one motor which can lead to better quality on straight walls (VFAs when both motors are in use).