### PR TITLE
Fix build: Text() takes a string format as first argument

### DIFF
--- a/src/imgui/imgui_widgets.cpp
+++ b/src/imgui/imgui_widgets.cpp
@@ -5126,13 +5126,13 @@ bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags fl
         PushItemFlag(ImGuiItemFlags_NoNavDefaultFocus, true);
         ImVec4 col_v4(col[0], col[1], col[2], (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : col[3]);
         if ((flags & ImGuiColorEditFlags_NoLabel))
-            Text(current_label ? current_label : "Current");
+            Text("%s", current_label ? current_label : "Current");
 
         ImGuiColorEditFlags sub_flags_to_forward = ImGuiColorEditFlags__InputMask | ImGuiColorEditFlags_HDR | ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoTooltip;
         ColorButton("##current", col_v4, (flags & sub_flags_to_forward), ImVec2(square_sz * 3, square_sz * 2));
         if (ref_col != NULL)
         {
-            Text(original_label ? original_label : "Original");
+            Text("%s", original_label ? original_label : "Original");
             ImVec4 ref_col_v4(ref_col[0], ref_col[1], ref_col[2], (flags & ImGuiColorEditFlags_NoAlpha) ? 1.0f : ref_col[3]);
             if (ColorButton("##original", ref_col_v4, (flags & sub_flags_to_forward), ImVec2(square_sz * 3, square_sz * 2)))
             {


### PR DESCRIPTION
This might be a new error from GCC13, not sure, but here's the error:

```
src/imgui/imgui_widgets.cpp:5129:18: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
            Text(current_label ? current_label : "Current");
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```