### PR TITLE
cmake: fix the resources symlink for multi-config builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,7 +267,7 @@ else ()
             COMMENT "Symlinking the G-code viewer to PrusaSlicer"
             VERBATIM)
     endif ()
-    if (XCODE)
+    if (CMAKE_CONFIGURATION_TYPES)
         # Because of Debug/Release/etc. configurations (similar to MSVC) the slic3r binary is located in an extra level
         set(BIN_RESOURCES_DIR "${CMAKE_CURRENT_BINARY_DIR}/resources")
     else ()


### PR DESCRIPTION
There was already code to do this for Xcode on the Mac but this change generalizes it to all multi-config generators (e.g. "Ninja Multi-Config").