### PR TITLE
libslic3r/utils.cpp: Add missing include

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -7,8 +7,10 @@
 #include <cstdarg>
 #include <stdio.h>
 
+#include "format.hpp"
 #include "Platform.hpp"
 #include "Time.hpp"
+
 #include "libslic3r.h"
 
 #ifdef WIN32


### PR DESCRIPTION
Hello and greetings, this is a pull to add a missing include for `version_2.6.0-beta3`

Details requested from `CONTRIBUTING.md` follow:
PrusaSlicer version: cc1e69b4348e961ee1ecd94fb8b950ffb4e79643 / tag: `version_2.6.0-beta3`
Operating systems reproduced on:
- x86_64: Ubuntu 22.04.2 LTS (Jammy Jellyfish) VM
- aarch64: Armbian with build processes running in balenalib/raspberrypi containers (PrusaSlicer-ARM.AppImage)

General steps to reproduce:

- Build project and deps

```
    cd PrusaSlicer/deps && \
    mkdir -p build && \
    cd build && \
    cmake .. -DDEP_WX_GTK3=ON && \
    cmake --build . && \
    cd ../.. && \
    mkdir -p build && \
    cd build && \
    rm -rf AppDir && \
    cmake .. \
    -GNinja \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_PREFIX_PATH="$(pwd)/../deps/build/destdir/usr/local" \
    -DSLIC3R_PCH=OFF \
    -DSLIC3R_STATIC=ON \
    -DSLIC3R_WX_STABLE=OFF \
    -DSLIC3R_GTK=3 \
    -DCMAKE_BUILD_TYPE=Release
```

The build fails with the following message:

```
FAILED: src/libslic3r/CMakeFiles/libslic3r.dir/utils.cpp.o
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_NO_LIB -DBOOST_DATE_TIME_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_IOSTREAMS_NO_LIB -DBOOST_LOCALE_NO_LIB -DBOOST_LOG_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DLIBNEST2D_GEOMETRIES_libslic3r -DLIBNEST2D_OPTIMIZER_nlopt -DLIBNEST2D_STATIC -DLIBNEST2D_THREADING_tbb -DOPENVDB_OPENEXR_STATICLIB -DOPENVDB_STATICLIB -DSLIC3R_DESKTOP_INTEGRATION -DSLIC3R_GUI -DTBB_USE_CAPTURED_EXCEPTION=0 -DUNICODE -DUSE_TBB -DWXINTL_NO_GETTEXT_MACRO -D_UNICODE -DwxNO_UNSAFE_WXSTRING_CONV -DwxUSE_UNICODE -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/home/prusa/psbuilder/PrusaSlicer/src -I/home/prusa/psbuilder/PrusaSlicer/build/src/platform -I/home/prusa/psbuilder/PrusaSlicer/src/libslic3r -I/home/prusa/psbuilder/PrusaSlicer/build/src/libslic3r -I/home/prusa/psbuilder/PrusaSlicer/src/libnest2d/include -I/home/prusa/psbuilder/PrusaSlicer/src/miniz -I/home/prusa/psbuilder/PrusaSlicer/src/glu-libtess/include -isystem /home/prusa/psbuilder/PrusaSlicer/src/eigen -isystem /home/prusa/psbuilder/PrusaSlicer/deps/build/destdir/usr/local/include -isystem /home/prusa/psbuilder/PrusaSlicer/src/libigl -isystem /home/prusa/psbuilder/PrusaSlicer/deps/build/destdir/usr/local/include/OpenEXR -fext-numeric-literals -Wall -Wno-reorder -O3 -DNDEBUG -fPIC -fsigned-char -Werror=return-type -Wno-ignored-attributes -Wno-unknown-pragmas -DOPENVDB_ABI_VERSION_NUMBER=8 -std=gnu++17 -MD -MT src/libslic3r/CMakeFiles/libslic3r.dir/utils.cpp.o -MF src/libslic3r/CMakeFiles/libslic3r.dir/utils.cpp.o.d -o src/libslic3r/CMakeFiles/libslic3r.dir/utils.cpp.o -c /home/prusa/psbuilder/PrusaSlicer/src/libslic3r/utils.cpp
/home/prusa/psbuilder/PrusaSlicer/src/libslic3r/utils.cpp: In lambda function:
/home/prusa/psbuilder/PrusaSlicer/src/libslic3r/utils.cpp:1015:48: error: ‘format’ was not declared in this scope
 1015 |                 auto get_d = [days]() { return format(_u8L("%1%d"), days); };
      |                                                ^~~~~~
```

Merging this pull request will add: `#include "format.hpp"` to `src/libslic3r/utils.cpp` and allows the build to continue