### PR TITLE
Creality CR-M4, K1 and K1 Max support

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -374,6 +374,15 @@ bed_model = cr8_bed.stl
 bed_texture = cr8.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
 
+[printer_model:CRM4]
+name = Creality CR-M4
+variants = 0.4; 0.3; 0.5; 0.6
+technology = FFF
+family = CR
+bed_model = crm4_bed.stl
+bed_texture = crm4.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
+
 #[printer_model:CRX]
 #name = Creality CR-X
 #variants = 0.4; 0.3; 0.5; 0.6
@@ -401,8 +410,6 @@ bed_model = sermoond1_bed.stl
 bed_texture = sermoond1.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
 
-
-
 [printer_model:SERMOONV1]
 name = Creality Sermoon-V1
 variants = 0.4; 0.3; 0.5; 0.6
@@ -412,8 +419,6 @@ bed_model = sermoonv1_bed.stl
 bed_texture = sermoonv1.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
 
-
-
 [printer_model:SERMOONV1PRO]
 name = Creality Sermoon-V1 Pro
 variants = 0.4; 0.3; 0.5; 0.6
@@ -421,6 +426,24 @@ technology = FFF
 family = SERMOON
 bed_model = sermoonv1_bed.stl
 bed_texture = sermoonv1.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
+
+[printer_model:K1]
+name = Creality K1
+variants = 0.4; 0.3; 0.5; 0.6
+technology = FFF
+family = K
+bed_model = k1_bed.stl
+bed_texture = k1.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
+
+[printer_model:K1MAX]
+name = Creality K1 Max
+variants = 0.4; 0.3; 0.5; 0.6
+technology = FFF
+family = K
+bed_model = k1max_bed.stl
+bed_texture = k1max.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY; Verbatim PLA @CREALITY
 
 
@@ -2606,6 +2629,27 @@ inherits = *CR8*; *0.6nozzle*
 
 
 
+[printer:*CRM4*]
+inherits = *common*; *spriteextruder*; *slowabl*; *32bitmainboard*
+bed_shape = 5x5,445x5,445x215,5x445
+max_print_height = 470
+printer_model = CRM4
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_CRM4\nPRINTER_HAS_HIGHSPEED
+
+[printer:Creality CR-M4 (0.3 mm nozzle)]
+inherits = *CRM4*; *0.3nozzle*
+
+[printer:Creality CR-M4 (0.4 mm nozzle)]
+inherits = *CRM4*; *0.4nozzle*
+
+[printer:Creality CR-M4 (0.5 mm nozzle)]
+inherits = *CRM4*; *0.5nozzle*
+
+[printer:Creality CR-M4 (0.6 mm nozzle)]
+inherits = *CRM4*; *0.6nozzle*
+
+
+
 [printer:*SERMOOND1*]
 inherits = *common*; *directdriveextruder*; *descendingz*
 bed_shape = 5x5,275x5,275x255,5x255
@@ -2667,3 +2711,45 @@ inherits = *SERMOONV1PRO*; *0.5nozzle*
 
 [printer:Creality Sermoon-V1 Pro (0.6 mm nozzle)]
 inherits = *SERMOONV1PRO*; *0.6nozzle*
+
+
+
+[printer:*K1*]
+inherits = *common*; *spriteextruder*; *fastabl*; *descendingz*; *32bitmainboard*
+bed_shape = 5,215x5,215x215,5x215
+max_print_height = 250
+printer_model = K1
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_K1\nPRINTER_HAS_ULTRADETAIL\nPRINTER_HAS_HIGHSPEED\nPRINTER_HAS_SUPERSPEED
+
+[printer:Creality K1 (0.3 mm nozzle)]
+inherits = *K1*; *0.3nozzle*
+
+[printer:Creality K1 (0.4 mm nozzle)]
+inherits = *K1*; *0.4nozzle*
+
+[printer:Creality K1 (0.5 mm nozzle)]
+inherits = *K1*; *0.5nozzle*
+
+[printer:Creality K1 (0.6 mm nozzle)]
+inherits = *K1*; *0.6nozzle*
+
+
+
+[printer:*K1MAX*]
+inherits = *common*; *spriteextruder*; *slowabl*; *descendingz*; *32bitmainboard*
+bed_shape = 5,295x5,295x295,5x295
+max_print_height = 300
+printer_model = K1MAX
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_K1MAX\nPRINTER_HAS_ULTRADETAIL\nPRINTER_HAS_HIGHSPEED\nPRINTER_HAS_SUPERSPEED
+
+[printer:Creality K1 (0.3 mm nozzle)]
+inherits = *K1MAX*; *0.3nozzle*
+
+[printer:Creality K1 (0.4 mm nozzle)]
+inherits = *K1MAX*; *0.4nozzle*
+
+[printer:Creality K1 (0.5 mm nozzle)]
+inherits = *K1MAX*; *0.5nozzle*
+
+[printer:Creality K1 (0.6 mm nozzle)]
+inherits = *K1MAX*; *0.6nozzle*

--- a/resources/profiles/Creality/cr10v2_bed.stl
+++ b/resources/profiles/Creality/cr10v2_bed.stl
@@ -1,2774 +1,2774 @@
 solid OpenSCAD_Model
   facet normal 0 0 -1
     outer loop
-      vertex 152.105 -159.998 -3
-      vertex 152.002 -159.998 -3
-      vertex 152.314 -159.984 -3
+      vertex 147.105 -154.998 -3
+      vertex 147.002 -154.998 -3
+      vertex 147.314 -154.984 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 152.314 -159.984 -3
-      vertex 152.002 -159.998 -3
-      vertex 152.521 -159.954 -3
+      vertex 147.314 -154.984 -3
+      vertex 147.002 -154.998 -3
+      vertex 147.521 -154.954 -3
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex 152.002 159.998 -3
-      vertex -155 157 -3
+      vertex -147.002 154.998 -3
+      vertex 147.002 154.998 -3
+      vertex -150 152 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 152.521 -159.954 -3
-      vertex 152.002 -159.998 -3
-      vertex 152.726 -159.911 -3
+      vertex 147.521 -154.954 -3
+      vertex 147.002 -154.998 -3
+      vertex 147.726 -154.911 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 152.726 -159.911 -3
-      vertex 152.002 -159.998 -3
-      vertex 152.927 -159.853 -3
+      vertex 147.726 -154.911 -3
+      vertex 147.002 -154.998 -3
+      vertex 147.927 -154.853 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 152.927 -159.853 -3
-      vertex 152.002 -159.998 -3
-      vertex 153.124 -159.782 -3
+      vertex 147.927 -154.853 -3
+      vertex 147.002 -154.998 -3
+      vertex 148.124 -154.782 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 153.124 -159.782 -3
-      vertex 152.002 -159.998 -3
-      vertex 153.315 -159.696 -3
+      vertex 148.124 -154.782 -3
+      vertex 147.002 -154.998 -3
+      vertex 148.315 -154.696 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 153.315 -159.696 -3
-      vertex 152.002 -159.998 -3
-      vertex 153.5 -159.598 -3
+      vertex 148.315 -154.696 -3
+      vertex 147.002 -154.998 -3
+      vertex 148.5 -154.598 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 153.5 -159.598 -3
-      vertex 152.002 -159.998 -3
-      vertex 153.678 -159.487 -3
+      vertex 148.5 -154.598 -3
+      vertex 147.002 -154.998 -3
+      vertex 148.678 -154.487 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 153.678 -159.487 -3
-      vertex 152.002 -159.998 -3
-      vertex 153.847 -159.364 -3
+      vertex 148.678 -154.487 -3
+      vertex 147.002 -154.998 -3
+      vertex 148.847 -154.364 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 153.847 -159.364 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.007 -159.229 -3
+      vertex 148.847 -154.364 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.007 -154.229 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.007 -159.229 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.158 -159.084 -3
+      vertex 149.007 -154.229 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.158 -154.084 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.158 -159.084 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.298 -158.928 -3
+      vertex 149.158 -154.084 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.298 -153.928 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.298 -158.928 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.427 -158.763 -3
+      vertex 149.298 -153.928 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.427 -153.763 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.427 -158.763 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.544 -158.59 -3
+      vertex 149.427 -153.763 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.544 -153.59 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.544 -158.59 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.649 -158.408 -3
+      vertex 149.544 -153.59 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.649 -153.408 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.649 -158.408 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.741 -158.22 -3
+      vertex 149.649 -153.408 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.741 -153.22 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.741 -158.22 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.819 -158.026 -3
+      vertex 149.741 -153.22 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.819 -153.026 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.819 -158.026 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.884 -157.827 -3
+      vertex 149.819 -153.026 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.884 -152.827 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.884 -157.827 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.934 -157.624 -3
+      vertex 149.884 -152.827 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.934 -152.624 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.934 -157.624 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.971 -157.418 -3
+      vertex 149.934 -152.624 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.971 -152.418 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.971 -157.418 -3
-      vertex 152.002 -159.998 -3
-      vertex 154.993 -157.209 -3
+      vertex 149.971 -152.418 -3
+      vertex 147.002 -154.998 -3
+      vertex 149.993 -152.209 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 154.993 -157.209 -3
-      vertex 152.002 -159.998 -3
-      vertex 155 -157 -3
+      vertex 149.993 -152.209 -3
+      vertex 147.002 -154.998 -3
+      vertex 150 -152 -3
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 152 160 -3
-      vertex 152.002 159.998 -3
-      vertex -152.002 159.998 -3
+      vertex 147 155 -3
+      vertex 147.002 154.998 -3
+      vertex -147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 154.971 157.418 -3
-      vertex 154.993 157.209 -3
+      vertex 147.002 154.998 -3
+      vertex 149.971 152.418 -3
+      vertex 149.993 152.209 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 154.884 157.827 -3
-      vertex 154.934 157.624 -3
-      vertex 152.002 159.998 -3
+      vertex 149.884 152.827 -3
+      vertex 149.934 152.624 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 154.741 158.22 -3
-      vertex 152.002 159.998 -3
-      vertex 154.649 158.408 -3
+      vertex 149.741 153.22 -3
+      vertex 147.002 154.998 -3
+      vertex 149.649 153.408 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 154.741 158.22 -3
-      vertex 154.819 158.026 -3
-      vertex 152.002 159.998 -3
+      vertex 149.741 153.22 -3
+      vertex 149.819 153.026 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 154.007 159.229 -3
-      vertex 154.158 159.084 -3
+      vertex 147.002 154.998 -3
+      vertex 149.007 154.229 -3
+      vertex 149.158 154.084 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 154.427 158.763 -3
-      vertex 152.002 159.998 -3
-      vertex 154.298 158.928 -3
+      vertex 149.427 153.763 -3
+      vertex 147.002 154.998 -3
+      vertex 149.298 153.928 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 154.427 158.763 -3
-      vertex 154.544 158.59 -3
-      vertex 152.002 159.998 -3
+      vertex 149.427 153.763 -3
+      vertex 149.544 153.59 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 154.298 158.928 -3
-      vertex 152.002 159.998 -3
-      vertex 154.158 159.084 -3
+      vertex 149.298 153.928 -3
+      vertex 147.002 154.998 -3
+      vertex 149.158 154.084 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 152.927 159.853 -3
-      vertex 153.124 159.782 -3
+      vertex 147.002 154.998 -3
+      vertex 147.927 154.853 -3
+      vertex 148.124 154.782 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 153.847 159.364 -3
-      vertex 152.002 159.998 -3
-      vertex 153.678 159.487 -3
+      vertex 148.847 154.364 -3
+      vertex 147.002 154.998 -3
+      vertex 148.678 154.487 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 153.847 159.364 -3
-      vertex 154.007 159.229 -3
-      vertex 152.002 159.998 -3
+      vertex 148.847 154.364 -3
+      vertex 149.007 154.229 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 153.678 159.487 -3
-      vertex 152.002 159.998 -3
-      vertex 153.5 159.598 -3
+      vertex 148.678 154.487 -3
+      vertex 147.002 154.998 -3
+      vertex 148.5 154.598 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 153.5 159.598 -3
-      vertex 152.002 159.998 -3
-      vertex 153.315 159.696 -3
+      vertex 148.5 154.598 -3
+      vertex 147.002 154.998 -3
+      vertex 148.315 154.696 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 153.315 159.696 -3
-      vertex 152.002 159.998 -3
-      vertex 153.124 159.782 -3
+      vertex 148.315 154.696 -3
+      vertex 147.002 154.998 -3
+      vertex 148.124 154.782 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 154.649 158.408 -3
-      vertex 152.002 159.998 -3
-      vertex 154.544 158.59 -3
+      vertex 149.649 153.408 -3
+      vertex 147.002 154.998 -3
+      vertex 149.544 153.59 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.726 159.911 -3
-      vertex 152.002 159.998 -3
-      vertex 152.521 159.954 -3
+      vertex 147.726 154.911 -3
+      vertex 147.002 154.998 -3
+      vertex 147.521 154.954 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 152.726 159.911 -3
-      vertex 152.927 159.853 -3
-      vertex 152.002 159.998 -3
+      vertex 147.726 154.911 -3
+      vertex 147.927 154.853 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 154.819 158.026 -3
-      vertex 154.884 157.827 -3
-      vertex 152.002 159.998 -3
+      vertex 149.819 153.026 -3
+      vertex 149.884 152.827 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal -0 -0 -1
     outer loop
-      vertex 152.314 159.984 -3
-      vertex 152.521 159.954 -3
-      vertex 152.002 159.998 -3
+      vertex 147.314 154.984 -3
+      vertex 147.521 154.954 -3
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 154.934 157.624 -3
-      vertex 154.971 157.418 -3
+      vertex 147.002 154.998 -3
+      vertex 149.934 152.624 -3
+      vertex 149.971 152.418 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 152.105 159.998 -3
-      vertex 152.314 159.984 -3
+      vertex 147.002 154.998 -3
+      vertex 147.105 154.998 -3
+      vertex 147.314 154.984 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 155 157 -3
-      vertex 152.002 159.998 -3
-      vertex 154.993 157.209 -3
+      vertex 150 152 -3
+      vertex 147.002 154.998 -3
+      vertex 149.993 152.209 -3
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex -152 160 -3
-      vertex 152 160 -3
-      vertex -152.002 159.998 -3
+      vertex -147 155 -3
+      vertex 147 155 -3
+      vertex -147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 155 157 -3
-      vertex -155 157 -3
+      vertex 147.002 154.998 -3
+      vertex 150 152 -3
+      vertex -150 152 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -155 157 -3
-      vertex 155 157 -3
-      vertex 155 -157 -3
+      vertex -150 152 -3
+      vertex 150 152 -3
+      vertex 150 -152 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -155 157 -3
-      vertex -154.993 157.209 -3
-      vertex -152.002 159.998 -3
+      vertex -150 152 -3
+      vertex -149.993 152.209 -3
+      vertex -147.002 154.998 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152.314 159.984 -3
-      vertex -152.105 159.998 -3
+      vertex -147.002 154.998 -3
+      vertex -147.314 154.984 -3
+      vertex -147.105 154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152.521 159.954 -3
-      vertex -152.314 159.984 -3
+      vertex -147.002 154.998 -3
+      vertex -147.521 154.954 -3
+      vertex -147.314 154.984 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152.726 159.911 -3
-      vertex -152.521 159.954 -3
+      vertex -147.002 154.998 -3
+      vertex -147.726 154.911 -3
+      vertex -147.521 154.954 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152.927 159.853 -3
-      vertex -152.726 159.911 -3
+      vertex -147.002 154.998 -3
+      vertex -147.927 154.853 -3
+      vertex -147.726 154.911 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -153.124 159.782 -3
-      vertex -152.927 159.853 -3
+      vertex -147.002 154.998 -3
+      vertex -148.124 154.782 -3
+      vertex -147.927 154.853 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -153.315 159.696 -3
-      vertex -153.124 159.782 -3
+      vertex -147.002 154.998 -3
+      vertex -148.315 154.696 -3
+      vertex -148.124 154.782 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -153.5 159.598 -3
-      vertex -153.315 159.696 -3
+      vertex -147.002 154.998 -3
+      vertex -148.5 154.598 -3
+      vertex -148.315 154.696 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -153.678 159.487 -3
-      vertex -153.5 159.598 -3
+      vertex -147.002 154.998 -3
+      vertex -148.678 154.487 -3
+      vertex -148.5 154.598 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -153.847 159.364 -3
-      vertex -153.678 159.487 -3
+      vertex -147.002 154.998 -3
+      vertex -148.847 154.364 -3
+      vertex -148.678 154.487 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.007 159.229 -3
-      vertex -153.847 159.364 -3
+      vertex -147.002 154.998 -3
+      vertex -149.007 154.229 -3
+      vertex -148.847 154.364 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.158 159.084 -3
-      vertex -154.007 159.229 -3
+      vertex -147.002 154.998 -3
+      vertex -149.158 154.084 -3
+      vertex -149.007 154.229 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.298 158.928 -3
-      vertex -154.158 159.084 -3
+      vertex -147.002 154.998 -3
+      vertex -149.298 153.928 -3
+      vertex -149.158 154.084 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.427 158.763 -3
-      vertex -154.298 158.928 -3
+      vertex -147.002 154.998 -3
+      vertex -149.427 153.763 -3
+      vertex -149.298 153.928 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.544 158.59 -3
-      vertex -154.427 158.763 -3
+      vertex -147.002 154.998 -3
+      vertex -149.544 153.59 -3
+      vertex -149.427 153.763 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.649 158.408 -3
-      vertex -154.544 158.59 -3
+      vertex -147.002 154.998 -3
+      vertex -149.649 153.408 -3
+      vertex -149.544 153.59 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.741 158.22 -3
-      vertex -154.649 158.408 -3
+      vertex -147.002 154.998 -3
+      vertex -149.741 153.22 -3
+      vertex -149.649 153.408 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.819 158.026 -3
-      vertex -154.741 158.22 -3
+      vertex -147.002 154.998 -3
+      vertex -149.819 153.026 -3
+      vertex -149.741 153.22 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.884 157.827 -3
-      vertex -154.819 158.026 -3
+      vertex -147.002 154.998 -3
+      vertex -149.884 152.827 -3
+      vertex -149.819 153.026 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.934 157.624 -3
-      vertex -154.884 157.827 -3
+      vertex -147.002 154.998 -3
+      vertex -149.934 152.624 -3
+      vertex -149.884 152.827 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.971 157.418 -3
-      vertex -154.934 157.624 -3
+      vertex -147.002 154.998 -3
+      vertex -149.971 152.418 -3
+      vertex -149.934 152.624 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -154.993 157.209 -3
-      vertex -154.971 157.418 -3
+      vertex -147.002 154.998 -3
+      vertex -149.993 152.209 -3
+      vertex -149.971 152.418 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -155 -157 -3
-      vertex -155 157 -3
-      vertex 155 -157 -3
+      vertex -150 -152 -3
+      vertex -150 152 -3
+      vertex 150 -152 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 -159.998 -3
-      vertex -155 -157 -3
-      vertex 155 -157 -3
+      vertex 147.002 -154.998 -3
+      vertex -150 -152 -3
+      vertex 150 -152 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 152.002 -159.998 -3
-      vertex -152.002 -159.998 -3
-      vertex -155 -157 -3
+      vertex 147.002 -154.998 -3
+      vertex -147.002 -154.998 -3
+      vertex -150 -152 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -154.971 -157.418 -3
-      vertex -154.993 -157.209 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.971 -152.418 -3
+      vertex -149.993 -152.209 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.884 -157.827 -3
-      vertex -154.934 -157.624 -3
-      vertex -152.002 -159.998 -3
+      vertex -149.884 -152.827 -3
+      vertex -149.934 -152.624 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.741 -158.22 -3
-      vertex -152.002 -159.998 -3
-      vertex -154.649 -158.408 -3
+      vertex -149.741 -153.22 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.649 -153.408 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.741 -158.22 -3
-      vertex -154.819 -158.026 -3
-      vertex -152.002 -159.998 -3
+      vertex -149.741 -153.22 -3
+      vertex -149.819 -153.026 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -154.007 -159.229 -3
-      vertex -154.158 -159.084 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.007 -154.229 -3
+      vertex -149.158 -154.084 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.427 -158.763 -3
-      vertex -152.002 -159.998 -3
-      vertex -154.298 -158.928 -3
+      vertex -149.427 -153.763 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.298 -153.928 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.427 -158.763 -3
-      vertex -154.544 -158.59 -3
-      vertex -152.002 -159.998 -3
+      vertex -149.427 -153.763 -3
+      vertex -149.544 -153.59 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.298 -158.928 -3
-      vertex -152.002 -159.998 -3
-      vertex -154.158 -159.084 -3
+      vertex -149.298 -153.928 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.158 -154.084 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -152.927 -159.853 -3
-      vertex -153.124 -159.782 -3
+      vertex -147.002 -154.998 -3
+      vertex -147.927 -154.853 -3
+      vertex -148.124 -154.782 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -153.847 -159.364 -3
-      vertex -152.002 -159.998 -3
-      vertex -153.678 -159.487 -3
+      vertex -148.847 -154.364 -3
+      vertex -147.002 -154.998 -3
+      vertex -148.678 -154.487 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -153.847 -159.364 -3
-      vertex -154.007 -159.229 -3
-      vertex -152.002 -159.998 -3
+      vertex -148.847 -154.364 -3
+      vertex -149.007 -154.229 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -153.678 -159.487 -3
-      vertex -152.002 -159.998 -3
-      vertex -153.5 -159.598 -3
+      vertex -148.678 -154.487 -3
+      vertex -147.002 -154.998 -3
+      vertex -148.5 -154.598 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -153.5 -159.598 -3
-      vertex -152.002 -159.998 -3
-      vertex -153.315 -159.696 -3
+      vertex -148.5 -154.598 -3
+      vertex -147.002 -154.998 -3
+      vertex -148.315 -154.696 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -153.315 -159.696 -3
-      vertex -152.002 -159.998 -3
-      vertex -153.124 -159.782 -3
+      vertex -148.315 -154.696 -3
+      vertex -147.002 -154.998 -3
+      vertex -148.124 -154.782 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.649 -158.408 -3
-      vertex -152.002 -159.998 -3
-      vertex -154.544 -158.59 -3
+      vertex -149.649 -153.408 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.544 -153.59 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.726 -159.911 -3
-      vertex -152.002 -159.998 -3
-      vertex -152.521 -159.954 -3
+      vertex -147.726 -154.911 -3
+      vertex -147.002 -154.998 -3
+      vertex -147.521 -154.954 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.726 -159.911 -3
-      vertex -152.927 -159.853 -3
-      vertex -152.002 -159.998 -3
+      vertex -147.726 -154.911 -3
+      vertex -147.927 -154.853 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -154.819 -158.026 -3
-      vertex -154.884 -157.827 -3
-      vertex -152.002 -159.998 -3
+      vertex -149.819 -153.026 -3
+      vertex -149.884 -152.827 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.314 -159.984 -3
-      vertex -152.521 -159.954 -3
-      vertex -152.002 -159.998 -3
+      vertex -147.314 -154.984 -3
+      vertex -147.521 -154.954 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -154.934 -157.624 -3
-      vertex -154.971 -157.418 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.934 -152.624 -3
+      vertex -149.971 -152.418 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -152.105 -159.998 -3
-      vertex -152.314 -159.984 -3
+      vertex -147.002 -154.998 -3
+      vertex -147.105 -154.998 -3
+      vertex -147.314 -154.984 -3
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 152.002 -159.998 -3
-      vertex 152 -160 -3
-      vertex -152.002 -159.998 -3
+      vertex 147.002 -154.998 -3
+      vertex 147 -155 -3
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex 152 -160 -3
-      vertex -152 -160 -3
+      vertex -147.002 -154.998 -3
+      vertex 147 -155 -3
+      vertex -147 -155 -3
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -155 -157 -3
-      vertex -152.002 -159.998 -3
-      vertex -154.993 -157.209 -3
+      vertex -150 -152 -3
+      vertex -147.002 -154.998 -3
+      vertex -149.993 -152.209 -3
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.314 -159.984 0
-      vertex 152.002 -159.998 0
-      vertex 152.105 -159.998 0
+      vertex 147.314 -154.984 0
+      vertex 147.002 -154.998 0
+      vertex 147.105 -154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.521 -159.954 0
-      vertex 152.002 -159.998 0
-      vertex 152.314 -159.984 0
+      vertex 147.521 -154.954 0
+      vertex 147.002 -154.998 0
+      vertex 147.314 -154.984 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -155 157 0
-      vertex 152.002 159.998 0
-      vertex -152.002 159.998 0
+      vertex -150 152 0
+      vertex 147.002 154.998 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.726 -159.911 0
-      vertex 152.002 -159.998 0
-      vertex 152.521 -159.954 0
+      vertex 147.726 -154.911 0
+      vertex 147.002 -154.998 0
+      vertex 147.521 -154.954 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.927 -159.853 0
-      vertex 152.002 -159.998 0
-      vertex 152.726 -159.911 0
+      vertex 147.927 -154.853 0
+      vertex 147.002 -154.998 0
+      vertex 147.726 -154.911 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.124 -159.782 0
-      vertex 152.002 -159.998 0
-      vertex 152.927 -159.853 0
+      vertex 148.124 -154.782 0
+      vertex 147.002 -154.998 0
+      vertex 147.927 -154.853 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.315 -159.696 0
-      vertex 152.002 -159.998 0
-      vertex 153.124 -159.782 0
+      vertex 148.315 -154.696 0
+      vertex 147.002 -154.998 0
+      vertex 148.124 -154.782 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.5 -159.598 0
-      vertex 152.002 -159.998 0
-      vertex 153.315 -159.696 0
+      vertex 148.5 -154.598 0
+      vertex 147.002 -154.998 0
+      vertex 148.315 -154.696 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.678 -159.487 0
-      vertex 152.002 -159.998 0
-      vertex 153.5 -159.598 0
+      vertex 148.678 -154.487 0
+      vertex 147.002 -154.998 0
+      vertex 148.5 -154.598 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.847 -159.364 0
-      vertex 152.002 -159.998 0
-      vertex 153.678 -159.487 0
+      vertex 148.847 -154.364 0
+      vertex 147.002 -154.998 0
+      vertex 148.678 -154.487 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.007 -159.229 0
-      vertex 152.002 -159.998 0
-      vertex 153.847 -159.364 0
+      vertex 149.007 -154.229 0
+      vertex 147.002 -154.998 0
+      vertex 148.847 -154.364 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.158 -159.084 0
-      vertex 152.002 -159.998 0
-      vertex 154.007 -159.229 0
+      vertex 149.158 -154.084 0
+      vertex 147.002 -154.998 0
+      vertex 149.007 -154.229 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.298 -158.928 0
-      vertex 152.002 -159.998 0
-      vertex 154.158 -159.084 0
+      vertex 149.298 -153.928 0
+      vertex 147.002 -154.998 0
+      vertex 149.158 -154.084 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.427 -158.763 0
-      vertex 152.002 -159.998 0
-      vertex 154.298 -158.928 0
+      vertex 149.427 -153.763 0
+      vertex 147.002 -154.998 0
+      vertex 149.298 -153.928 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.544 -158.59 0
-      vertex 152.002 -159.998 0
-      vertex 154.427 -158.763 0
+      vertex 149.544 -153.59 0
+      vertex 147.002 -154.998 0
+      vertex 149.427 -153.763 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.649 -158.408 0
-      vertex 152.002 -159.998 0
-      vertex 154.544 -158.59 0
+      vertex 149.649 -153.408 0
+      vertex 147.002 -154.998 0
+      vertex 149.544 -153.59 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.741 -158.22 0
-      vertex 152.002 -159.998 0
-      vertex 154.649 -158.408 0
+      vertex 149.741 -153.22 0
+      vertex 147.002 -154.998 0
+      vertex 149.649 -153.408 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.819 -158.026 0
-      vertex 152.002 -159.998 0
-      vertex 154.741 -158.22 0
+      vertex 149.819 -153.026 0
+      vertex 147.002 -154.998 0
+      vertex 149.741 -153.22 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.884 -157.827 0
-      vertex 152.002 -159.998 0
-      vertex 154.819 -158.026 0
+      vertex 149.884 -152.827 0
+      vertex 147.002 -154.998 0
+      vertex 149.819 -153.026 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.934 -157.624 0
-      vertex 152.002 -159.998 0
-      vertex 154.884 -157.827 0
+      vertex 149.934 -152.624 0
+      vertex 147.002 -154.998 0
+      vertex 149.884 -152.827 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.971 -157.418 0
-      vertex 152.002 -159.998 0
-      vertex 154.934 -157.624 0
+      vertex 149.971 -152.418 0
+      vertex 147.002 -154.998 0
+      vertex 149.934 -152.624 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.993 -157.209 0
-      vertex 152.002 -159.998 0
-      vertex 154.971 -157.418 0
+      vertex 149.993 -152.209 0
+      vertex 147.002 -154.998 0
+      vertex 149.971 -152.418 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 155 -157 0
-      vertex 152.002 -159.998 0
-      vertex 154.993 -157.209 0
+      vertex 150 -152 0
+      vertex 147.002 -154.998 0
+      vertex 149.993 -152.209 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 159.998 0
-      vertex 152.002 159.998 0
-      vertex 152 160 0
+      vertex -147.002 154.998 0
+      vertex 147.002 154.998 0
+      vertex 147 155 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.993 157.209 0
-      vertex 154.971 157.418 0
-      vertex 152.002 159.998 0
+      vertex 149.993 152.209 0
+      vertex 149.971 152.418 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 154.934 157.624 0
-      vertex 154.884 157.827 0
+      vertex 147.002 154.998 0
+      vertex 149.934 152.624 0
+      vertex 149.884 152.827 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.649 158.408 0
-      vertex 152.002 159.998 0
-      vertex 154.741 158.22 0
+      vertex 149.649 153.408 0
+      vertex 147.002 154.998 0
+      vertex 149.741 153.22 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 154.819 158.026 0
-      vertex 154.741 158.22 0
+      vertex 147.002 154.998 0
+      vertex 149.819 153.026 0
+      vertex 149.741 153.22 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.158 159.084 0
-      vertex 154.007 159.229 0
-      vertex 152.002 159.998 0
+      vertex 149.158 154.084 0
+      vertex 149.007 154.229 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.298 158.928 0
-      vertex 152.002 159.998 0
-      vertex 154.427 158.763 0
+      vertex 149.298 153.928 0
+      vertex 147.002 154.998 0
+      vertex 149.427 153.763 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 154.544 158.59 0
-      vertex 154.427 158.763 0
+      vertex 147.002 154.998 0
+      vertex 149.544 153.59 0
+      vertex 149.427 153.763 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.158 159.084 0
-      vertex 152.002 159.998 0
-      vertex 154.298 158.928 0
+      vertex 149.158 154.084 0
+      vertex 147.002 154.998 0
+      vertex 149.298 153.928 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.124 159.782 0
-      vertex 152.927 159.853 0
-      vertex 152.002 159.998 0
+      vertex 148.124 154.782 0
+      vertex 147.927 154.853 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.678 159.487 0
-      vertex 152.002 159.998 0
-      vertex 153.847 159.364 0
+      vertex 148.678 154.487 0
+      vertex 147.002 154.998 0
+      vertex 148.847 154.364 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 154.007 159.229 0
-      vertex 153.847 159.364 0
+      vertex 147.002 154.998 0
+      vertex 149.007 154.229 0
+      vertex 148.847 154.364 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.5 159.598 0
-      vertex 152.002 159.998 0
-      vertex 153.678 159.487 0
+      vertex 148.5 154.598 0
+      vertex 147.002 154.998 0
+      vertex 148.678 154.487 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.315 159.696 0
-      vertex 152.002 159.998 0
-      vertex 153.5 159.598 0
+      vertex 148.315 154.696 0
+      vertex 147.002 154.998 0
+      vertex 148.5 154.598 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 153.124 159.782 0
-      vertex 152.002 159.998 0
-      vertex 153.315 159.696 0
+      vertex 148.124 154.782 0
+      vertex 147.002 154.998 0
+      vertex 148.315 154.696 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.544 158.59 0
-      vertex 152.002 159.998 0
-      vertex 154.649 158.408 0
+      vertex 149.544 153.59 0
+      vertex 147.002 154.998 0
+      vertex 149.649 153.408 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.521 159.954 0
-      vertex 152.002 159.998 0
-      vertex 152.726 159.911 0
+      vertex 147.521 154.954 0
+      vertex 147.002 154.998 0
+      vertex 147.726 154.911 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 152.927 159.853 0
-      vertex 152.726 159.911 0
+      vertex 147.002 154.998 0
+      vertex 147.927 154.853 0
+      vertex 147.726 154.911 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 154.884 157.827 0
-      vertex 154.819 158.026 0
+      vertex 147.002 154.998 0
+      vertex 149.884 152.827 0
+      vertex 149.819 153.026 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.002 159.998 0
-      vertex 152.521 159.954 0
-      vertex 152.314 159.984 0
+      vertex 147.002 154.998 0
+      vertex 147.521 154.954 0
+      vertex 147.314 154.984 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.971 157.418 0
-      vertex 154.934 157.624 0
-      vertex 152.002 159.998 0
+      vertex 149.971 152.418 0
+      vertex 149.934 152.624 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 152.314 159.984 0
-      vertex 152.105 159.998 0
-      vertex 152.002 159.998 0
+      vertex 147.314 154.984 0
+      vertex 147.105 154.998 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 154.993 157.209 0
-      vertex 152.002 159.998 0
-      vertex 155 157 0
+      vertex 149.993 152.209 0
+      vertex 147.002 154.998 0
+      vertex 150 152 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 159.998 0
-      vertex 152 160 0
-      vertex -152 160 0
+      vertex -147.002 154.998 0
+      vertex 147 155 0
+      vertex -147 155 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -155 157 0
-      vertex 155 157 0
-      vertex 152.002 159.998 0
+      vertex -150 152 0
+      vertex 150 152 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 155 -157 0
-      vertex 155 157 0
-      vertex -155 157 0
+      vertex 150 -152 0
+      vertex 150 152 0
+      vertex -150 152 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 159.998 0
-      vertex -154.993 157.209 0
-      vertex -155 157 0
+      vertex -147.002 154.998 0
+      vertex -149.993 152.209 0
+      vertex -150 152 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.105 159.998 0
-      vertex -152.314 159.984 0
-      vertex -152.002 159.998 0
+      vertex -147.105 154.998 0
+      vertex -147.314 154.984 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.314 159.984 0
-      vertex -152.521 159.954 0
-      vertex -152.002 159.998 0
+      vertex -147.314 154.984 0
+      vertex -147.521 154.954 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.521 159.954 0
-      vertex -152.726 159.911 0
-      vertex -152.002 159.998 0
+      vertex -147.521 154.954 0
+      vertex -147.726 154.911 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.726 159.911 0
-      vertex -152.927 159.853 0
-      vertex -152.002 159.998 0
+      vertex -147.726 154.911 0
+      vertex -147.927 154.853 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.927 159.853 0
-      vertex -153.124 159.782 0
-      vertex -152.002 159.998 0
+      vertex -147.927 154.853 0
+      vertex -148.124 154.782 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -153.124 159.782 0
-      vertex -153.315 159.696 0
-      vertex -152.002 159.998 0
+      vertex -148.124 154.782 0
+      vertex -148.315 154.696 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -153.315 159.696 0
-      vertex -153.5 159.598 0
-      vertex -152.002 159.998 0
+      vertex -148.315 154.696 0
+      vertex -148.5 154.598 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -153.5 159.598 0
-      vertex -153.678 159.487 0
-      vertex -152.002 159.998 0
+      vertex -148.5 154.598 0
+      vertex -148.678 154.487 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -153.678 159.487 0
-      vertex -153.847 159.364 0
-      vertex -152.002 159.998 0
+      vertex -148.678 154.487 0
+      vertex -148.847 154.364 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -153.847 159.364 0
-      vertex -154.007 159.229 0
-      vertex -152.002 159.998 0
+      vertex -148.847 154.364 0
+      vertex -149.007 154.229 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.007 159.229 0
-      vertex -154.158 159.084 0
-      vertex -152.002 159.998 0
+      vertex -149.007 154.229 0
+      vertex -149.158 154.084 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.158 159.084 0
-      vertex -154.298 158.928 0
-      vertex -152.002 159.998 0
+      vertex -149.158 154.084 0
+      vertex -149.298 153.928 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.298 158.928 0
-      vertex -154.427 158.763 0
-      vertex -152.002 159.998 0
+      vertex -149.298 153.928 0
+      vertex -149.427 153.763 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.427 158.763 0
-      vertex -154.544 158.59 0
-      vertex -152.002 159.998 0
+      vertex -149.427 153.763 0
+      vertex -149.544 153.59 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.544 158.59 0
-      vertex -154.649 158.408 0
-      vertex -152.002 159.998 0
+      vertex -149.544 153.59 0
+      vertex -149.649 153.408 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.649 158.408 0
-      vertex -154.741 158.22 0
-      vertex -152.002 159.998 0
+      vertex -149.649 153.408 0
+      vertex -149.741 153.22 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.741 158.22 0
-      vertex -154.819 158.026 0
-      vertex -152.002 159.998 0
+      vertex -149.741 153.22 0
+      vertex -149.819 153.026 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.819 158.026 0
-      vertex -154.884 157.827 0
-      vertex -152.002 159.998 0
+      vertex -149.819 153.026 0
+      vertex -149.884 152.827 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.884 157.827 0
-      vertex -154.934 157.624 0
-      vertex -152.002 159.998 0
+      vertex -149.884 152.827 0
+      vertex -149.934 152.624 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.934 157.624 0
-      vertex -154.971 157.418 0
-      vertex -152.002 159.998 0
+      vertex -149.934 152.624 0
+      vertex -149.971 152.418 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -154.971 157.418 0
-      vertex -154.993 157.209 0
-      vertex -152.002 159.998 0
+      vertex -149.971 152.418 0
+      vertex -149.993 152.209 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 155 -157 0
-      vertex -155 157 0
-      vertex -155 -157 0
+      vertex 150 -152 0
+      vertex -150 152 0
+      vertex -150 -152 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 155 -157 0
-      vertex -155 -157 0
-      vertex 152.002 -159.998 0
+      vertex 150 -152 0
+      vertex -150 -152 0
+      vertex 147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -155 -157 0
-      vertex -152.002 -159.998 0
-      vertex 152.002 -159.998 0
+      vertex -150 -152 0
+      vertex -147.002 -154.998 0
+      vertex 147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -154.993 -157.209 0
-      vertex -154.971 -157.418 0
-      vertex -152.002 -159.998 0
+      vertex -149.993 -152.209 0
+      vertex -149.971 -152.418 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -154.934 -157.624 0
-      vertex -154.884 -157.827 0
+      vertex -147.002 -154.998 0
+      vertex -149.934 -152.624 0
+      vertex -149.884 -152.827 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -154.649 -158.408 0
-      vertex -152.002 -159.998 0
-      vertex -154.741 -158.22 0
+      vertex -149.649 -153.408 0
+      vertex -147.002 -154.998 0
+      vertex -149.741 -153.22 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -154.819 -158.026 0
-      vertex -154.741 -158.22 0
+      vertex -147.002 -154.998 0
+      vertex -149.819 -153.026 0
+      vertex -149.741 -153.22 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -154.158 -159.084 0
-      vertex -154.007 -159.229 0
-      vertex -152.002 -159.998 0
+      vertex -149.158 -154.084 0
+      vertex -149.007 -154.229 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -154.298 -158.928 0
-      vertex -152.002 -159.998 0
-      vertex -154.427 -158.763 0
+      vertex -149.298 -153.928 0
+      vertex -147.002 -154.998 0
+      vertex -149.427 -153.763 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -154.544 -158.59 0
-      vertex -154.427 -158.763 0
+      vertex -147.002 -154.998 0
+      vertex -149.544 -153.59 0
+      vertex -149.427 -153.763 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -154.158 -159.084 0
-      vertex -152.002 -159.998 0
-      vertex -154.298 -158.928 0
+      vertex -149.158 -154.084 0
+      vertex -147.002 -154.998 0
+      vertex -149.298 -153.928 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -153.124 -159.782 0
-      vertex -152.927 -159.853 0
-      vertex -152.002 -159.998 0
+      vertex -148.124 -154.782 0
+      vertex -147.927 -154.853 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -153.678 -159.487 0
-      vertex -152.002 -159.998 0
-      vertex -153.847 -159.364 0
+      vertex -148.678 -154.487 0
+      vertex -147.002 -154.998 0
+      vertex -148.847 -154.364 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -154.007 -159.229 0
-      vertex -153.847 -159.364 0
+      vertex -147.002 -154.998 0
+      vertex -149.007 -154.229 0
+      vertex -148.847 -154.364 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -153.5 -159.598 0
-      vertex -152.002 -159.998 0
-      vertex -153.678 -159.487 0
+      vertex -148.5 -154.598 0
+      vertex -147.002 -154.998 0
+      vertex -148.678 -154.487 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -153.315 -159.696 0
-      vertex -152.002 -159.998 0
-      vertex -153.5 -159.598 0
+      vertex -148.315 -154.696 0
+      vertex -147.002 -154.998 0
+      vertex -148.5 -154.598 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -153.124 -159.782 0
-      vertex -152.002 -159.998 0
-      vertex -153.315 -159.696 0
+      vertex -148.124 -154.782 0
+      vertex -147.002 -154.998 0
+      vertex -148.315 -154.696 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -154.544 -158.59 0
-      vertex -152.002 -159.998 0
-      vertex -154.649 -158.408 0
+      vertex -149.544 -153.59 0
+      vertex -147.002 -154.998 0
+      vertex -149.649 -153.408 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -152.521 -159.954 0
-      vertex -152.002 -159.998 0
-      vertex -152.726 -159.911 0
+      vertex -147.521 -154.954 0
+      vertex -147.002 -154.998 0
+      vertex -147.726 -154.911 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -152.927 -159.853 0
-      vertex -152.726 -159.911 0
+      vertex -147.002 -154.998 0
+      vertex -147.927 -154.853 0
+      vertex -147.726 -154.911 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -154.884 -157.827 0
-      vertex -154.819 -158.026 0
+      vertex -147.002 -154.998 0
+      vertex -149.884 -152.827 0
+      vertex -149.819 -153.026 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex -152.521 -159.954 0
-      vertex -152.314 -159.984 0
+      vertex -147.002 -154.998 0
+      vertex -147.521 -154.954 0
+      vertex -147.314 -154.984 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -154.971 -157.418 0
-      vertex -154.934 -157.624 0
-      vertex -152.002 -159.998 0
+      vertex -149.971 -152.418 0
+      vertex -149.934 -152.624 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -152.314 -159.984 0
-      vertex -152.105 -159.998 0
-      vertex -152.002 -159.998 0
+      vertex -147.314 -154.984 0
+      vertex -147.105 -154.998 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -152.002 -159.998 0
-      vertex 152 -160 0
-      vertex 152.002 -159.998 0
+      vertex -147.002 -154.998 0
+      vertex 147 -155 0
+      vertex 147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex -152 -160 0
-      vertex 152 -160 0
-      vertex -152.002 -159.998 0
+      vertex -147 -155 0
+      vertex 147 -155 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal -0 -0 1
     outer loop
-      vertex -154.993 -157.209 0
-      vertex -152.002 -159.998 0
-      vertex -155 -157 0
+      vertex -149.993 -152.209 0
+      vertex -147.002 -154.998 0
+      vertex -150 -152 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 152.105 -159.998 -3
-      vertex 152.002 -159.998 0
-      vertex 152.002 -159.998 -3
+      vertex 147.105 -154.998 -3
+      vertex 147.002 -154.998 0
+      vertex 147.002 -154.998 -3
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 152.105 -159.998 -3
-      vertex 152.105 -159.998 0
-      vertex 152.002 -159.998 0
+      vertex 147.105 -154.998 -3
+      vertex 147.105 -154.998 0
+      vertex 147.002 -154.998 0
     endloop
   endfacet
   facet normal 0.0668359 -0.997764 0
     outer loop
-      vertex 152.314 -159.984 -3
-      vertex 152.105 -159.998 0
-      vertex 152.105 -159.998 -3
+      vertex 147.314 -154.984 -3
+      vertex 147.105 -154.998 0
+      vertex 147.105 -154.998 -3
     endloop
   endfacet
   facet normal 0.0668359 -0.997764 0
     outer loop
-      vertex 152.314 -159.984 -3
-      vertex 152.314 -159.984 0
-      vertex 152.105 -159.998 0
+      vertex 147.314 -154.984 -3
+      vertex 147.314 -154.984 0
+      vertex 147.105 -154.998 0
     endloop
   endfacet
   facet normal 0.143429 -0.989661 0
     outer loop
-      vertex 152.521 -159.954 -3
-      vertex 152.314 -159.984 0
-      vertex 152.314 -159.984 -3
+      vertex 147.521 -154.954 -3
+      vertex 147.314 -154.984 0
+      vertex 147.314 -154.984 -3
     endloop
   endfacet
   facet normal 0.143429 -0.989661 0
     outer loop
-      vertex 152.521 -159.954 -3
-      vertex 152.521 -159.954 0
-      vertex 152.314 -159.984 0
+      vertex 147.521 -154.954 -3
+      vertex 147.521 -154.954 0
+      vertex 147.314 -154.984 0
     endloop
   endfacet
   facet normal 0.205289 -0.978701 0
     outer loop
-      vertex 152.726 -159.911 -3
-      vertex 152.521 -159.954 0
-      vertex 152.521 -159.954 -3
+      vertex 147.726 -154.911 -3
+      vertex 147.521 -154.954 0
+      vertex 147.521 -154.954 -3
     endloop
   endfacet
   facet normal 0.205289 -0.978701 0
     outer loop
-      vertex 152.726 -159.911 -3
-      vertex 152.726 -159.911 0
-      vertex 152.521 -159.954 0
+      vertex 147.726 -154.911 -3
+      vertex 147.726 -154.911 0
+      vertex 147.521 -154.954 0
     endloop
   endfacet
   facet normal 0.277246 -0.960799 0
     outer loop
-      vertex 152.927 -159.853 -3
-      vertex 152.726 -159.911 0
-      vertex 152.726 -159.911 -3
+      vertex 147.927 -154.853 -3
+      vertex 147.726 -154.911 0
+      vertex 147.726 -154.911 -3
     endloop
   endfacet
   facet normal 0.277246 -0.960799 0
     outer loop
-      vertex 152.927 -159.853 -3
-      vertex 152.927 -159.853 0
-      vertex 152.726 -159.911 0
+      vertex 147.927 -154.853 -3
+      vertex 147.927 -154.853 0
+      vertex 147.726 -154.911 0
     endloop
   endfacet
   facet normal 0.339058 -0.940766 0
     outer loop
-      vertex 153.124 -159.782 -3
-      vertex 152.927 -159.853 0
-      vertex 152.927 -159.853 -3
+      vertex 148.124 -154.782 -3
+      vertex 147.927 -154.853 0
+      vertex 147.927 -154.853 -3
     endloop
   endfacet
   facet normal 0.339058 -0.940766 0
     outer loop
-      vertex 153.124 -159.782 -3
-      vertex 153.124 -159.782 0
-      vertex 152.927 -159.853 0
+      vertex 148.124 -154.782 -3
+      vertex 148.124 -154.782 0
+      vertex 147.927 -154.853 0
     endloop
   endfacet
   facet normal 0.410563 -0.911832 0
     outer loop
-      vertex 153.315 -159.696 -3
-      vertex 153.124 -159.782 0
-      vertex 153.124 -159.782 -3
+      vertex 148.315 -154.696 -3
+      vertex 148.124 -154.782 0
+      vertex 148.124 -154.782 -3
     endloop
   endfacet
   facet normal 0.410563 -0.911832 0
     outer loop
-      vertex 153.315 -159.696 -3
-      vertex 153.315 -159.696 0
-      vertex 153.124 -159.782 0
+      vertex 148.315 -154.696 -3
+      vertex 148.315 -154.696 0
+      vertex 148.124 -154.782 0
     endloop
   endfacet
   facet normal 0.468107 -0.883672 0
     outer loop
-      vertex 153.5 -159.598 -3
-      vertex 153.315 -159.696 0
-      vertex 153.315 -159.696 -3
+      vertex 148.5 -154.598 -3
+      vertex 148.315 -154.696 0
+      vertex 148.315 -154.696 -3
     endloop
   endfacet
   facet normal 0.468107 -0.883672 0
     outer loop
-      vertex 153.5 -159.598 -3
-      vertex 153.5 -159.598 0
-      vertex 153.315 -159.696 0
+      vertex 148.5 -154.598 -3
+      vertex 148.5 -154.598 0
+      vertex 148.315 -154.696 0
     endloop
   endfacet
   facet normal 0.529142 -0.848533 0
     outer loop
-      vertex 153.678 -159.487 -3
-      vertex 153.5 -159.598 0
-      vertex 153.5 -159.598 -3
+      vertex 148.678 -154.487 -3
+      vertex 148.5 -154.598 0
+      vertex 148.5 -154.598 -3
     endloop
   endfacet
   facet normal 0.529142 -0.848533 0
     outer loop
-      vertex 153.678 -159.487 -3
-      vertex 153.678 -159.487 0
-      vertex 153.5 -159.598 0
+      vertex 148.678 -154.487 -3
+      vertex 148.678 -154.487 0
+      vertex 148.5 -154.598 0
     endloop
   endfacet
   facet normal 0.588456 -0.808529 0
     outer loop
-      vertex 153.847 -159.364 -3
-      vertex 153.678 -159.487 0
-      vertex 153.678 -159.487 -3
+      vertex 148.847 -154.364 -3
+      vertex 148.678 -154.487 0
+      vertex 148.678 -154.487 -3
     endloop
   endfacet
   facet normal 0.588456 -0.808529 0
     outer loop
-      vertex 153.847 -159.364 -3
-      vertex 153.847 -159.364 0
-      vertex 153.678 -159.487 0
+      vertex 148.847 -154.364 -3
+      vertex 148.847 -154.364 0
+      vertex 148.678 -154.487 0
     endloop
   endfacet
   facet normal 0.644871 -0.764291 0
     outer loop
-      vertex 154.007 -159.229 -3
-      vertex 153.847 -159.364 0
-      vertex 153.847 -159.364 -3
+      vertex 149.007 -154.229 -3
+      vertex 148.847 -154.364 0
+      vertex 148.847 -154.364 -3
     endloop
   endfacet
   facet normal 0.644871 -0.764291 0
     outer loop
-      vertex 154.007 -159.229 -3
-      vertex 154.007 -159.229 0
-      vertex 153.847 -159.364 0
+      vertex 149.007 -154.229 -3
+      vertex 149.007 -154.229 0
+      vertex 148.847 -154.364 0
     endloop
   endfacet
   facet normal 0.692631 -0.721292 0
     outer loop
-      vertex 154.158 -159.084 -3
-      vertex 154.007 -159.229 0
-      vertex 154.007 -159.229 -3
+      vertex 149.158 -154.084 -3
+      vertex 149.007 -154.229 0
+      vertex 149.007 -154.229 -3
     endloop
   endfacet
   facet normal 0.692631 -0.721292 0
     outer loop
-      vertex 154.158 -159.084 -3
-      vertex 154.158 -159.084 0
-      vertex 154.007 -159.229 0
+      vertex 149.158 -154.084 -3
+      vertex 149.158 -154.084 0
+      vertex 149.007 -154.229 0
     endloop
   endfacet
   facet normal 0.744242 -0.66791 0
     outer loop
-      vertex 154.298 -158.928 -3
-      vertex 154.158 -159.084 0
-      vertex 154.158 -159.084 -3
+      vertex 149.298 -153.928 -3
+      vertex 149.158 -154.084 0
+      vertex 149.158 -154.084 -3
     endloop
   endfacet
   facet normal 0.744242 -0.66791 0
     outer loop
-      vertex 154.298 -158.928 -3
-      vertex 154.298 -158.928 0
-      vertex 154.158 -159.084 0
+      vertex 149.298 -153.928 -3
+      vertex 149.298 -153.928 0
+      vertex 149.158 -154.084 0
     endloop
   endfacet
   facet normal 0.787807 -0.615922 0
     outer loop
-      vertex 154.427 -158.763 -3
-      vertex 154.298 -158.928 0
-      vertex 154.298 -158.928 -3
+      vertex 149.427 -153.763 -3
+      vertex 149.298 -153.928 0
+      vertex 149.298 -153.928 -3
     endloop
   endfacet
   facet normal 0.787807 -0.615922 0
     outer loop
-      vertex 154.427 -158.763 -3
-      vertex 154.427 -158.763 0
-      vertex 154.298 -158.928 0
+      vertex 149.427 -153.763 -3
+      vertex 149.427 -153.763 0
+      vertex 149.298 -153.928 0
     endloop
   endfacet
   facet normal 0.828349 -0.560213 0
     outer loop
-      vertex 154.544 -158.59 -3
-      vertex 154.427 -158.763 0
-      vertex 154.427 -158.763 -3
+      vertex 149.544 -153.59 -3
+      vertex 149.427 -153.763 0
+      vertex 149.427 -153.763 -3
     endloop
   endfacet
   facet normal 0.828349 -0.560213 0
     outer loop
-      vertex 154.544 -158.59 -3
-      vertex 154.544 -158.59 0
-      vertex 154.427 -158.763 0
+      vertex 149.544 -153.59 -3
+      vertex 149.544 -153.59 0
+      vertex 149.427 -153.763 0
     endloop
   endfacet
   facet normal 0.866186 -0.499722 0
     outer loop
-      vertex 154.649 -158.408 -3
-      vertex 154.544 -158.59 0
-      vertex 154.544 -158.59 -3
+      vertex 149.649 -153.408 -3
+      vertex 149.544 -153.59 0
+      vertex 149.544 -153.59 -3
     endloop
   endfacet
   facet normal 0.866186 -0.499722 0
     outer loop
-      vertex 154.649 -158.408 -3
-      vertex 154.649 -158.408 0
-      vertex 154.544 -158.59 0
+      vertex 149.649 -153.408 -3
+      vertex 149.649 -153.408 0
+      vertex 149.544 -153.59 0
     endloop
   endfacet
   facet normal 0.898217 -0.439553 0
     outer loop
-      vertex 154.741 -158.22 -3
-      vertex 154.649 -158.408 0
-      vertex 154.649 -158.408 -3
+      vertex 149.741 -153.22 -3
+      vertex 149.649 -153.408 0
+      vertex 149.649 -153.408 -3
     endloop
   endfacet
   facet normal 0.898217 -0.439553 0
     outer loop
-      vertex 154.741 -158.22 -3
-      vertex 154.741 -158.22 0
-      vertex 154.649 -158.408 0
+      vertex 149.741 -153.22 -3
+      vertex 149.741 -153.22 0
+      vertex 149.649 -153.408 0
     endloop
   endfacet
   facet normal 0.927816 -0.373039 0
     outer loop
-      vertex 154.819 -158.026 -3
-      vertex 154.741 -158.22 0
-      vertex 154.741 -158.22 -3
+      vertex 149.819 -153.026 -3
+      vertex 149.741 -153.22 0
+      vertex 149.741 -153.22 -3
     endloop
   endfacet
   facet normal 0.927816 -0.373039 0
     outer loop
-      vertex 154.819 -158.026 -3
-      vertex 154.819 -158.026 0
-      vertex 154.741 -158.22 0
+      vertex 149.819 -153.026 -3
+      vertex 149.819 -153.026 0
+      vertex 149.741 -153.22 0
     endloop
   endfacet
   facet normal 0.950577 -0.31049 0
     outer loop
-      vertex 154.884 -157.827 -3
-      vertex 154.819 -158.026 0
-      vertex 154.819 -158.026 -3
+      vertex 149.884 -152.827 -3
+      vertex 149.819 -153.026 0
+      vertex 149.819 -153.026 -3
     endloop
   endfacet
   facet normal 0.950577 -0.31049 0
     outer loop
-      vertex 154.884 -157.827 -3
-      vertex 154.884 -157.827 0
-      vertex 154.819 -158.026 0
+      vertex 149.884 -152.827 -3
+      vertex 149.884 -152.827 0
+      vertex 149.819 -153.026 0
     endloop
   endfacet
   facet normal 0.970981 -0.239158 0
     outer loop
-      vertex 154.934 -157.624 -3
-      vertex 154.884 -157.827 0
-      vertex 154.884 -157.827 -3
+      vertex 149.934 -152.624 -3
+      vertex 149.884 -152.827 0
+      vertex 149.884 -152.827 -3
     endloop
   endfacet
   facet normal 0.970981 -0.239158 0
     outer loop
-      vertex 154.934 -157.624 -3
-      vertex 154.934 -157.624 0
-      vertex 154.884 -157.827 0
+      vertex 149.934 -152.624 -3
+      vertex 149.934 -152.624 0
+      vertex 149.884 -152.827 0
     endloop
   endfacet
   facet normal 0.98425 -0.176783 0
     outer loop
-      vertex 154.971 -157.418 -3
-      vertex 154.934 -157.624 0
-      vertex 154.934 -157.624 -3
+      vertex 149.971 -152.418 -3
+      vertex 149.934 -152.624 0
+      vertex 149.934 -152.624 -3
     endloop
   endfacet
   facet normal 0.98425 -0.176783 0
     outer loop
-      vertex 154.971 -157.418 -3
-      vertex 154.971 -157.418 0
-      vertex 154.934 -157.624 0
+      vertex 149.971 -152.418 -3
+      vertex 149.971 -152.418 0
+      vertex 149.934 -152.624 0
     endloop
   endfacet
   facet normal 0.994505 -0.104685 0
     outer loop
-      vertex 154.993 -157.209 -3
-      vertex 154.971 -157.418 0
-      vertex 154.971 -157.418 -3
+      vertex 149.993 -152.209 -3
+      vertex 149.971 -152.418 0
+      vertex 149.971 -152.418 -3
     endloop
   endfacet
   facet normal 0.994505 -0.104685 0
     outer loop
-      vertex 154.993 -157.209 -3
-      vertex 154.993 -157.209 0
-      vertex 154.971 -157.418 0
+      vertex 149.993 -152.209 -3
+      vertex 149.993 -152.209 0
+      vertex 149.971 -152.418 0
     endloop
   endfacet
   facet normal 0.99944 -0.0334741 0
     outer loop
-      vertex 155 -157 -3
-      vertex 154.993 -157.209 0
-      vertex 154.993 -157.209 -3
+      vertex 150 -152 -3
+      vertex 149.993 -152.209 0
+      vertex 149.993 -152.209 -3
     endloop
   endfacet
   facet normal 0.99944 -0.0334741 0
     outer loop
-      vertex 155 -157 -3
-      vertex 155 -157 0
-      vertex 154.993 -157.209 0
+      vertex 150 -152 -3
+      vertex 150 -152 0
+      vertex 149.993 -152.209 0
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 155 157 -3
-      vertex 155 -157 0
-      vertex 155 -157 -3
+      vertex 150 152 -3
+      vertex 150 -152 0
+      vertex 150 -152 -3
     endloop
   endfacet
   facet normal 1 0 -0
     outer loop
-      vertex 155 157 -3
-      vertex 155 157 0
-      vertex 155 -157 0
+      vertex 150 152 -3
+      vertex 150 152 0
+      vertex 150 -152 0
     endloop
   endfacet
   facet normal 0.99944 0.0334741 0
     outer loop
-      vertex 154.993 157.209 -3
-      vertex 155 157 0
-      vertex 155 157 -3
+      vertex 149.993 152.209 -3
+      vertex 150 152 0
+      vertex 150 152 -3
     endloop
   endfacet
   facet normal 0.99944 0.0334741 -0
     outer loop
-      vertex 154.993 157.209 -3
-      vertex 154.993 157.209 0
-      vertex 155 157 0
+      vertex 149.993 152.209 -3
+      vertex 149.993 152.209 0
+      vertex 150 152 0
     endloop
   endfacet
   facet normal 0.994505 0.104685 0
     outer loop
-      vertex 154.971 157.418 -3
-      vertex 154.993 157.209 0
-      vertex 154.993 157.209 -3
+      vertex 149.971 152.418 -3
+      vertex 149.993 152.209 0
+      vertex 149.993 152.209 -3
     endloop
   endfacet
   facet normal 0.994505 0.104685 -0
     outer loop
-      vertex 154.971 157.418 -3
-      vertex 154.971 157.418 0
-      vertex 154.993 157.209 0
+      vertex 149.971 152.418 -3
+      vertex 149.971 152.418 0
+      vertex 149.993 152.209 0
     endloop
   endfacet
   facet normal 0.98425 0.176783 0
     outer loop
-      vertex 154.934 157.624 -3
-      vertex 154.971 157.418 0
-      vertex 154.971 157.418 -3
+      vertex 149.934 152.624 -3
+      vertex 149.971 152.418 0
+      vertex 149.971 152.418 -3
     endloop
   endfacet
   facet normal 0.98425 0.176783 -0
     outer loop
-      vertex 154.934 157.624 -3
-      vertex 154.934 157.624 0
-      vertex 154.971 157.418 0
+      vertex 149.934 152.624 -3
+      vertex 149.934 152.624 0
+      vertex 149.971 152.418 0
     endloop
   endfacet
   facet normal 0.970981 0.239158 0
     outer loop
-      vertex 154.884 157.827 -3
-      vertex 154.934 157.624 0
-      vertex 154.934 157.624 -3
+      vertex 149.884 152.827 -3
+      vertex 149.934 152.624 0
+      vertex 149.934 152.624 -3
     endloop
   endfacet
   facet normal 0.970981 0.239158 -0
     outer loop
-      vertex 154.884 157.827 -3
-      vertex 154.884 157.827 0
-      vertex 154.934 157.624 0
+      vertex 149.884 152.827 -3
+      vertex 149.884 152.827 0
+      vertex 149.934 152.624 0
     endloop
   endfacet
   facet normal 0.950577 0.31049 0
     outer loop
-      vertex 154.819 158.026 -3
-      vertex 154.884 157.827 0
-      vertex 154.884 157.827 -3
+      vertex 149.819 153.026 -3
+      vertex 149.884 152.827 0
+      vertex 149.884 152.827 -3
     endloop
   endfacet
   facet normal 0.950577 0.31049 -0
     outer loop
-      vertex 154.819 158.026 -3
-      vertex 154.819 158.026 0
-      vertex 154.884 157.827 0
+      vertex 149.819 153.026 -3
+      vertex 149.819 153.026 0
+      vertex 149.884 152.827 0
     endloop
   endfacet
   facet normal 0.927816 0.373039 0
     outer loop
-      vertex 154.741 158.22 -3
-      vertex 154.819 158.026 0
-      vertex 154.819 158.026 -3
+      vertex 149.741 153.22 -3
+      vertex 149.819 153.026 0
+      vertex 149.819 153.026 -3
     endloop
   endfacet
   facet normal 0.927816 0.373039 -0
     outer loop
-      vertex 154.741 158.22 -3
-      vertex 154.741 158.22 0
-      vertex 154.819 158.026 0
+      vertex 149.741 153.22 -3
+      vertex 149.741 153.22 0
+      vertex 149.819 153.026 0
     endloop
   endfacet
   facet normal 0.898217 0.439553 0
     outer loop
-      vertex 154.649 158.408 -3
-      vertex 154.741 158.22 0
-      vertex 154.741 158.22 -3
+      vertex 149.649 153.408 -3
+      vertex 149.741 153.22 0
+      vertex 149.741 153.22 -3
     endloop
   endfacet
   facet normal 0.898217 0.439553 -0
     outer loop
-      vertex 154.649 158.408 -3
-      vertex 154.649 158.408 0
-      vertex 154.741 158.22 0
+      vertex 149.649 153.408 -3
+      vertex 149.649 153.408 0
+      vertex 149.741 153.22 0
     endloop
   endfacet
   facet normal 0.866186 0.499722 0
     outer loop
-      vertex 154.544 158.59 -3
-      vertex 154.649 158.408 0
-      vertex 154.649 158.408 -3
+      vertex 149.544 153.59 -3
+      vertex 149.649 153.408 0
+      vertex 149.649 153.408 -3
     endloop
   endfacet
   facet normal 0.866186 0.499722 -0
     outer loop
-      vertex 154.544 158.59 -3
-      vertex 154.544 158.59 0
-      vertex 154.649 158.408 0
+      vertex 149.544 153.59 -3
+      vertex 149.544 153.59 0
+      vertex 149.649 153.408 0
     endloop
   endfacet
   facet normal 0.828349 0.560213 0
     outer loop
-      vertex 154.427 158.763 -3
-      vertex 154.544 158.59 0
-      vertex 154.544 158.59 -3
+      vertex 149.427 153.763 -3
+      vertex 149.544 153.59 0
+      vertex 149.544 153.59 -3
     endloop
   endfacet
   facet normal 0.828349 0.560213 -0
     outer loop
-      vertex 154.427 158.763 -3
-      vertex 154.427 158.763 0
-      vertex 154.544 158.59 0
+      vertex 149.427 153.763 -3
+      vertex 149.427 153.763 0
+      vertex 149.544 153.59 0
     endloop
   endfacet
   facet normal 0.787807 0.615922 0
     outer loop
-      vertex 154.298 158.928 -3
-      vertex 154.427 158.763 0
-      vertex 154.427 158.763 -3
+      vertex 149.298 153.928 -3
+      vertex 149.427 153.763 0
+      vertex 149.427 153.763 -3
     endloop
   endfacet
   facet normal 0.787807 0.615922 -0
     outer loop
-      vertex 154.298 158.928 -3
-      vertex 154.298 158.928 0
-      vertex 154.427 158.763 0
+      vertex 149.298 153.928 -3
+      vertex 149.298 153.928 0
+      vertex 149.427 153.763 0
     endloop
   endfacet
   facet normal 0.744242 0.66791 0
     outer loop
-      vertex 154.158 159.084 -3
-      vertex 154.298 158.928 0
-      vertex 154.298 158.928 -3
+      vertex 149.158 154.084 -3
+      vertex 149.298 153.928 0
+      vertex 149.298 153.928 -3
     endloop
   endfacet
   facet normal 0.744242 0.66791 -0
     outer loop
-      vertex 154.158 159.084 -3
-      vertex 154.158 159.084 0
-      vertex 154.298 158.928 0
+      vertex 149.158 154.084 -3
+      vertex 149.158 154.084 0
+      vertex 149.298 153.928 0
     endloop
   endfacet
   facet normal 0.692631 0.721292 0
     outer loop
-      vertex 154.007 159.229 -3
-      vertex 154.158 159.084 0
-      vertex 154.158 159.084 -3
+      vertex 149.007 154.229 -3
+      vertex 149.158 154.084 0
+      vertex 149.158 154.084 -3
     endloop
   endfacet
   facet normal 0.692631 0.721292 -0
     outer loop
-      vertex 154.007 159.229 -3
-      vertex 154.007 159.229 0
-      vertex 154.158 159.084 0
+      vertex 149.007 154.229 -3
+      vertex 149.007 154.229 0
+      vertex 149.158 154.084 0
     endloop
   endfacet
   facet normal 0.644871 0.764291 0
     outer loop
-      vertex 153.847 159.364 -3
-      vertex 154.007 159.229 0
-      vertex 154.007 159.229 -3
+      vertex 148.847 154.364 -3
+      vertex 149.007 154.229 0
+      vertex 149.007 154.229 -3
     endloop
   endfacet
   facet normal 0.644871 0.764291 -0
     outer loop
-      vertex 153.847 159.364 -3
-      vertex 153.847 159.364 0
-      vertex 154.007 159.229 0
+      vertex 148.847 154.364 -3
+      vertex 148.847 154.364 0
+      vertex 149.007 154.229 0
     endloop
   endfacet
   facet normal 0.588456 0.808529 0
     outer loop
-      vertex 153.678 159.487 -3
-      vertex 153.847 159.364 0
-      vertex 153.847 159.364 -3
+      vertex 148.678 154.487 -3
+      vertex 148.847 154.364 0
+      vertex 148.847 154.364 -3
     endloop
   endfacet
   facet normal 0.588456 0.808529 -0
     outer loop
-      vertex 153.678 159.487 -3
-      vertex 153.678 159.487 0
-      vertex 153.847 159.364 0
+      vertex 148.678 154.487 -3
+      vertex 148.678 154.487 0
+      vertex 148.847 154.364 0
     endloop
   endfacet
   facet normal 0.529142 0.848533 0
     outer loop
-      vertex 153.5 159.598 -3
-      vertex 153.678 159.487 0
-      vertex 153.678 159.487 -3
+      vertex 148.5 154.598 -3
+      vertex 148.678 154.487 0
+      vertex 148.678 154.487 -3
     endloop
   endfacet
   facet normal 0.529142 0.848533 -0
     outer loop
-      vertex 153.5 159.598 -3
-      vertex 153.5 159.598 0
-      vertex 153.678 159.487 0
+      vertex 148.5 154.598 -3
+      vertex 148.5 154.598 0
+      vertex 148.678 154.487 0
     endloop
   endfacet
   facet normal 0.468107 0.883672 0
     outer loop
-      vertex 153.315 159.696 -3
-      vertex 153.5 159.598 0
-      vertex 153.5 159.598 -3
+      vertex 148.315 154.696 -3
+      vertex 148.5 154.598 0
+      vertex 148.5 154.598 -3
     endloop
   endfacet
   facet normal 0.468107 0.883672 -0
     outer loop
-      vertex 153.315 159.696 -3
-      vertex 153.315 159.696 0
-      vertex 153.5 159.598 0
+      vertex 148.315 154.696 -3
+      vertex 148.315 154.696 0
+      vertex 148.5 154.598 0
     endloop
   endfacet
   facet normal 0.410563 0.911832 0
     outer loop
-      vertex 153.124 159.782 -3
-      vertex 153.315 159.696 0
-      vertex 153.315 159.696 -3
+      vertex 148.124 154.782 -3
+      vertex 148.315 154.696 0
+      vertex 148.315 154.696 -3
     endloop
   endfacet
   facet normal 0.410563 0.911832 -0
     outer loop
-      vertex 153.124 159.782 -3
-      vertex 153.124 159.782 0
-      vertex 153.315 159.696 0
+      vertex 148.124 154.782 -3
+      vertex 148.124 154.782 0
+      vertex 148.315 154.696 0
     endloop
   endfacet
   facet normal 0.339058 0.940766 0
     outer loop
-      vertex 152.927 159.853 -3
-      vertex 153.124 159.782 0
-      vertex 153.124 159.782 -3
+      vertex 147.927 154.853 -3
+      vertex 148.124 154.782 0
+      vertex 148.124 154.782 -3
     endloop
   endfacet
   facet normal 0.339058 0.940766 -0
     outer loop
-      vertex 152.927 159.853 -3
-      vertex 152.927 159.853 0
-      vertex 153.124 159.782 0
+      vertex 147.927 154.853 -3
+      vertex 147.927 154.853 0
+      vertex 148.124 154.782 0
     endloop
   endfacet
   facet normal 0.277246 0.960799 0
     outer loop
-      vertex 152.726 159.911 -3
-      vertex 152.927 159.853 0
-      vertex 152.927 159.853 -3
+      vertex 147.726 154.911 -3
+      vertex 147.927 154.853 0
+      vertex 147.927 154.853 -3
     endloop
   endfacet
   facet normal 0.277246 0.960799 -0
     outer loop
-      vertex 152.726 159.911 -3
-      vertex 152.726 159.911 0
-      vertex 152.927 159.853 0
+      vertex 147.726 154.911 -3
+      vertex 147.726 154.911 0
+      vertex 147.927 154.853 0
     endloop
   endfacet
   facet normal 0.205289 0.978701 0
     outer loop
-      vertex 152.521 159.954 -3
-      vertex 152.726 159.911 0
-      vertex 152.726 159.911 -3
+      vertex 147.521 154.954 -3
+      vertex 147.726 154.911 0
+      vertex 147.726 154.911 -3
     endloop
   endfacet
   facet normal 0.205289 0.978701 -0
     outer loop
-      vertex 152.521 159.954 -3
-      vertex 152.521 159.954 0
-      vertex 152.726 159.911 0
+      vertex 147.521 154.954 -3
+      vertex 147.521 154.954 0
+      vertex 147.726 154.911 0
     endloop
   endfacet
   facet normal 0.143429 0.989661 0
     outer loop
-      vertex 152.314 159.984 -3
-      vertex 152.521 159.954 0
-      vertex 152.521 159.954 -3
+      vertex 147.314 154.984 -3
+      vertex 147.521 154.954 0
+      vertex 147.521 154.954 -3
     endloop
   endfacet
   facet normal 0.143429 0.989661 -0
     outer loop
-      vertex 152.314 159.984 -3
-      vertex 152.314 159.984 0
-      vertex 152.521 159.954 0
+      vertex 147.314 154.984 -3
+      vertex 147.314 154.984 0
+      vertex 147.521 154.954 0
     endloop
   endfacet
   facet normal 0.0668359 0.997764 0
     outer loop
-      vertex 152.105 159.998 -3
-      vertex 152.314 159.984 0
-      vertex 152.314 159.984 -3
+      vertex 147.105 154.998 -3
+      vertex 147.314 154.984 0
+      vertex 147.314 154.984 -3
     endloop
   endfacet
   facet normal 0.0668359 0.997764 -0
     outer loop
-      vertex 152.105 159.998 -3
-      vertex 152.105 159.998 0
-      vertex 152.314 159.984 0
+      vertex 147.105 154.998 -3
+      vertex 147.105 154.998 0
+      vertex 147.314 154.984 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 152.105 159.998 0
-      vertex 152.105 159.998 -3
+      vertex 147.002 154.998 -3
+      vertex 147.105 154.998 0
+      vertex 147.105 154.998 -3
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 152.002 159.998 -3
-      vertex 152.002 159.998 0
-      vertex 152.105 159.998 0
+      vertex 147.002 154.998 -3
+      vertex 147.002 154.998 0
+      vertex 147.105 154.998 0
     endloop
   endfacet
   facet normal 0.707107 0.707107 0
     outer loop
-      vertex 152 160 -3
-      vertex 152.002 159.998 0
-      vertex 152.002 159.998 -3
+      vertex 147 155 -3
+      vertex 147.002 154.998 0
+      vertex 147.002 154.998 -3
     endloop
   endfacet
   facet normal 0.707107 0.707107 -0
     outer loop
-      vertex 152 160 -3
-      vertex 152 160 0
-      vertex 152.002 159.998 0
+      vertex 147 155 -3
+      vertex 147 155 0
+      vertex 147.002 154.998 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -152 160 -3
-      vertex 152 160 0
-      vertex 152 160 -3
+      vertex -147 155 -3
+      vertex 147 155 0
+      vertex 147 155 -3
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -152 160 -3
-      vertex -152 160 0
-      vertex 152 160 0
+      vertex -147 155 -3
+      vertex -147 155 0
+      vertex 147 155 0
     endloop
   endfacet
   facet normal -0.707107 0.707107 0
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152 160 0
-      vertex -152 160 -3
+      vertex -147.002 154.998 -3
+      vertex -147 155 0
+      vertex -147 155 -3
     endloop
   endfacet
   facet normal -0.707107 0.707107 0
     outer loop
-      vertex -152.002 159.998 -3
-      vertex -152.002 159.998 0
-      vertex -152 160 0
+      vertex -147.002 154.998 -3
+      vertex -147.002 154.998 0
+      vertex -147 155 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -152.105 159.998 -3
-      vertex -152.002 159.998 0
-      vertex -152.002 159.998 -3
+      vertex -147.105 154.998 -3
+      vertex -147.002 154.998 0
+      vertex -147.002 154.998 -3
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -152.105 159.998 -3
-      vertex -152.105 159.998 0
-      vertex -152.002 159.998 0
+      vertex -147.105 154.998 -3
+      vertex -147.105 154.998 0
+      vertex -147.002 154.998 0
     endloop
   endfacet
   facet normal -0.0668359 0.997764 0
     outer loop
-      vertex -152.314 159.984 -3
-      vertex -152.105 159.998 0
-      vertex -152.105 159.998 -3
+      vertex -147.314 154.984 -3
+      vertex -147.105 154.998 0
+      vertex -147.105 154.998 -3
     endloop
   endfacet
   facet normal -0.0668359 0.997764 0
     outer loop
-      vertex -152.314 159.984 -3
-      vertex -152.314 159.984 0
-      vertex -152.105 159.998 0
+      vertex -147.314 154.984 -3
+      vertex -147.314 154.984 0
+      vertex -147.105 154.998 0
     endloop
   endfacet
   facet normal -0.143429 0.989661 0
     outer loop
-      vertex -152.521 159.954 -3
-      vertex -152.314 159.984 0
-      vertex -152.314 159.984 -3
+      vertex -147.521 154.954 -3
+      vertex -147.314 154.984 0
+      vertex -147.314 154.984 -3
     endloop
   endfacet
   facet normal -0.143429 0.989661 0
     outer loop
-      vertex -152.521 159.954 -3
-      vertex -152.521 159.954 0
-      vertex -152.314 159.984 0
+      vertex -147.521 154.954 -3
+      vertex -147.521 154.954 0
+      vertex -147.314 154.984 0
     endloop
   endfacet
   facet normal -0.205289 0.978701 0
     outer loop
-      vertex -152.726 159.911 -3
-      vertex -152.521 159.954 0
-      vertex -152.521 159.954 -3
+      vertex -147.726 154.911 -3
+      vertex -147.521 154.954 0
+      vertex -147.521 154.954 -3
     endloop
   endfacet
   facet normal -0.205289 0.978701 0
     outer loop
-      vertex -152.726 159.911 -3
-      vertex -152.726 159.911 0
-      vertex -152.521 159.954 0
+      vertex -147.726 154.911 -3
+      vertex -147.726 154.911 0
+      vertex -147.521 154.954 0
     endloop
   endfacet
   facet normal -0.277246 0.960799 0
     outer loop
-      vertex -152.927 159.853 -3
-      vertex -152.726 159.911 0
-      vertex -152.726 159.911 -3
+      vertex -147.927 154.853 -3
+      vertex -147.726 154.911 0
+      vertex -147.726 154.911 -3
     endloop
   endfacet
   facet normal -0.277246 0.960799 0
     outer loop
-      vertex -152.927 159.853 -3
-      vertex -152.927 159.853 0
-      vertex -152.726 159.911 0
+      vertex -147.927 154.853 -3
+      vertex -147.927 154.853 0
+      vertex -147.726 154.911 0
     endloop
   endfacet
   facet normal -0.339058 0.940766 0
     outer loop
-      vertex -153.124 159.782 -3
-      vertex -152.927 159.853 0
-      vertex -152.927 159.853 -3
+      vertex -148.124 154.782 -3
+      vertex -147.927 154.853 0
+      vertex -147.927 154.853 -3
     endloop
   endfacet
   facet normal -0.339058 0.940766 0
     outer loop
-      vertex -153.124 159.782 -3
-      vertex -153.124 159.782 0
-      vertex -152.927 159.853 0
+      vertex -148.124 154.782 -3
+      vertex -148.124 154.782 0
+      vertex -147.927 154.853 0
     endloop
   endfacet
   facet normal -0.410563 0.911832 0
     outer loop
-      vertex -153.315 159.696 -3
-      vertex -153.124 159.782 0
-      vertex -153.124 159.782 -3
+      vertex -148.315 154.696 -3
+      vertex -148.124 154.782 0
+      vertex -148.124 154.782 -3
     endloop
   endfacet
   facet normal -0.410563 0.911832 0
     outer loop
-      vertex -153.315 159.696 -3
-      vertex -153.315 159.696 0
-      vertex -153.124 159.782 0
+      vertex -148.315 154.696 -3
+      vertex -148.315 154.696 0
+      vertex -148.124 154.782 0
     endloop
   endfacet
   facet normal -0.468107 0.883672 0
     outer loop
-      vertex -153.5 159.598 -3
-      vertex -153.315 159.696 0
-      vertex -153.315 159.696 -3
+      vertex -148.5 154.598 -3
+      vertex -148.315 154.696 0
+      vertex -148.315 154.696 -3
     endloop
   endfacet
   facet normal -0.468107 0.883672 0
     outer loop
-      vertex -153.5 159.598 -3
-      vertex -153.5 159.598 0
-      vertex -153.315 159.696 0
+      vertex -148.5 154.598 -3
+      vertex -148.5 154.598 0
+      vertex -148.315 154.696 0
     endloop
   endfacet
   facet normal -0.529142 0.848533 0
     outer loop
-      vertex -153.678 159.487 -3
-      vertex -153.5 159.598 0
-      vertex -153.5 159.598 -3
+      vertex -148.678 154.487 -3
+      vertex -148.5 154.598 0
+      vertex -148.5 154.598 -3
     endloop
   endfacet
   facet normal -0.529142 0.848533 0
     outer loop
-      vertex -153.678 159.487 -3
-      vertex -153.678 159.487 0
-      vertex -153.5 159.598 0
+      vertex -148.678 154.487 -3
+      vertex -148.678 154.487 0
+      vertex -148.5 154.598 0
     endloop
   endfacet
   facet normal -0.588456 0.808529 0
     outer loop
-      vertex -153.847 159.364 -3
-      vertex -153.678 159.487 0
-      vertex -153.678 159.487 -3
+      vertex -148.847 154.364 -3
+      vertex -148.678 154.487 0
+      vertex -148.678 154.487 -3
     endloop
   endfacet
   facet normal -0.588456 0.808529 0
     outer loop
-      vertex -153.847 159.364 -3
-      vertex -153.847 159.364 0
-      vertex -153.678 159.487 0
+      vertex -148.847 154.364 -3
+      vertex -148.847 154.364 0
+      vertex -148.678 154.487 0
     endloop
   endfacet
   facet normal -0.644871 0.764291 0
     outer loop
-      vertex -154.007 159.229 -3
-      vertex -153.847 159.364 0
-      vertex -153.847 159.364 -3
+      vertex -149.007 154.229 -3
+      vertex -148.847 154.364 0
+      vertex -148.847 154.364 -3
     endloop
   endfacet
   facet normal -0.644871 0.764291 0
     outer loop
-      vertex -154.007 159.229 -3
-      vertex -154.007 159.229 0
-      vertex -153.847 159.364 0
+      vertex -149.007 154.229 -3
+      vertex -149.007 154.229 0
+      vertex -148.847 154.364 0
     endloop
   endfacet
   facet normal -0.692631 0.721292 0
     outer loop
-      vertex -154.158 159.084 -3
-      vertex -154.007 159.229 0
-      vertex -154.007 159.229 -3
+      vertex -149.158 154.084 -3
+      vertex -149.007 154.229 0
+      vertex -149.007 154.229 -3
     endloop
   endfacet
   facet normal -0.692631 0.721292 0
     outer loop
-      vertex -154.158 159.084 -3
-      vertex -154.158 159.084 0
-      vertex -154.007 159.229 0
+      vertex -149.158 154.084 -3
+      vertex -149.158 154.084 0
+      vertex -149.007 154.229 0
     endloop
   endfacet
   facet normal -0.744242 0.66791 0
     outer loop
-      vertex -154.298 158.928 -3
-      vertex -154.158 159.084 0
-      vertex -154.158 159.084 -3
+      vertex -149.298 153.928 -3
+      vertex -149.158 154.084 0
+      vertex -149.158 154.084 -3
     endloop
   endfacet
   facet normal -0.744242 0.66791 0
     outer loop
-      vertex -154.298 158.928 -3
-      vertex -154.298 158.928 0
-      vertex -154.158 159.084 0
+      vertex -149.298 153.928 -3
+      vertex -149.298 153.928 0
+      vertex -149.158 154.084 0
     endloop
   endfacet
   facet normal -0.787807 0.615922 0
     outer loop
-      vertex -154.427 158.763 -3
-      vertex -154.298 158.928 0
-      vertex -154.298 158.928 -3
+      vertex -149.427 153.763 -3
+      vertex -149.298 153.928 0
+      vertex -149.298 153.928 -3
     endloop
   endfacet
   facet normal -0.787807 0.615922 0
     outer loop
-      vertex -154.427 158.763 -3
-      vertex -154.427 158.763 0
-      vertex -154.298 158.928 0
+      vertex -149.427 153.763 -3
+      vertex -149.427 153.763 0
+      vertex -149.298 153.928 0
     endloop
   endfacet
   facet normal -0.828349 0.560213 0
     outer loop
-      vertex -154.544 158.59 -3
-      vertex -154.427 158.763 0
-      vertex -154.427 158.763 -3
+      vertex -149.544 153.59 -3
+      vertex -149.427 153.763 0
+      vertex -149.427 153.763 -3
     endloop
   endfacet
   facet normal -0.828349 0.560213 0
     outer loop
-      vertex -154.544 158.59 -3
-      vertex -154.544 158.59 0
-      vertex -154.427 158.763 0
+      vertex -149.544 153.59 -3
+      vertex -149.544 153.59 0
+      vertex -149.427 153.763 0
     endloop
   endfacet
   facet normal -0.866186 0.499722 0
     outer loop
-      vertex -154.649 158.408 -3
-      vertex -154.544 158.59 0
-      vertex -154.544 158.59 -3
+      vertex -149.649 153.408 -3
+      vertex -149.544 153.59 0
+      vertex -149.544 153.59 -3
     endloop
   endfacet
   facet normal -0.866186 0.499722 0
     outer loop
-      vertex -154.649 158.408 -3
-      vertex -154.649 158.408 0
-      vertex -154.544 158.59 0
+      vertex -149.649 153.408 -3
+      vertex -149.649 153.408 0
+      vertex -149.544 153.59 0
     endloop
   endfacet
   facet normal -0.898217 0.439553 0
     outer loop
-      vertex -154.741 158.22 -3
-      vertex -154.649 158.408 0
-      vertex -154.649 158.408 -3
+      vertex -149.741 153.22 -3
+      vertex -149.649 153.408 0
+      vertex -149.649 153.408 -3
     endloop
   endfacet
   facet normal -0.898217 0.439553 0
     outer loop
-      vertex -154.741 158.22 -3
-      vertex -154.741 158.22 0
-      vertex -154.649 158.408 0
+      vertex -149.741 153.22 -3
+      vertex -149.741 153.22 0
+      vertex -149.649 153.408 0
     endloop
   endfacet
   facet normal -0.927816 0.373039 0
     outer loop
-      vertex -154.819 158.026 -3
-      vertex -154.741 158.22 0
-      vertex -154.741 158.22 -3
+      vertex -149.819 153.026 -3
+      vertex -149.741 153.22 0
+      vertex -149.741 153.22 -3
     endloop
   endfacet
   facet normal -0.927816 0.373039 0
     outer loop
-      vertex -154.819 158.026 -3
-      vertex -154.819 158.026 0
-      vertex -154.741 158.22 0
+      vertex -149.819 153.026 -3
+      vertex -149.819 153.026 0
+      vertex -149.741 153.22 0
     endloop
   endfacet
   facet normal -0.950577 0.31049 0
     outer loop
-      vertex -154.884 157.827 -3
-      vertex -154.819 158.026 0
-      vertex -154.819 158.026 -3
+      vertex -149.884 152.827 -3
+      vertex -149.819 153.026 0
+      vertex -149.819 153.026 -3
     endloop
   endfacet
   facet normal -0.950577 0.31049 0
     outer loop
-      vertex -154.884 157.827 -3
-      vertex -154.884 157.827 0
-      vertex -154.819 158.026 0
+      vertex -149.884 152.827 -3
+      vertex -149.884 152.827 0
+      vertex -149.819 153.026 0
     endloop
   endfacet
   facet normal -0.970981 0.239158 0
     outer loop
-      vertex -154.934 157.624 -3
-      vertex -154.884 157.827 0
-      vertex -154.884 157.827 -3
+      vertex -149.934 152.624 -3
+      vertex -149.884 152.827 0
+      vertex -149.884 152.827 -3
     endloop
   endfacet
   facet normal -0.970981 0.239158 0
     outer loop
-      vertex -154.934 157.624 -3
-      vertex -154.934 157.624 0
-      vertex -154.884 157.827 0
+      vertex -149.934 152.624 -3
+      vertex -149.934 152.624 0
+      vertex -149.884 152.827 0
     endloop
   endfacet
   facet normal -0.98425 0.176783 0
     outer loop
-      vertex -154.971 157.418 -3
-      vertex -154.934 157.624 0
-      vertex -154.934 157.624 -3
+      vertex -149.971 152.418 -3
+      vertex -149.934 152.624 0
+      vertex -149.934 152.624 -3
     endloop
   endfacet
   facet normal -0.98425 0.176783 0
     outer loop
-      vertex -154.971 157.418 -3
-      vertex -154.971 157.418 0
-      vertex -154.934 157.624 0
+      vertex -149.971 152.418 -3
+      vertex -149.971 152.418 0
+      vertex -149.934 152.624 0
     endloop
   endfacet
   facet normal -0.994505 0.104685 0
     outer loop
-      vertex -154.993 157.209 -3
-      vertex -154.971 157.418 0
-      vertex -154.971 157.418 -3
+      vertex -149.993 152.209 -3
+      vertex -149.971 152.418 0
+      vertex -149.971 152.418 -3
     endloop
   endfacet
   facet normal -0.994505 0.104685 0
     outer loop
-      vertex -154.993 157.209 -3
-      vertex -154.993 157.209 0
-      vertex -154.971 157.418 0
+      vertex -149.993 152.209 -3
+      vertex -149.993 152.209 0
+      vertex -149.971 152.418 0
     endloop
   endfacet
   facet normal -0.99944 0.0334741 0
     outer loop
-      vertex -155 157 -3
-      vertex -154.993 157.209 0
-      vertex -154.993 157.209 -3
+      vertex -150 152 -3
+      vertex -149.993 152.209 0
+      vertex -149.993 152.209 -3
     endloop
   endfacet
   facet normal -0.99944 0.0334741 0
     outer loop
-      vertex -155 157 -3
-      vertex -155 157 0
-      vertex -154.993 157.209 0
+      vertex -150 152 -3
+      vertex -150 152 0
+      vertex -149.993 152.209 0
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -155 -157 -3
-      vertex -155 157 0
-      vertex -155 157 -3
+      vertex -150 -152 -3
+      vertex -150 152 0
+      vertex -150 152 -3
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -155 -157 -3
-      vertex -155 -157 0
-      vertex -155 157 0
+      vertex -150 -152 -3
+      vertex -150 -152 0
+      vertex -150 152 0
     endloop
   endfacet
   facet normal -0.99944 -0.0334741 0
     outer loop
-      vertex -154.993 -157.209 -3
-      vertex -155 -157 0
-      vertex -155 -157 -3
+      vertex -149.993 -152.209 -3
+      vertex -150 -152 0
+      vertex -150 -152 -3
     endloop
   endfacet
   facet normal -0.99944 -0.0334741 0
     outer loop
-      vertex -154.993 -157.209 -3
-      vertex -154.993 -157.209 0
-      vertex -155 -157 0
+      vertex -149.993 -152.209 -3
+      vertex -149.993 -152.209 0
+      vertex -150 -152 0
     endloop
   endfacet
   facet normal -0.994505 -0.104685 0
     outer loop
-      vertex -154.971 -157.418 -3
-      vertex -154.993 -157.209 0
-      vertex -154.993 -157.209 -3
+      vertex -149.971 -152.418 -3
+      vertex -149.993 -152.209 0
+      vertex -149.993 -152.209 -3
     endloop
   endfacet
   facet normal -0.994505 -0.104685 0
     outer loop
-      vertex -154.971 -157.418 -3
-      vertex -154.971 -157.418 0
-      vertex -154.993 -157.209 0
+      vertex -149.971 -152.418 -3
+      vertex -149.971 -152.418 0
+      vertex -149.993 -152.209 0
     endloop
   endfacet
   facet normal -0.98425 -0.176783 0
     outer loop
-      vertex -154.934 -157.624 -3
-      vertex -154.971 -157.418 0
-      vertex -154.971 -157.418 -3
+      vertex -149.934 -152.624 -3
+      vertex -149.971 -152.418 0
+      vertex -149.971 -152.418 -3
     endloop
   endfacet
   facet normal -0.98425 -0.176783 0
     outer loop
-      vertex -154.934 -157.624 -3
-      vertex -154.934 -157.624 0
-      vertex -154.971 -157.418 0
+      vertex -149.934 -152.624 -3
+      vertex -149.934 -152.624 0
+      vertex -149.971 -152.418 0
     endloop
   endfacet
   facet normal -0.970981 -0.239158 0
     outer loop
-      vertex -154.884 -157.827 -3
-      vertex -154.934 -157.624 0
-      vertex -154.934 -157.624 -3
+      vertex -149.884 -152.827 -3
+      vertex -149.934 -152.624 0
+      vertex -149.934 -152.624 -3
     endloop
   endfacet
   facet normal -0.970981 -0.239158 0
     outer loop
-      vertex -154.884 -157.827 -3
-      vertex -154.884 -157.827 0
-      vertex -154.934 -157.624 0
+      vertex -149.884 -152.827 -3
+      vertex -149.884 -152.827 0
+      vertex -149.934 -152.624 0
     endloop
   endfacet
   facet normal -0.950577 -0.31049 0
     outer loop
-      vertex -154.819 -158.026 -3
-      vertex -154.884 -157.827 0
-      vertex -154.884 -157.827 -3
+      vertex -149.819 -153.026 -3
+      vertex -149.884 -152.827 0
+      vertex -149.884 -152.827 -3
     endloop
   endfacet
   facet normal -0.950577 -0.31049 0
     outer loop
-      vertex -154.819 -158.026 -3
-      vertex -154.819 -158.026 0
-      vertex -154.884 -157.827 0
+      vertex -149.819 -153.026 -3
+      vertex -149.819 -153.026 0
+      vertex -149.884 -152.827 0
     endloop
   endfacet
   facet normal -0.927816 -0.373039 0
     outer loop
-      vertex -154.741 -158.22 -3
-      vertex -154.819 -158.026 0
-      vertex -154.819 -158.026 -3
+      vertex -149.741 -153.22 -3
+      vertex -149.819 -153.026 0
+      vertex -149.819 -153.026 -3
     endloop
   endfacet
   facet normal -0.927816 -0.373039 0
     outer loop
-      vertex -154.741 -158.22 -3
-      vertex -154.741 -158.22 0
-      vertex -154.819 -158.026 0
+      vertex -149.741 -153.22 -3
+      vertex -149.741 -153.22 0
+      vertex -149.819 -153.026 0
     endloop
   endfacet
   facet normal -0.898217 -0.439553 0
     outer loop
-      vertex -154.649 -158.408 -3
-      vertex -154.741 -158.22 0
-      vertex -154.741 -158.22 -3
+      vertex -149.649 -153.408 -3
+      vertex -149.741 -153.22 0
+      vertex -149.741 -153.22 -3
     endloop
   endfacet
   facet normal -0.898217 -0.439553 0
     outer loop
-      vertex -154.649 -158.408 -3
-      vertex -154.649 -158.408 0
-      vertex -154.741 -158.22 0
+      vertex -149.649 -153.408 -3
+      vertex -149.649 -153.408 0
+      vertex -149.741 -153.22 0
     endloop
   endfacet
   facet normal -0.866186 -0.499722 0
     outer loop
-      vertex -154.544 -158.59 -3
-      vertex -154.649 -158.408 0
-      vertex -154.649 -158.408 -3
+      vertex -149.544 -153.59 -3
+      vertex -149.649 -153.408 0
+      vertex -149.649 -153.408 -3
     endloop
   endfacet
   facet normal -0.866186 -0.499722 0
     outer loop
-      vertex -154.544 -158.59 -3
-      vertex -154.544 -158.59 0
-      vertex -154.649 -158.408 0
+      vertex -149.544 -153.59 -3
+      vertex -149.544 -153.59 0
+      vertex -149.649 -153.408 0
     endloop
   endfacet
   facet normal -0.828349 -0.560213 0
     outer loop
-      vertex -154.427 -158.763 -3
-      vertex -154.544 -158.59 0
-      vertex -154.544 -158.59 -3
+      vertex -149.427 -153.763 -3
+      vertex -149.544 -153.59 0
+      vertex -149.544 -153.59 -3
     endloop
   endfacet
   facet normal -0.828349 -0.560213 0
     outer loop
-      vertex -154.427 -158.763 -3
-      vertex -154.427 -158.763 0
-      vertex -154.544 -158.59 0
+      vertex -149.427 -153.763 -3
+      vertex -149.427 -153.763 0
+      vertex -149.544 -153.59 0
     endloop
   endfacet
   facet normal -0.787807 -0.615922 0
     outer loop
-      vertex -154.298 -158.928 -3
-      vertex -154.427 -158.763 0
-      vertex -154.427 -158.763 -3
+      vertex -149.298 -153.928 -3
+      vertex -149.427 -153.763 0
+      vertex -149.427 -153.763 -3
     endloop
   endfacet
   facet normal -0.787807 -0.615922 0
     outer loop
-      vertex -154.298 -158.928 -3
-      vertex -154.298 -158.928 0
-      vertex -154.427 -158.763 0
+      vertex -149.298 -153.928 -3
+      vertex -149.298 -153.928 0
+      vertex -149.427 -153.763 0
     endloop
   endfacet
   facet normal -0.744242 -0.66791 0
     outer loop
-      vertex -154.158 -159.084 -3
-      vertex -154.298 -158.928 0
-      vertex -154.298 -158.928 -3
+      vertex -149.158 -154.084 -3
+      vertex -149.298 -153.928 0
+      vertex -149.298 -153.928 -3
     endloop
   endfacet
   facet normal -0.744242 -0.66791 0
     outer loop
-      vertex -154.158 -159.084 -3
-      vertex -154.158 -159.084 0
-      vertex -154.298 -158.928 0
+      vertex -149.158 -154.084 -3
+      vertex -149.158 -154.084 0
+      vertex -149.298 -153.928 0
     endloop
   endfacet
   facet normal -0.692631 -0.721292 0
     outer loop
-      vertex -154.007 -159.229 -3
-      vertex -154.158 -159.084 0
-      vertex -154.158 -159.084 -3
+      vertex -149.007 -154.229 -3
+      vertex -149.158 -154.084 0
+      vertex -149.158 -154.084 -3
     endloop
   endfacet
   facet normal -0.692631 -0.721292 0
     outer loop
-      vertex -154.007 -159.229 -3
-      vertex -154.007 -159.229 0
-      vertex -154.158 -159.084 0
+      vertex -149.007 -154.229 -3
+      vertex -149.007 -154.229 0
+      vertex -149.158 -154.084 0
     endloop
   endfacet
   facet normal -0.644871 -0.764291 0
     outer loop
-      vertex -153.847 -159.364 -3
-      vertex -154.007 -159.229 0
-      vertex -154.007 -159.229 -3
+      vertex -148.847 -154.364 -3
+      vertex -149.007 -154.229 0
+      vertex -149.007 -154.229 -3
     endloop
   endfacet
   facet normal -0.644871 -0.764291 0
     outer loop
-      vertex -153.847 -159.364 -3
-      vertex -153.847 -159.364 0
-      vertex -154.007 -159.229 0
+      vertex -148.847 -154.364 -3
+      vertex -148.847 -154.364 0
+      vertex -149.007 -154.229 0
     endloop
   endfacet
   facet normal -0.588456 -0.808529 0
     outer loop
-      vertex -153.678 -159.487 -3
-      vertex -153.847 -159.364 0
-      vertex -153.847 -159.364 -3
+      vertex -148.678 -154.487 -3
+      vertex -148.847 -154.364 0
+      vertex -148.847 -154.364 -3
     endloop
   endfacet
   facet normal -0.588456 -0.808529 0
     outer loop
-      vertex -153.678 -159.487 -3
-      vertex -153.678 -159.487 0
-      vertex -153.847 -159.364 0
+      vertex -148.678 -154.487 -3
+      vertex -148.678 -154.487 0
+      vertex -148.847 -154.364 0
     endloop
   endfacet
   facet normal -0.529142 -0.848533 0
     outer loop
-      vertex -153.5 -159.598 -3
-      vertex -153.678 -159.487 0
-      vertex -153.678 -159.487 -3
+      vertex -148.5 -154.598 -3
+      vertex -148.678 -154.487 0
+      vertex -148.678 -154.487 -3
     endloop
   endfacet
   facet normal -0.529142 -0.848533 0
     outer loop
-      vertex -153.5 -159.598 -3
-      vertex -153.5 -159.598 0
-      vertex -153.678 -159.487 0
+      vertex -148.5 -154.598 -3
+      vertex -148.5 -154.598 0
+      vertex -148.678 -154.487 0
     endloop
   endfacet
   facet normal -0.468107 -0.883672 0
     outer loop
-      vertex -153.315 -159.696 -3
-      vertex -153.5 -159.598 0
-      vertex -153.5 -159.598 -3
+      vertex -148.315 -154.696 -3
+      vertex -148.5 -154.598 0
+      vertex -148.5 -154.598 -3
     endloop
   endfacet
   facet normal -0.468107 -0.883672 0
     outer loop
-      vertex -153.315 -159.696 -3
-      vertex -153.315 -159.696 0
-      vertex -153.5 -159.598 0
+      vertex -148.315 -154.696 -3
+      vertex -148.315 -154.696 0
+      vertex -148.5 -154.598 0
     endloop
   endfacet
   facet normal -0.410563 -0.911832 0
     outer loop
-      vertex -153.124 -159.782 -3
-      vertex -153.315 -159.696 0
-      vertex -153.315 -159.696 -3
+      vertex -148.124 -154.782 -3
+      vertex -148.315 -154.696 0
+      vertex -148.315 -154.696 -3
     endloop
   endfacet
   facet normal -0.410563 -0.911832 0
     outer loop
-      vertex -153.124 -159.782 -3
-      vertex -153.124 -159.782 0
-      vertex -153.315 -159.696 0
+      vertex -148.124 -154.782 -3
+      vertex -148.124 -154.782 0
+      vertex -148.315 -154.696 0
     endloop
   endfacet
   facet normal -0.339058 -0.940766 0
     outer loop
-      vertex -152.927 -159.853 -3
-      vertex -153.124 -159.782 0
-      vertex -153.124 -159.782 -3
+      vertex -147.927 -154.853 -3
+      vertex -148.124 -154.782 0
+      vertex -148.124 -154.782 -3
     endloop
   endfacet
   facet normal -0.339058 -0.940766 0
     outer loop
-      vertex -152.927 -159.853 -3
-      vertex -152.927 -159.853 0
-      vertex -153.124 -159.782 0
+      vertex -147.927 -154.853 -3
+      vertex -147.927 -154.853 0
+      vertex -148.124 -154.782 0
     endloop
   endfacet
   facet normal -0.277246 -0.960799 0
     outer loop
-      vertex -152.726 -159.911 -3
-      vertex -152.927 -159.853 0
-      vertex -152.927 -159.853 -3
+      vertex -147.726 -154.911 -3
+      vertex -147.927 -154.853 0
+      vertex -147.927 -154.853 -3
     endloop
   endfacet
   facet normal -0.277246 -0.960799 0
     outer loop
-      vertex -152.726 -159.911 -3
-      vertex -152.726 -159.911 0
-      vertex -152.927 -159.853 0
+      vertex -147.726 -154.911 -3
+      vertex -147.726 -154.911 0
+      vertex -147.927 -154.853 0
     endloop
   endfacet
   facet normal -0.205289 -0.978701 0
     outer loop
-      vertex -152.521 -159.954 -3
-      vertex -152.726 -159.911 0
-      vertex -152.726 -159.911 -3
+      vertex -147.521 -154.954 -3
+      vertex -147.726 -154.911 0
+      vertex -147.726 -154.911 -3
     endloop
   endfacet
   facet normal -0.205289 -0.978701 0
     outer loop
-      vertex -152.521 -159.954 -3
-      vertex -152.521 -159.954 0
-      vertex -152.726 -159.911 0
+      vertex -147.521 -154.954 -3
+      vertex -147.521 -154.954 0
+      vertex -147.726 -154.911 0
     endloop
   endfacet
   facet normal -0.143429 -0.989661 0
     outer loop
-      vertex -152.314 -159.984 -3
-      vertex -152.521 -159.954 0
-      vertex -152.521 -159.954 -3
+      vertex -147.314 -154.984 -3
+      vertex -147.521 -154.954 0
+      vertex -147.521 -154.954 -3
     endloop
   endfacet
   facet normal -0.143429 -0.989661 0
     outer loop
-      vertex -152.314 -159.984 -3
-      vertex -152.314 -159.984 0
-      vertex -152.521 -159.954 0
+      vertex -147.314 -154.984 -3
+      vertex -147.314 -154.984 0
+      vertex -147.521 -154.954 0
     endloop
   endfacet
   facet normal -0.0668359 -0.997764 0
     outer loop
-      vertex -152.105 -159.998 -3
-      vertex -152.314 -159.984 0
-      vertex -152.314 -159.984 -3
+      vertex -147.105 -154.998 -3
+      vertex -147.314 -154.984 0
+      vertex -147.314 -154.984 -3
     endloop
   endfacet
   facet normal -0.0668359 -0.997764 0
     outer loop
-      vertex -152.105 -159.998 -3
-      vertex -152.105 -159.998 0
-      vertex -152.314 -159.984 0
+      vertex -147.105 -154.998 -3
+      vertex -147.105 -154.998 0
+      vertex -147.314 -154.984 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -152.105 -159.998 0
-      vertex -152.105 -159.998 -3
+      vertex -147.002 -154.998 -3
+      vertex -147.105 -154.998 0
+      vertex -147.105 -154.998 -3
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -152.002 -159.998 -3
-      vertex -152.002 -159.998 0
-      vertex -152.105 -159.998 0
+      vertex -147.002 -154.998 -3
+      vertex -147.002 -154.998 0
+      vertex -147.105 -154.998 0
     endloop
   endfacet
   facet normal -0.707107 -0.707107 0
     outer loop
-      vertex -152 -160 -3
-      vertex -152.002 -159.998 0
-      vertex -152.002 -159.998 -3
+      vertex -147 -155 -3
+      vertex -147.002 -154.998 0
+      vertex -147.002 -154.998 -3
     endloop
   endfacet
   facet normal -0.707107 -0.707107 0
     outer loop
-      vertex -152 -160 -3
-      vertex -152 -160 0
-      vertex -152.002 -159.998 0
+      vertex -147 -155 -3
+      vertex -147 -155 0
+      vertex -147.002 -154.998 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 152 -160 -3
-      vertex -152 -160 0
-      vertex -152 -160 -3
+      vertex 147 -155 -3
+      vertex -147 -155 0
+      vertex -147 -155 -3
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 152 -160 -3
-      vertex 152 -160 0
-      vertex -152 -160 0
+      vertex 147 -155 -3
+      vertex 147 -155 0
+      vertex -147 -155 0
     endloop
   endfacet
   facet normal 0.707107 -0.707107 0
     outer loop
-      vertex 152.002 -159.998 -3
-      vertex 152 -160 0
-      vertex 152 -160 -3
+      vertex 147.002 -154.998 -3
+      vertex 147 -155 0
+      vertex 147 -155 -3
     endloop
   endfacet
   facet normal 0.707107 -0.707107 0
     outer loop
-      vertex 152.002 -159.998 -3
-      vertex 152.002 -159.998 0
-      vertex 152 -160 0
+      vertex 147.002 -154.998 -3
+      vertex 147.002 -154.998 0
+      vertex 147 -155 0
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/resources/profiles/Creality/crm4.svg
+++ b/resources/profiles/Creality/crm4.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="440mm" height="440mm" version="1.1" viewBox="0 0 440 440" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".25" y=".25" width="439.5" height="439.5" fill="none" stroke="#fff" stroke-width=".5"/>
+</svg>

--- a/resources/profiles/Creality/crm4_bed.stl
+++ b/resources/profiles/Creality/crm4_bed.stl
@@ -1,0 +1,2774 @@
+solid OpenSCAD_Model
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.105 -224.998 -3
+      vertex 222.002 -224.998 -3
+      vertex 222.314 -224.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 222.314 -224.984 -3
+      vertex 222.002 -224.998 -3
+      vertex 222.521 -224.954 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 225 -222 -3
+      vertex 222.002 -224.998 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 222.521 -224.954 -3
+      vertex 222.002 -224.998 -3
+      vertex 222.726 -224.911 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 222.726 -224.911 -3
+      vertex 222.002 -224.998 -3
+      vertex 222.927 -224.853 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 222.927 -224.853 -3
+      vertex 222.002 -224.998 -3
+      vertex 223.124 -224.782 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 223.124 -224.782 -3
+      vertex 222.002 -224.998 -3
+      vertex 223.315 -224.696 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 223.315 -224.696 -3
+      vertex 222.002 -224.998 -3
+      vertex 223.5 -224.598 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 223.5 -224.598 -3
+      vertex 222.002 -224.998 -3
+      vertex 223.678 -224.487 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 223.678 -224.487 -3
+      vertex 222.002 -224.998 -3
+      vertex 223.847 -224.364 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 223.847 -224.364 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.007 -224.229 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.007 -224.229 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.158 -224.084 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.158 -224.084 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.298 -223.928 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.298 -223.928 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.427 -223.763 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.427 -223.763 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.544 -223.59 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.544 -223.59 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.649 -223.408 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.649 -223.408 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.741 -223.22 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.741 -223.22 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.819 -223.026 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.819 -223.026 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.884 -222.827 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.884 -222.827 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.934 -222.624 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.934 -222.624 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.971 -222.418 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.971 -222.418 -3
+      vertex 222.002 -224.998 -3
+      vertex 224.993 -222.209 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 224.993 -222.209 -3
+      vertex 222.002 -224.998 -3
+      vertex 225 -222 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 225 -222 -3
+      vertex 222.002 224.998 -3
+      vertex 225 222 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 224.971 222.418 -3
+      vertex 224.993 222.209 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 224.884 222.827 -3
+      vertex 224.934 222.624 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.741 223.22 -3
+      vertex 222.002 224.998 -3
+      vertex 224.649 223.408 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 224.741 223.22 -3
+      vertex 224.819 223.026 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 224.007 224.229 -3
+      vertex 224.158 224.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.427 223.763 -3
+      vertex 222.002 224.998 -3
+      vertex 224.298 223.928 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 224.427 223.763 -3
+      vertex 224.544 223.59 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.298 223.928 -3
+      vertex 222.002 224.998 -3
+      vertex 224.158 224.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 222.927 224.853 -3
+      vertex 223.124 224.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.847 224.364 -3
+      vertex 222.002 224.998 -3
+      vertex 223.678 224.487 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 223.847 224.364 -3
+      vertex 224.007 224.229 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.678 224.487 -3
+      vertex 222.002 224.998 -3
+      vertex 223.5 224.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.5 224.598 -3
+      vertex 222.002 224.998 -3
+      vertex 223.315 224.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.315 224.696 -3
+      vertex 222.002 224.998 -3
+      vertex 223.124 224.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.649 223.408 -3
+      vertex 222.002 224.998 -3
+      vertex 224.544 223.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.726 224.911 -3
+      vertex 222.002 224.998 -3
+      vertex 222.521 224.954 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 222.726 224.911 -3
+      vertex 222.927 224.853 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 224.819 223.026 -3
+      vertex 224.884 222.827 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 222.314 224.984 -3
+      vertex 222.521 224.954 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 224.934 222.624 -3
+      vertex 224.971 222.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 222.105 224.998 -3
+      vertex 222.314 224.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 225 222 -3
+      vertex 222.002 224.998 -3
+      vertex 224.993 222.209 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -222 225 -3
+      vertex 222 225 -3
+      vertex -222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex 222 225 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 -224.998 -3
+      vertex -222.002 224.998 -3
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -225 -222 -3
+      vertex -225 222 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222.314 224.984 -3
+      vertex -222.105 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222.521 224.954 -3
+      vertex -222.314 224.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222.726 224.911 -3
+      vertex -222.521 224.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222.927 224.853 -3
+      vertex -222.726 224.911 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -223.124 224.782 -3
+      vertex -222.927 224.853 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -223.315 224.696 -3
+      vertex -223.124 224.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -223.5 224.598 -3
+      vertex -223.315 224.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -223.678 224.487 -3
+      vertex -223.5 224.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -223.847 224.364 -3
+      vertex -223.678 224.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.007 224.229 -3
+      vertex -223.847 224.364 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.158 224.084 -3
+      vertex -224.007 224.229 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.298 223.928 -3
+      vertex -224.158 224.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.427 223.763 -3
+      vertex -224.298 223.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.544 223.59 -3
+      vertex -224.427 223.763 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.649 223.408 -3
+      vertex -224.544 223.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.741 223.22 -3
+      vertex -224.649 223.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.819 223.026 -3
+      vertex -224.741 223.22 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.884 222.827 -3
+      vertex -224.819 223.026 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.934 222.624 -3
+      vertex -224.884 222.827 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.971 222.418 -3
+      vertex -224.934 222.624 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -224.993 222.209 -3
+      vertex -224.971 222.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -225 222 -3
+      vertex -224.993 222.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -225 222 -3
+      vertex -222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.002 -224.998 -3
+      vertex -222.002 -224.998 -3
+      vertex -222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -224.971 -222.418 -3
+      vertex -224.993 -222.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.884 -222.827 -3
+      vertex -224.934 -222.624 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.741 -223.22 -3
+      vertex -222.002 -224.998 -3
+      vertex -224.649 -223.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.741 -223.22 -3
+      vertex -224.819 -223.026 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -224.007 -224.229 -3
+      vertex -224.158 -224.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.427 -223.763 -3
+      vertex -222.002 -224.998 -3
+      vertex -224.298 -223.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.427 -223.763 -3
+      vertex -224.544 -223.59 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.298 -223.928 -3
+      vertex -222.002 -224.998 -3
+      vertex -224.158 -224.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -222.927 -224.853 -3
+      vertex -223.124 -224.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -223.847 -224.364 -3
+      vertex -222.002 -224.998 -3
+      vertex -223.678 -224.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -223.847 -224.364 -3
+      vertex -224.007 -224.229 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -223.678 -224.487 -3
+      vertex -222.002 -224.998 -3
+      vertex -223.5 -224.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -223.5 -224.598 -3
+      vertex -222.002 -224.998 -3
+      vertex -223.315 -224.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -223.315 -224.696 -3
+      vertex -222.002 -224.998 -3
+      vertex -223.124 -224.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.649 -223.408 -3
+      vertex -222.002 -224.998 -3
+      vertex -224.544 -223.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.726 -224.911 -3
+      vertex -222.002 -224.998 -3
+      vertex -222.521 -224.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.726 -224.911 -3
+      vertex -222.927 -224.853 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -224.819 -223.026 -3
+      vertex -224.884 -222.827 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.314 -224.984 -3
+      vertex -222.521 -224.954 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -224.934 -222.624 -3
+      vertex -224.971 -222.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -222.105 -224.998 -3
+      vertex -222.314 -224.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 222.002 -224.998 -3
+      vertex 222 -225 -3
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex 222 -225 -3
+      vertex -222 -225 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -225 -222 -3
+      vertex -222.002 -224.998 -3
+      vertex -224.993 -222.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.314 -224.984 0
+      vertex 222.002 -224.998 0
+      vertex 222.105 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.521 -224.954 0
+      vertex 222.002 -224.998 0
+      vertex 222.314 -224.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 222.002 -224.998 0
+      vertex 225 -222 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.726 -224.911 0
+      vertex 222.002 -224.998 0
+      vertex 222.521 -224.954 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.927 -224.853 0
+      vertex 222.002 -224.998 0
+      vertex 222.726 -224.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.124 -224.782 0
+      vertex 222.002 -224.998 0
+      vertex 222.927 -224.853 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.315 -224.696 0
+      vertex 222.002 -224.998 0
+      vertex 223.124 -224.782 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.5 -224.598 0
+      vertex 222.002 -224.998 0
+      vertex 223.315 -224.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.678 -224.487 0
+      vertex 222.002 -224.998 0
+      vertex 223.5 -224.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.847 -224.364 0
+      vertex 222.002 -224.998 0
+      vertex 223.678 -224.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.007 -224.229 0
+      vertex 222.002 -224.998 0
+      vertex 223.847 -224.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.158 -224.084 0
+      vertex 222.002 -224.998 0
+      vertex 224.007 -224.229 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.298 -223.928 0
+      vertex 222.002 -224.998 0
+      vertex 224.158 -224.084 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.427 -223.763 0
+      vertex 222.002 -224.998 0
+      vertex 224.298 -223.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.544 -223.59 0
+      vertex 222.002 -224.998 0
+      vertex 224.427 -223.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.649 -223.408 0
+      vertex 222.002 -224.998 0
+      vertex 224.544 -223.59 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.741 -223.22 0
+      vertex 222.002 -224.998 0
+      vertex 224.649 -223.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.819 -223.026 0
+      vertex 222.002 -224.998 0
+      vertex 224.741 -223.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.884 -222.827 0
+      vertex 222.002 -224.998 0
+      vertex 224.819 -223.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.934 -222.624 0
+      vertex 222.002 -224.998 0
+      vertex 224.884 -222.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.971 -222.418 0
+      vertex 222.002 -224.998 0
+      vertex 224.934 -222.624 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.993 -222.209 0
+      vertex 222.002 -224.998 0
+      vertex 224.971 -222.418 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 225 -222 0
+      vertex 222.002 -224.998 0
+      vertex 224.993 -222.209 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 225 222 0
+      vertex 222.002 224.998 0
+      vertex 225 -222 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.993 222.209 0
+      vertex 224.971 222.418 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 224.934 222.624 0
+      vertex 224.884 222.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.649 223.408 0
+      vertex 222.002 224.998 0
+      vertex 224.741 223.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 224.819 223.026 0
+      vertex 224.741 223.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.158 224.084 0
+      vertex 224.007 224.229 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.298 223.928 0
+      vertex 222.002 224.998 0
+      vertex 224.427 223.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 224.544 223.59 0
+      vertex 224.427 223.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.158 224.084 0
+      vertex 222.002 224.998 0
+      vertex 224.298 223.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.124 224.782 0
+      vertex 222.927 224.853 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.678 224.487 0
+      vertex 222.002 224.998 0
+      vertex 223.847 224.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 224.007 224.229 0
+      vertex 223.847 224.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.5 224.598 0
+      vertex 222.002 224.998 0
+      vertex 223.678 224.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.315 224.696 0
+      vertex 222.002 224.998 0
+      vertex 223.5 224.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 223.124 224.782 0
+      vertex 222.002 224.998 0
+      vertex 223.315 224.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.544 223.59 0
+      vertex 222.002 224.998 0
+      vertex 224.649 223.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.521 224.954 0
+      vertex 222.002 224.998 0
+      vertex 222.726 224.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 222.927 224.853 0
+      vertex 222.726 224.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 224.884 222.827 0
+      vertex 224.819 223.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 222.521 224.954 0
+      vertex 222.314 224.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.971 222.418 0
+      vertex 224.934 222.624 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.314 224.984 0
+      vertex 222.105 224.998 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 224.993 222.209 0
+      vertex 222.002 224.998 0
+      vertex 225 222 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 224.998 0
+      vertex 222 225 0
+      vertex -222 225 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex 222 225 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 222.002 224.998 0
+      vertex -222.002 224.998 0
+      vertex 222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -225 222 0
+      vertex -225 -222 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.105 224.998 0
+      vertex -222.314 224.984 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.314 224.984 0
+      vertex -222.521 224.954 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.521 224.954 0
+      vertex -222.726 224.911 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.726 224.911 0
+      vertex -222.927 224.853 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.927 224.853 0
+      vertex -223.124 224.782 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -223.124 224.782 0
+      vertex -223.315 224.696 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -223.315 224.696 0
+      vertex -223.5 224.598 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -223.5 224.598 0
+      vertex -223.678 224.487 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -223.678 224.487 0
+      vertex -223.847 224.364 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -223.847 224.364 0
+      vertex -224.007 224.229 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.007 224.229 0
+      vertex -224.158 224.084 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.158 224.084 0
+      vertex -224.298 223.928 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.298 223.928 0
+      vertex -224.427 223.763 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.427 223.763 0
+      vertex -224.544 223.59 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.544 223.59 0
+      vertex -224.649 223.408 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.649 223.408 0
+      vertex -224.741 223.22 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.741 223.22 0
+      vertex -224.819 223.026 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.819 223.026 0
+      vertex -224.884 222.827 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.884 222.827 0
+      vertex -224.934 222.624 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.934 222.624 0
+      vertex -224.971 222.418 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.971 222.418 0
+      vertex -224.993 222.209 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -224.993 222.209 0
+      vertex -225 222 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 224.998 0
+      vertex -225 222 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 224.998 0
+      vertex -222.002 -224.998 0
+      vertex 222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -224.993 -222.209 0
+      vertex -224.971 -222.418 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -224.934 -222.624 0
+      vertex -224.884 -222.827 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -224.649 -223.408 0
+      vertex -222.002 -224.998 0
+      vertex -224.741 -223.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -224.819 -223.026 0
+      vertex -224.741 -223.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -224.158 -224.084 0
+      vertex -224.007 -224.229 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -224.298 -223.928 0
+      vertex -222.002 -224.998 0
+      vertex -224.427 -223.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -224.544 -223.59 0
+      vertex -224.427 -223.763 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -224.158 -224.084 0
+      vertex -222.002 -224.998 0
+      vertex -224.298 -223.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -223.124 -224.782 0
+      vertex -222.927 -224.853 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -223.678 -224.487 0
+      vertex -222.002 -224.998 0
+      vertex -223.847 -224.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -224.007 -224.229 0
+      vertex -223.847 -224.364 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -223.5 -224.598 0
+      vertex -222.002 -224.998 0
+      vertex -223.678 -224.487 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -223.315 -224.696 0
+      vertex -222.002 -224.998 0
+      vertex -223.5 -224.598 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -223.124 -224.782 0
+      vertex -222.002 -224.998 0
+      vertex -223.315 -224.696 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -224.544 -223.59 0
+      vertex -222.002 -224.998 0
+      vertex -224.649 -223.408 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -222.521 -224.954 0
+      vertex -222.002 -224.998 0
+      vertex -222.726 -224.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -222.927 -224.853 0
+      vertex -222.726 -224.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -224.884 -222.827 0
+      vertex -224.819 -223.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex -222.521 -224.954 0
+      vertex -222.314 -224.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -224.971 -222.418 0
+      vertex -224.934 -222.624 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -222.314 -224.984 0
+      vertex -222.105 -224.998 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -222.002 -224.998 0
+      vertex 222 -225 0
+      vertex 222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -222 -225 0
+      vertex 222 -225 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -224.993 -222.209 0
+      vertex -222.002 -224.998 0
+      vertex -225 -222 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 222.105 -224.998 -3
+      vertex 222.002 -224.998 0
+      vertex 222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 222.105 -224.998 -3
+      vertex 222.105 -224.998 0
+      vertex 222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 222.314 -224.984 -3
+      vertex 222.105 -224.998 0
+      vertex 222.105 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 222.314 -224.984 -3
+      vertex 222.314 -224.984 0
+      vertex 222.105 -224.998 0
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 222.521 -224.954 -3
+      vertex 222.314 -224.984 0
+      vertex 222.314 -224.984 -3
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 222.521 -224.954 -3
+      vertex 222.521 -224.954 0
+      vertex 222.314 -224.984 0
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 222.726 -224.911 -3
+      vertex 222.521 -224.954 0
+      vertex 222.521 -224.954 -3
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 222.726 -224.911 -3
+      vertex 222.726 -224.911 0
+      vertex 222.521 -224.954 0
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 222.927 -224.853 -3
+      vertex 222.726 -224.911 0
+      vertex 222.726 -224.911 -3
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 222.927 -224.853 -3
+      vertex 222.927 -224.853 0
+      vertex 222.726 -224.911 0
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 223.124 -224.782 -3
+      vertex 222.927 -224.853 0
+      vertex 222.927 -224.853 -3
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 223.124 -224.782 -3
+      vertex 223.124 -224.782 0
+      vertex 222.927 -224.853 0
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 223.315 -224.696 -3
+      vertex 223.124 -224.782 0
+      vertex 223.124 -224.782 -3
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 223.315 -224.696 -3
+      vertex 223.315 -224.696 0
+      vertex 223.124 -224.782 0
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 223.5 -224.598 -3
+      vertex 223.315 -224.696 0
+      vertex 223.315 -224.696 -3
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 223.5 -224.598 -3
+      vertex 223.5 -224.598 0
+      vertex 223.315 -224.696 0
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 223.678 -224.487 -3
+      vertex 223.5 -224.598 0
+      vertex 223.5 -224.598 -3
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 223.678 -224.487 -3
+      vertex 223.678 -224.487 0
+      vertex 223.5 -224.598 0
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 223.847 -224.364 -3
+      vertex 223.678 -224.487 0
+      vertex 223.678 -224.487 -3
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 223.847 -224.364 -3
+      vertex 223.847 -224.364 0
+      vertex 223.678 -224.487 0
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 224.007 -224.229 -3
+      vertex 223.847 -224.364 0
+      vertex 223.847 -224.364 -3
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 224.007 -224.229 -3
+      vertex 224.007 -224.229 0
+      vertex 223.847 -224.364 0
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 224.158 -224.084 -3
+      vertex 224.007 -224.229 0
+      vertex 224.007 -224.229 -3
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 224.158 -224.084 -3
+      vertex 224.158 -224.084 0
+      vertex 224.007 -224.229 0
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 224.298 -223.928 -3
+      vertex 224.158 -224.084 0
+      vertex 224.158 -224.084 -3
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 224.298 -223.928 -3
+      vertex 224.298 -223.928 0
+      vertex 224.158 -224.084 0
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 224.427 -223.763 -3
+      vertex 224.298 -223.928 0
+      vertex 224.298 -223.928 -3
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 224.427 -223.763 -3
+      vertex 224.427 -223.763 0
+      vertex 224.298 -223.928 0
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 224.544 -223.59 -3
+      vertex 224.427 -223.763 0
+      vertex 224.427 -223.763 -3
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 224.544 -223.59 -3
+      vertex 224.544 -223.59 0
+      vertex 224.427 -223.763 0
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 224.649 -223.408 -3
+      vertex 224.544 -223.59 0
+      vertex 224.544 -223.59 -3
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 224.649 -223.408 -3
+      vertex 224.649 -223.408 0
+      vertex 224.544 -223.59 0
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 224.741 -223.22 -3
+      vertex 224.649 -223.408 0
+      vertex 224.649 -223.408 -3
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 224.741 -223.22 -3
+      vertex 224.741 -223.22 0
+      vertex 224.649 -223.408 0
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 224.819 -223.026 -3
+      vertex 224.741 -223.22 0
+      vertex 224.741 -223.22 -3
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 224.819 -223.026 -3
+      vertex 224.819 -223.026 0
+      vertex 224.741 -223.22 0
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 224.884 -222.827 -3
+      vertex 224.819 -223.026 0
+      vertex 224.819 -223.026 -3
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 224.884 -222.827 -3
+      vertex 224.884 -222.827 0
+      vertex 224.819 -223.026 0
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 224.934 -222.624 -3
+      vertex 224.884 -222.827 0
+      vertex 224.884 -222.827 -3
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 224.934 -222.624 -3
+      vertex 224.934 -222.624 0
+      vertex 224.884 -222.827 0
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 224.971 -222.418 -3
+      vertex 224.934 -222.624 0
+      vertex 224.934 -222.624 -3
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 224.971 -222.418 -3
+      vertex 224.971 -222.418 0
+      vertex 224.934 -222.624 0
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 224.993 -222.209 -3
+      vertex 224.971 -222.418 0
+      vertex 224.971 -222.418 -3
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 224.993 -222.209 -3
+      vertex 224.993 -222.209 0
+      vertex 224.971 -222.418 0
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 225 -222 -3
+      vertex 224.993 -222.209 0
+      vertex 224.993 -222.209 -3
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 225 -222 -3
+      vertex 225 -222 0
+      vertex 224.993 -222.209 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 225 222 -3
+      vertex 225 -222 0
+      vertex 225 -222 -3
+    endloop
+  endfacet
+  facet normal 1 0 -0
+    outer loop
+      vertex 225 222 -3
+      vertex 225 222 0
+      vertex 225 -222 0
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 0
+    outer loop
+      vertex 224.993 222.209 -3
+      vertex 225 222 0
+      vertex 225 222 -3
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 -0
+    outer loop
+      vertex 224.993 222.209 -3
+      vertex 224.993 222.209 0
+      vertex 225 222 0
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex 224.971 222.418 -3
+      vertex 224.993 222.209 0
+      vertex 224.993 222.209 -3
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 -0
+    outer loop
+      vertex 224.971 222.418 -3
+      vertex 224.971 222.418 0
+      vertex 224.993 222.209 0
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 0
+    outer loop
+      vertex 224.934 222.624 -3
+      vertex 224.971 222.418 0
+      vertex 224.971 222.418 -3
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 -0
+    outer loop
+      vertex 224.934 222.624 -3
+      vertex 224.934 222.624 0
+      vertex 224.971 222.418 0
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 0
+    outer loop
+      vertex 224.884 222.827 -3
+      vertex 224.934 222.624 0
+      vertex 224.934 222.624 -3
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 -0
+    outer loop
+      vertex 224.884 222.827 -3
+      vertex 224.884 222.827 0
+      vertex 224.934 222.624 0
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 0
+    outer loop
+      vertex 224.819 223.026 -3
+      vertex 224.884 222.827 0
+      vertex 224.884 222.827 -3
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 -0
+    outer loop
+      vertex 224.819 223.026 -3
+      vertex 224.819 223.026 0
+      vertex 224.884 222.827 0
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 0
+    outer loop
+      vertex 224.741 223.22 -3
+      vertex 224.819 223.026 0
+      vertex 224.819 223.026 -3
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 -0
+    outer loop
+      vertex 224.741 223.22 -3
+      vertex 224.741 223.22 0
+      vertex 224.819 223.026 0
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 0
+    outer loop
+      vertex 224.649 223.408 -3
+      vertex 224.741 223.22 0
+      vertex 224.741 223.22 -3
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 -0
+    outer loop
+      vertex 224.649 223.408 -3
+      vertex 224.649 223.408 0
+      vertex 224.741 223.22 0
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 0
+    outer loop
+      vertex 224.544 223.59 -3
+      vertex 224.649 223.408 0
+      vertex 224.649 223.408 -3
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 -0
+    outer loop
+      vertex 224.544 223.59 -3
+      vertex 224.544 223.59 0
+      vertex 224.649 223.408 0
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 0
+    outer loop
+      vertex 224.427 223.763 -3
+      vertex 224.544 223.59 0
+      vertex 224.544 223.59 -3
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 -0
+    outer loop
+      vertex 224.427 223.763 -3
+      vertex 224.427 223.763 0
+      vertex 224.544 223.59 0
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 0
+    outer loop
+      vertex 224.298 223.928 -3
+      vertex 224.427 223.763 0
+      vertex 224.427 223.763 -3
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 -0
+    outer loop
+      vertex 224.298 223.928 -3
+      vertex 224.298 223.928 0
+      vertex 224.427 223.763 0
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 0
+    outer loop
+      vertex 224.158 224.084 -3
+      vertex 224.298 223.928 0
+      vertex 224.298 223.928 -3
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 -0
+    outer loop
+      vertex 224.158 224.084 -3
+      vertex 224.158 224.084 0
+      vertex 224.298 223.928 0
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 0
+    outer loop
+      vertex 224.007 224.229 -3
+      vertex 224.158 224.084 0
+      vertex 224.158 224.084 -3
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 -0
+    outer loop
+      vertex 224.007 224.229 -3
+      vertex 224.007 224.229 0
+      vertex 224.158 224.084 0
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 0
+    outer loop
+      vertex 223.847 224.364 -3
+      vertex 224.007 224.229 0
+      vertex 224.007 224.229 -3
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 -0
+    outer loop
+      vertex 223.847 224.364 -3
+      vertex 223.847 224.364 0
+      vertex 224.007 224.229 0
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 0
+    outer loop
+      vertex 223.678 224.487 -3
+      vertex 223.847 224.364 0
+      vertex 223.847 224.364 -3
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 -0
+    outer loop
+      vertex 223.678 224.487 -3
+      vertex 223.678 224.487 0
+      vertex 223.847 224.364 0
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 0
+    outer loop
+      vertex 223.5 224.598 -3
+      vertex 223.678 224.487 0
+      vertex 223.678 224.487 -3
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 -0
+    outer loop
+      vertex 223.5 224.598 -3
+      vertex 223.5 224.598 0
+      vertex 223.678 224.487 0
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 0
+    outer loop
+      vertex 223.315 224.696 -3
+      vertex 223.5 224.598 0
+      vertex 223.5 224.598 -3
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 -0
+    outer loop
+      vertex 223.315 224.696 -3
+      vertex 223.315 224.696 0
+      vertex 223.5 224.598 0
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 0
+    outer loop
+      vertex 223.124 224.782 -3
+      vertex 223.315 224.696 0
+      vertex 223.315 224.696 -3
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 -0
+    outer loop
+      vertex 223.124 224.782 -3
+      vertex 223.124 224.782 0
+      vertex 223.315 224.696 0
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 0
+    outer loop
+      vertex 222.927 224.853 -3
+      vertex 223.124 224.782 0
+      vertex 223.124 224.782 -3
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 -0
+    outer loop
+      vertex 222.927 224.853 -3
+      vertex 222.927 224.853 0
+      vertex 223.124 224.782 0
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 0
+    outer loop
+      vertex 222.726 224.911 -3
+      vertex 222.927 224.853 0
+      vertex 222.927 224.853 -3
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 -0
+    outer loop
+      vertex 222.726 224.911 -3
+      vertex 222.726 224.911 0
+      vertex 222.927 224.853 0
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 0
+    outer loop
+      vertex 222.521 224.954 -3
+      vertex 222.726 224.911 0
+      vertex 222.726 224.911 -3
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 -0
+    outer loop
+      vertex 222.521 224.954 -3
+      vertex 222.521 224.954 0
+      vertex 222.726 224.911 0
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 0
+    outer loop
+      vertex 222.314 224.984 -3
+      vertex 222.521 224.954 0
+      vertex 222.521 224.954 -3
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 -0
+    outer loop
+      vertex 222.314 224.984 -3
+      vertex 222.314 224.984 0
+      vertex 222.521 224.954 0
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 0
+    outer loop
+      vertex 222.105 224.998 -3
+      vertex 222.314 224.984 0
+      vertex 222.314 224.984 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 -0
+    outer loop
+      vertex 222.105 224.998 -3
+      vertex 222.105 224.998 0
+      vertex 222.314 224.984 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 222.105 224.998 0
+      vertex 222.105 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 222.002 224.998 -3
+      vertex 222.002 224.998 0
+      vertex 222.105 224.998 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 222 225 -3
+      vertex 222.002 224.998 0
+      vertex 222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 -0
+    outer loop
+      vertex 222 225 -3
+      vertex 222 225 0
+      vertex 222.002 224.998 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -222 225 -3
+      vertex 222 225 0
+      vertex 222 225 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -222 225 -3
+      vertex -222 225 0
+      vertex 222 225 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222 225 0
+      vertex -222 225 -3
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -222.002 224.998 -3
+      vertex -222.002 224.998 0
+      vertex -222 225 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -222.105 224.998 -3
+      vertex -222.002 224.998 0
+      vertex -222.002 224.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -222.105 224.998 -3
+      vertex -222.105 224.998 0
+      vertex -222.002 224.998 0
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -222.314 224.984 -3
+      vertex -222.105 224.998 0
+      vertex -222.105 224.998 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -222.314 224.984 -3
+      vertex -222.314 224.984 0
+      vertex -222.105 224.998 0
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -222.521 224.954 -3
+      vertex -222.314 224.984 0
+      vertex -222.314 224.984 -3
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -222.521 224.954 -3
+      vertex -222.521 224.954 0
+      vertex -222.314 224.984 0
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -222.726 224.911 -3
+      vertex -222.521 224.954 0
+      vertex -222.521 224.954 -3
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -222.726 224.911 -3
+      vertex -222.726 224.911 0
+      vertex -222.521 224.954 0
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -222.927 224.853 -3
+      vertex -222.726 224.911 0
+      vertex -222.726 224.911 -3
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -222.927 224.853 -3
+      vertex -222.927 224.853 0
+      vertex -222.726 224.911 0
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -223.124 224.782 -3
+      vertex -222.927 224.853 0
+      vertex -222.927 224.853 -3
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -223.124 224.782 -3
+      vertex -223.124 224.782 0
+      vertex -222.927 224.853 0
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -223.315 224.696 -3
+      vertex -223.124 224.782 0
+      vertex -223.124 224.782 -3
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -223.315 224.696 -3
+      vertex -223.315 224.696 0
+      vertex -223.124 224.782 0
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -223.5 224.598 -3
+      vertex -223.315 224.696 0
+      vertex -223.315 224.696 -3
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -223.5 224.598 -3
+      vertex -223.5 224.598 0
+      vertex -223.315 224.696 0
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -223.678 224.487 -3
+      vertex -223.5 224.598 0
+      vertex -223.5 224.598 -3
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -223.678 224.487 -3
+      vertex -223.678 224.487 0
+      vertex -223.5 224.598 0
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -223.847 224.364 -3
+      vertex -223.678 224.487 0
+      vertex -223.678 224.487 -3
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -223.847 224.364 -3
+      vertex -223.847 224.364 0
+      vertex -223.678 224.487 0
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -224.007 224.229 -3
+      vertex -223.847 224.364 0
+      vertex -223.847 224.364 -3
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -224.007 224.229 -3
+      vertex -224.007 224.229 0
+      vertex -223.847 224.364 0
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -224.158 224.084 -3
+      vertex -224.007 224.229 0
+      vertex -224.007 224.229 -3
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -224.158 224.084 -3
+      vertex -224.158 224.084 0
+      vertex -224.007 224.229 0
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -224.298 223.928 -3
+      vertex -224.158 224.084 0
+      vertex -224.158 224.084 -3
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -224.298 223.928 -3
+      vertex -224.298 223.928 0
+      vertex -224.158 224.084 0
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -224.427 223.763 -3
+      vertex -224.298 223.928 0
+      vertex -224.298 223.928 -3
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -224.427 223.763 -3
+      vertex -224.427 223.763 0
+      vertex -224.298 223.928 0
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -224.544 223.59 -3
+      vertex -224.427 223.763 0
+      vertex -224.427 223.763 -3
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -224.544 223.59 -3
+      vertex -224.544 223.59 0
+      vertex -224.427 223.763 0
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -224.649 223.408 -3
+      vertex -224.544 223.59 0
+      vertex -224.544 223.59 -3
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -224.649 223.408 -3
+      vertex -224.649 223.408 0
+      vertex -224.544 223.59 0
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -224.741 223.22 -3
+      vertex -224.649 223.408 0
+      vertex -224.649 223.408 -3
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -224.741 223.22 -3
+      vertex -224.741 223.22 0
+      vertex -224.649 223.408 0
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -224.819 223.026 -3
+      vertex -224.741 223.22 0
+      vertex -224.741 223.22 -3
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -224.819 223.026 -3
+      vertex -224.819 223.026 0
+      vertex -224.741 223.22 0
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -224.884 222.827 -3
+      vertex -224.819 223.026 0
+      vertex -224.819 223.026 -3
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -224.884 222.827 -3
+      vertex -224.884 222.827 0
+      vertex -224.819 223.026 0
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -224.934 222.624 -3
+      vertex -224.884 222.827 0
+      vertex -224.884 222.827 -3
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -224.934 222.624 -3
+      vertex -224.934 222.624 0
+      vertex -224.884 222.827 0
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -224.971 222.418 -3
+      vertex -224.934 222.624 0
+      vertex -224.934 222.624 -3
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -224.971 222.418 -3
+      vertex -224.971 222.418 0
+      vertex -224.934 222.624 0
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -224.993 222.209 -3
+      vertex -224.971 222.418 0
+      vertex -224.971 222.418 -3
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -224.993 222.209 -3
+      vertex -224.993 222.209 0
+      vertex -224.971 222.418 0
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -225 222 -3
+      vertex -224.993 222.209 0
+      vertex -224.993 222.209 -3
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -225 222 -3
+      vertex -225 222 0
+      vertex -224.993 222.209 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -225 -222 -3
+      vertex -225 222 0
+      vertex -225 222 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -225 -222 -3
+      vertex -225 -222 0
+      vertex -225 222 0
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -224.993 -222.209 -3
+      vertex -225 -222 0
+      vertex -225 -222 -3
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -224.993 -222.209 -3
+      vertex -224.993 -222.209 0
+      vertex -225 -222 0
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -224.971 -222.418 -3
+      vertex -224.993 -222.209 0
+      vertex -224.993 -222.209 -3
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -224.971 -222.418 -3
+      vertex -224.971 -222.418 0
+      vertex -224.993 -222.209 0
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -224.934 -222.624 -3
+      vertex -224.971 -222.418 0
+      vertex -224.971 -222.418 -3
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -224.934 -222.624 -3
+      vertex -224.934 -222.624 0
+      vertex -224.971 -222.418 0
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -224.884 -222.827 -3
+      vertex -224.934 -222.624 0
+      vertex -224.934 -222.624 -3
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -224.884 -222.827 -3
+      vertex -224.884 -222.827 0
+      vertex -224.934 -222.624 0
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -224.819 -223.026 -3
+      vertex -224.884 -222.827 0
+      vertex -224.884 -222.827 -3
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -224.819 -223.026 -3
+      vertex -224.819 -223.026 0
+      vertex -224.884 -222.827 0
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -224.741 -223.22 -3
+      vertex -224.819 -223.026 0
+      vertex -224.819 -223.026 -3
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -224.741 -223.22 -3
+      vertex -224.741 -223.22 0
+      vertex -224.819 -223.026 0
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -224.649 -223.408 -3
+      vertex -224.741 -223.22 0
+      vertex -224.741 -223.22 -3
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -224.649 -223.408 -3
+      vertex -224.649 -223.408 0
+      vertex -224.741 -223.22 0
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -224.544 -223.59 -3
+      vertex -224.649 -223.408 0
+      vertex -224.649 -223.408 -3
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -224.544 -223.59 -3
+      vertex -224.544 -223.59 0
+      vertex -224.649 -223.408 0
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -224.427 -223.763 -3
+      vertex -224.544 -223.59 0
+      vertex -224.544 -223.59 -3
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -224.427 -223.763 -3
+      vertex -224.427 -223.763 0
+      vertex -224.544 -223.59 0
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -224.298 -223.928 -3
+      vertex -224.427 -223.763 0
+      vertex -224.427 -223.763 -3
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -224.298 -223.928 -3
+      vertex -224.298 -223.928 0
+      vertex -224.427 -223.763 0
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -224.158 -224.084 -3
+      vertex -224.298 -223.928 0
+      vertex -224.298 -223.928 -3
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -224.158 -224.084 -3
+      vertex -224.158 -224.084 0
+      vertex -224.298 -223.928 0
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -224.007 -224.229 -3
+      vertex -224.158 -224.084 0
+      vertex -224.158 -224.084 -3
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -224.007 -224.229 -3
+      vertex -224.007 -224.229 0
+      vertex -224.158 -224.084 0
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -223.847 -224.364 -3
+      vertex -224.007 -224.229 0
+      vertex -224.007 -224.229 -3
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -223.847 -224.364 -3
+      vertex -223.847 -224.364 0
+      vertex -224.007 -224.229 0
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -223.678 -224.487 -3
+      vertex -223.847 -224.364 0
+      vertex -223.847 -224.364 -3
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -223.678 -224.487 -3
+      vertex -223.678 -224.487 0
+      vertex -223.847 -224.364 0
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -223.5 -224.598 -3
+      vertex -223.678 -224.487 0
+      vertex -223.678 -224.487 -3
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -223.5 -224.598 -3
+      vertex -223.5 -224.598 0
+      vertex -223.678 -224.487 0
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -223.315 -224.696 -3
+      vertex -223.5 -224.598 0
+      vertex -223.5 -224.598 -3
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -223.315 -224.696 -3
+      vertex -223.315 -224.696 0
+      vertex -223.5 -224.598 0
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -223.124 -224.782 -3
+      vertex -223.315 -224.696 0
+      vertex -223.315 -224.696 -3
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -223.124 -224.782 -3
+      vertex -223.124 -224.782 0
+      vertex -223.315 -224.696 0
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -222.927 -224.853 -3
+      vertex -223.124 -224.782 0
+      vertex -223.124 -224.782 -3
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -222.927 -224.853 -3
+      vertex -222.927 -224.853 0
+      vertex -223.124 -224.782 0
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -222.726 -224.911 -3
+      vertex -222.927 -224.853 0
+      vertex -222.927 -224.853 -3
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -222.726 -224.911 -3
+      vertex -222.726 -224.911 0
+      vertex -222.927 -224.853 0
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -222.521 -224.954 -3
+      vertex -222.726 -224.911 0
+      vertex -222.726 -224.911 -3
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -222.521 -224.954 -3
+      vertex -222.521 -224.954 0
+      vertex -222.726 -224.911 0
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -222.314 -224.984 -3
+      vertex -222.521 -224.954 0
+      vertex -222.521 -224.954 -3
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -222.314 -224.984 -3
+      vertex -222.314 -224.984 0
+      vertex -222.521 -224.954 0
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -222.105 -224.998 -3
+      vertex -222.314 -224.984 0
+      vertex -222.314 -224.984 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -222.105 -224.998 -3
+      vertex -222.105 -224.998 0
+      vertex -222.314 -224.984 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -222.105 -224.998 0
+      vertex -222.105 -224.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -222.002 -224.998 -3
+      vertex -222.002 -224.998 0
+      vertex -222.105 -224.998 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -222 -225 -3
+      vertex -222.002 -224.998 0
+      vertex -222.002 -224.998 -3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -222 -225 -3
+      vertex -222 -225 0
+      vertex -222.002 -224.998 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 222 -225 -3
+      vertex -222 -225 0
+      vertex -222 -225 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 222 -225 -3
+      vertex 222 -225 0
+      vertex -222 -225 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 222.002 -224.998 -3
+      vertex 222 -225 0
+      vertex 222 -225 -3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 222.002 -224.998 -3
+      vertex 222.002 -224.998 0
+      vertex 222 -225 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/resources/profiles/Creality/k1.svg
+++ b/resources/profiles/Creality/k1.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="210mm" height="210mm" version="1.1" viewBox="0 0 210 210" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".25" y=".25" width="209.5" height="209.5" fill="none" stroke="#fff" stroke-width=".5"/>
+</svg>

--- a/resources/profiles/Creality/k1_bed.stl
+++ b/resources/profiles/Creality/k1_bed.stl
@@ -1,0 +1,2774 @@
+solid OpenSCAD_Model
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.105 -109.998 -3
+      vertex 107.002 -109.998 -3
+      vertex 107.314 -109.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 107.314 -109.984 -3
+      vertex 107.002 -109.998 -3
+      vertex 107.521 -109.954 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 110 -107 -3
+      vertex 107.002 -109.998 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 107.521 -109.954 -3
+      vertex 107.002 -109.998 -3
+      vertex 107.726 -109.911 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 107.726 -109.911 -3
+      vertex 107.002 -109.998 -3
+      vertex 107.927 -109.853 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 107.927 -109.853 -3
+      vertex 107.002 -109.998 -3
+      vertex 108.124 -109.782 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.124 -109.782 -3
+      vertex 107.002 -109.998 -3
+      vertex 108.315 -109.696 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.315 -109.696 -3
+      vertex 107.002 -109.998 -3
+      vertex 108.5 -109.598 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.5 -109.598 -3
+      vertex 107.002 -109.998 -3
+      vertex 108.678 -109.487 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.678 -109.487 -3
+      vertex 107.002 -109.998 -3
+      vertex 108.847 -109.364 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.847 -109.364 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.007 -109.229 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.007 -109.229 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.158 -109.084 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.158 -109.084 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.298 -108.928 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.298 -108.928 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.427 -108.763 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.427 -108.763 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.544 -108.59 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.544 -108.59 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.649 -108.408 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.649 -108.408 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.741 -108.22 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.741 -108.22 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.819 -108.026 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.819 -108.026 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.884 -107.827 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.884 -107.827 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.934 -107.624 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.934 -107.624 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.971 -107.418 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.971 -107.418 -3
+      vertex 107.002 -109.998 -3
+      vertex 109.993 -107.209 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 109.993 -107.209 -3
+      vertex 107.002 -109.998 -3
+      vertex 110 -107 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110 -107 -3
+      vertex 107.002 109.998 -3
+      vertex 110 107 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 109.971 107.418 -3
+      vertex 109.993 107.209 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 109.884 107.827 -3
+      vertex 109.934 107.624 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 109.741 108.22 -3
+      vertex 107.002 109.998 -3
+      vertex 109.649 108.408 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 109.741 108.22 -3
+      vertex 109.819 108.026 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 109.007 109.229 -3
+      vertex 109.158 109.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 109.427 108.763 -3
+      vertex 107.002 109.998 -3
+      vertex 109.298 108.928 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 109.427 108.763 -3
+      vertex 109.544 108.59 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 109.298 108.928 -3
+      vertex 107.002 109.998 -3
+      vertex 109.158 109.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 107.927 109.853 -3
+      vertex 108.124 109.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108.847 109.364 -3
+      vertex 107.002 109.998 -3
+      vertex 108.678 109.487 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 108.847 109.364 -3
+      vertex 109.007 109.229 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108.678 109.487 -3
+      vertex 107.002 109.998 -3
+      vertex 108.5 109.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108.5 109.598 -3
+      vertex 107.002 109.998 -3
+      vertex 108.315 109.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108.315 109.696 -3
+      vertex 107.002 109.998 -3
+      vertex 108.124 109.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 109.649 108.408 -3
+      vertex 107.002 109.998 -3
+      vertex 109.544 108.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.726 109.911 -3
+      vertex 107.002 109.998 -3
+      vertex 107.521 109.954 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 107.726 109.911 -3
+      vertex 107.927 109.853 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 109.819 108.026 -3
+      vertex 109.884 107.827 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 107.314 109.984 -3
+      vertex 107.521 109.954 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 109.934 107.624 -3
+      vertex 109.971 107.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 107.105 109.998 -3
+      vertex 107.314 109.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 110 107 -3
+      vertex 107.002 109.998 -3
+      vertex 109.993 107.209 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -107 110 -3
+      vertex 107 110 -3
+      vertex -107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex 107 110 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 -109.998 -3
+      vertex -107.002 109.998 -3
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -110 -107 -3
+      vertex -110 107 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107.314 109.984 -3
+      vertex -107.105 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107.521 109.954 -3
+      vertex -107.314 109.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107.726 109.911 -3
+      vertex -107.521 109.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107.927 109.853 -3
+      vertex -107.726 109.911 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -108.124 109.782 -3
+      vertex -107.927 109.853 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -108.315 109.696 -3
+      vertex -108.124 109.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -108.5 109.598 -3
+      vertex -108.315 109.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -108.678 109.487 -3
+      vertex -108.5 109.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -108.847 109.364 -3
+      vertex -108.678 109.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.007 109.229 -3
+      vertex -108.847 109.364 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.158 109.084 -3
+      vertex -109.007 109.229 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.298 108.928 -3
+      vertex -109.158 109.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.427 108.763 -3
+      vertex -109.298 108.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.544 108.59 -3
+      vertex -109.427 108.763 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.649 108.408 -3
+      vertex -109.544 108.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.741 108.22 -3
+      vertex -109.649 108.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.819 108.026 -3
+      vertex -109.741 108.22 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.884 107.827 -3
+      vertex -109.819 108.026 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.934 107.624 -3
+      vertex -109.884 107.827 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.971 107.418 -3
+      vertex -109.934 107.624 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -109.993 107.209 -3
+      vertex -109.971 107.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -110 107 -3
+      vertex -109.993 107.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -110 107 -3
+      vertex -107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 107.002 -109.998 -3
+      vertex -107.002 -109.998 -3
+      vertex -107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -109.971 -107.418 -3
+      vertex -109.993 -107.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.884 -107.827 -3
+      vertex -109.934 -107.624 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.741 -108.22 -3
+      vertex -107.002 -109.998 -3
+      vertex -109.649 -108.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.741 -108.22 -3
+      vertex -109.819 -108.026 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -109.007 -109.229 -3
+      vertex -109.158 -109.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.427 -108.763 -3
+      vertex -107.002 -109.998 -3
+      vertex -109.298 -108.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.427 -108.763 -3
+      vertex -109.544 -108.59 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.298 -108.928 -3
+      vertex -107.002 -109.998 -3
+      vertex -109.158 -109.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -107.927 -109.853 -3
+      vertex -108.124 -109.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -108.847 -109.364 -3
+      vertex -107.002 -109.998 -3
+      vertex -108.678 -109.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -108.847 -109.364 -3
+      vertex -109.007 -109.229 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -108.678 -109.487 -3
+      vertex -107.002 -109.998 -3
+      vertex -108.5 -109.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -108.5 -109.598 -3
+      vertex -107.002 -109.998 -3
+      vertex -108.315 -109.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -108.315 -109.696 -3
+      vertex -107.002 -109.998 -3
+      vertex -108.124 -109.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.649 -108.408 -3
+      vertex -107.002 -109.998 -3
+      vertex -109.544 -108.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.726 -109.911 -3
+      vertex -107.002 -109.998 -3
+      vertex -107.521 -109.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.726 -109.911 -3
+      vertex -107.927 -109.853 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -109.819 -108.026 -3
+      vertex -109.884 -107.827 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.314 -109.984 -3
+      vertex -107.521 -109.954 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -109.934 -107.624 -3
+      vertex -109.971 -107.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -107.105 -109.998 -3
+      vertex -107.314 -109.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 107.002 -109.998 -3
+      vertex 107 -110 -3
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex 107 -110 -3
+      vertex -107 -110 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -110 -107 -3
+      vertex -107.002 -109.998 -3
+      vertex -109.993 -107.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.314 -109.984 0
+      vertex 107.002 -109.998 0
+      vertex 107.105 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.521 -109.954 0
+      vertex 107.002 -109.998 0
+      vertex 107.314 -109.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 107.002 -109.998 0
+      vertex 110 -107 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.726 -109.911 0
+      vertex 107.002 -109.998 0
+      vertex 107.521 -109.954 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.927 -109.853 0
+      vertex 107.002 -109.998 0
+      vertex 107.726 -109.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.124 -109.782 0
+      vertex 107.002 -109.998 0
+      vertex 107.927 -109.853 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.315 -109.696 0
+      vertex 107.002 -109.998 0
+      vertex 108.124 -109.782 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.5 -109.598 0
+      vertex 107.002 -109.998 0
+      vertex 108.315 -109.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.678 -109.487 0
+      vertex 107.002 -109.998 0
+      vertex 108.5 -109.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.847 -109.364 0
+      vertex 107.002 -109.998 0
+      vertex 108.678 -109.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.007 -109.229 0
+      vertex 107.002 -109.998 0
+      vertex 108.847 -109.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.158 -109.084 0
+      vertex 107.002 -109.998 0
+      vertex 109.007 -109.229 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.298 -108.928 0
+      vertex 107.002 -109.998 0
+      vertex 109.158 -109.084 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.427 -108.763 0
+      vertex 107.002 -109.998 0
+      vertex 109.298 -108.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.544 -108.59 0
+      vertex 107.002 -109.998 0
+      vertex 109.427 -108.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.649 -108.408 0
+      vertex 107.002 -109.998 0
+      vertex 109.544 -108.59 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.741 -108.22 0
+      vertex 107.002 -109.998 0
+      vertex 109.649 -108.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.819 -108.026 0
+      vertex 107.002 -109.998 0
+      vertex 109.741 -108.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.884 -107.827 0
+      vertex 107.002 -109.998 0
+      vertex 109.819 -108.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.934 -107.624 0
+      vertex 107.002 -109.998 0
+      vertex 109.884 -107.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.971 -107.418 0
+      vertex 107.002 -109.998 0
+      vertex 109.934 -107.624 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.993 -107.209 0
+      vertex 107.002 -109.998 0
+      vertex 109.971 -107.418 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110 -107 0
+      vertex 107.002 -109.998 0
+      vertex 109.993 -107.209 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 110 107 0
+      vertex 107.002 109.998 0
+      vertex 110 -107 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.993 107.209 0
+      vertex 109.971 107.418 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 109.934 107.624 0
+      vertex 109.884 107.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.649 108.408 0
+      vertex 107.002 109.998 0
+      vertex 109.741 108.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 109.819 108.026 0
+      vertex 109.741 108.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.158 109.084 0
+      vertex 109.007 109.229 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.298 108.928 0
+      vertex 107.002 109.998 0
+      vertex 109.427 108.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 109.544 108.59 0
+      vertex 109.427 108.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.158 109.084 0
+      vertex 107.002 109.998 0
+      vertex 109.298 108.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.124 109.782 0
+      vertex 107.927 109.853 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.678 109.487 0
+      vertex 107.002 109.998 0
+      vertex 108.847 109.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 109.007 109.229 0
+      vertex 108.847 109.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.5 109.598 0
+      vertex 107.002 109.998 0
+      vertex 108.678 109.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.315 109.696 0
+      vertex 107.002 109.998 0
+      vertex 108.5 109.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108.124 109.782 0
+      vertex 107.002 109.998 0
+      vertex 108.315 109.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.544 108.59 0
+      vertex 107.002 109.998 0
+      vertex 109.649 108.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.521 109.954 0
+      vertex 107.002 109.998 0
+      vertex 107.726 109.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 107.927 109.853 0
+      vertex 107.726 109.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 109.884 107.827 0
+      vertex 109.819 108.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 107.521 109.954 0
+      vertex 107.314 109.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.971 107.418 0
+      vertex 109.934 107.624 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.314 109.984 0
+      vertex 107.105 109.998 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.993 107.209 0
+      vertex 107.002 109.998 0
+      vertex 110 107 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 109.998 0
+      vertex 107 110 0
+      vertex -107 110 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex 107 110 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 107.002 109.998 0
+      vertex -107.002 109.998 0
+      vertex 107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -110 107 0
+      vertex -110 -107 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.105 109.998 0
+      vertex -107.314 109.984 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.314 109.984 0
+      vertex -107.521 109.954 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.521 109.954 0
+      vertex -107.726 109.911 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.726 109.911 0
+      vertex -107.927 109.853 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.927 109.853 0
+      vertex -108.124 109.782 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -108.124 109.782 0
+      vertex -108.315 109.696 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -108.315 109.696 0
+      vertex -108.5 109.598 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -108.5 109.598 0
+      vertex -108.678 109.487 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -108.678 109.487 0
+      vertex -108.847 109.364 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -108.847 109.364 0
+      vertex -109.007 109.229 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.007 109.229 0
+      vertex -109.158 109.084 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.158 109.084 0
+      vertex -109.298 108.928 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.298 108.928 0
+      vertex -109.427 108.763 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.427 108.763 0
+      vertex -109.544 108.59 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.544 108.59 0
+      vertex -109.649 108.408 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.649 108.408 0
+      vertex -109.741 108.22 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.741 108.22 0
+      vertex -109.819 108.026 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.819 108.026 0
+      vertex -109.884 107.827 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.884 107.827 0
+      vertex -109.934 107.624 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.934 107.624 0
+      vertex -109.971 107.418 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.971 107.418 0
+      vertex -109.993 107.209 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -109.993 107.209 0
+      vertex -110 107 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 109.998 0
+      vertex -110 107 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 109.998 0
+      vertex -107.002 -109.998 0
+      vertex 107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.993 -107.209 0
+      vertex -109.971 -107.418 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -109.934 -107.624 0
+      vertex -109.884 -107.827 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -109.649 -108.408 0
+      vertex -107.002 -109.998 0
+      vertex -109.741 -108.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -109.819 -108.026 0
+      vertex -109.741 -108.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.158 -109.084 0
+      vertex -109.007 -109.229 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -109.298 -108.928 0
+      vertex -107.002 -109.998 0
+      vertex -109.427 -108.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -109.544 -108.59 0
+      vertex -109.427 -108.763 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -109.158 -109.084 0
+      vertex -107.002 -109.998 0
+      vertex -109.298 -108.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -108.124 -109.782 0
+      vertex -107.927 -109.853 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -108.678 -109.487 0
+      vertex -107.002 -109.998 0
+      vertex -108.847 -109.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -109.007 -109.229 0
+      vertex -108.847 -109.364 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -108.5 -109.598 0
+      vertex -107.002 -109.998 0
+      vertex -108.678 -109.487 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -108.315 -109.696 0
+      vertex -107.002 -109.998 0
+      vertex -108.5 -109.598 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -108.124 -109.782 0
+      vertex -107.002 -109.998 0
+      vertex -108.315 -109.696 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -109.544 -108.59 0
+      vertex -107.002 -109.998 0
+      vertex -109.649 -108.408 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -107.521 -109.954 0
+      vertex -107.002 -109.998 0
+      vertex -107.726 -109.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -107.927 -109.853 0
+      vertex -107.726 -109.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -109.884 -107.827 0
+      vertex -109.819 -108.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex -107.521 -109.954 0
+      vertex -107.314 -109.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.971 -107.418 0
+      vertex -109.934 -107.624 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -107.314 -109.984 0
+      vertex -107.105 -109.998 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -107.002 -109.998 0
+      vertex 107 -110 0
+      vertex 107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -107 -110 0
+      vertex 107 -110 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -109.993 -107.209 0
+      vertex -107.002 -109.998 0
+      vertex -110 -107 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 107.105 -109.998 -3
+      vertex 107.002 -109.998 0
+      vertex 107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 107.105 -109.998 -3
+      vertex 107.105 -109.998 0
+      vertex 107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 107.314 -109.984 -3
+      vertex 107.105 -109.998 0
+      vertex 107.105 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 107.314 -109.984 -3
+      vertex 107.314 -109.984 0
+      vertex 107.105 -109.998 0
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 107.521 -109.954 -3
+      vertex 107.314 -109.984 0
+      vertex 107.314 -109.984 -3
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 107.521 -109.954 -3
+      vertex 107.521 -109.954 0
+      vertex 107.314 -109.984 0
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 107.726 -109.911 -3
+      vertex 107.521 -109.954 0
+      vertex 107.521 -109.954 -3
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 107.726 -109.911 -3
+      vertex 107.726 -109.911 0
+      vertex 107.521 -109.954 0
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 107.927 -109.853 -3
+      vertex 107.726 -109.911 0
+      vertex 107.726 -109.911 -3
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 107.927 -109.853 -3
+      vertex 107.927 -109.853 0
+      vertex 107.726 -109.911 0
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 108.124 -109.782 -3
+      vertex 107.927 -109.853 0
+      vertex 107.927 -109.853 -3
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 108.124 -109.782 -3
+      vertex 108.124 -109.782 0
+      vertex 107.927 -109.853 0
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 108.315 -109.696 -3
+      vertex 108.124 -109.782 0
+      vertex 108.124 -109.782 -3
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 108.315 -109.696 -3
+      vertex 108.315 -109.696 0
+      vertex 108.124 -109.782 0
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 108.5 -109.598 -3
+      vertex 108.315 -109.696 0
+      vertex 108.315 -109.696 -3
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 108.5 -109.598 -3
+      vertex 108.5 -109.598 0
+      vertex 108.315 -109.696 0
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 108.678 -109.487 -3
+      vertex 108.5 -109.598 0
+      vertex 108.5 -109.598 -3
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 108.678 -109.487 -3
+      vertex 108.678 -109.487 0
+      vertex 108.5 -109.598 0
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 108.847 -109.364 -3
+      vertex 108.678 -109.487 0
+      vertex 108.678 -109.487 -3
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 108.847 -109.364 -3
+      vertex 108.847 -109.364 0
+      vertex 108.678 -109.487 0
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 109.007 -109.229 -3
+      vertex 108.847 -109.364 0
+      vertex 108.847 -109.364 -3
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 109.007 -109.229 -3
+      vertex 109.007 -109.229 0
+      vertex 108.847 -109.364 0
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 109.158 -109.084 -3
+      vertex 109.007 -109.229 0
+      vertex 109.007 -109.229 -3
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 109.158 -109.084 -3
+      vertex 109.158 -109.084 0
+      vertex 109.007 -109.229 0
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 109.298 -108.928 -3
+      vertex 109.158 -109.084 0
+      vertex 109.158 -109.084 -3
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 109.298 -108.928 -3
+      vertex 109.298 -108.928 0
+      vertex 109.158 -109.084 0
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 109.427 -108.763 -3
+      vertex 109.298 -108.928 0
+      vertex 109.298 -108.928 -3
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 109.427 -108.763 -3
+      vertex 109.427 -108.763 0
+      vertex 109.298 -108.928 0
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 109.544 -108.59 -3
+      vertex 109.427 -108.763 0
+      vertex 109.427 -108.763 -3
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 109.544 -108.59 -3
+      vertex 109.544 -108.59 0
+      vertex 109.427 -108.763 0
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 109.649 -108.408 -3
+      vertex 109.544 -108.59 0
+      vertex 109.544 -108.59 -3
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 109.649 -108.408 -3
+      vertex 109.649 -108.408 0
+      vertex 109.544 -108.59 0
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 109.741 -108.22 -3
+      vertex 109.649 -108.408 0
+      vertex 109.649 -108.408 -3
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 109.741 -108.22 -3
+      vertex 109.741 -108.22 0
+      vertex 109.649 -108.408 0
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 109.819 -108.026 -3
+      vertex 109.741 -108.22 0
+      vertex 109.741 -108.22 -3
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 109.819 -108.026 -3
+      vertex 109.819 -108.026 0
+      vertex 109.741 -108.22 0
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 109.884 -107.827 -3
+      vertex 109.819 -108.026 0
+      vertex 109.819 -108.026 -3
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 109.884 -107.827 -3
+      vertex 109.884 -107.827 0
+      vertex 109.819 -108.026 0
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 109.934 -107.624 -3
+      vertex 109.884 -107.827 0
+      vertex 109.884 -107.827 -3
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 109.934 -107.624 -3
+      vertex 109.934 -107.624 0
+      vertex 109.884 -107.827 0
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 109.971 -107.418 -3
+      vertex 109.934 -107.624 0
+      vertex 109.934 -107.624 -3
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 109.971 -107.418 -3
+      vertex 109.971 -107.418 0
+      vertex 109.934 -107.624 0
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 109.993 -107.209 -3
+      vertex 109.971 -107.418 0
+      vertex 109.971 -107.418 -3
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 109.993 -107.209 -3
+      vertex 109.993 -107.209 0
+      vertex 109.971 -107.418 0
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 110 -107 -3
+      vertex 109.993 -107.209 0
+      vertex 109.993 -107.209 -3
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 110 -107 -3
+      vertex 110 -107 0
+      vertex 109.993 -107.209 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 110 107 -3
+      vertex 110 -107 0
+      vertex 110 -107 -3
+    endloop
+  endfacet
+  facet normal 1 0 -0
+    outer loop
+      vertex 110 107 -3
+      vertex 110 107 0
+      vertex 110 -107 0
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 0
+    outer loop
+      vertex 109.993 107.209 -3
+      vertex 110 107 0
+      vertex 110 107 -3
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 -0
+    outer loop
+      vertex 109.993 107.209 -3
+      vertex 109.993 107.209 0
+      vertex 110 107 0
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex 109.971 107.418 -3
+      vertex 109.993 107.209 0
+      vertex 109.993 107.209 -3
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 -0
+    outer loop
+      vertex 109.971 107.418 -3
+      vertex 109.971 107.418 0
+      vertex 109.993 107.209 0
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 0
+    outer loop
+      vertex 109.934 107.624 -3
+      vertex 109.971 107.418 0
+      vertex 109.971 107.418 -3
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 -0
+    outer loop
+      vertex 109.934 107.624 -3
+      vertex 109.934 107.624 0
+      vertex 109.971 107.418 0
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 0
+    outer loop
+      vertex 109.884 107.827 -3
+      vertex 109.934 107.624 0
+      vertex 109.934 107.624 -3
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 -0
+    outer loop
+      vertex 109.884 107.827 -3
+      vertex 109.884 107.827 0
+      vertex 109.934 107.624 0
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 0
+    outer loop
+      vertex 109.819 108.026 -3
+      vertex 109.884 107.827 0
+      vertex 109.884 107.827 -3
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 -0
+    outer loop
+      vertex 109.819 108.026 -3
+      vertex 109.819 108.026 0
+      vertex 109.884 107.827 0
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 0
+    outer loop
+      vertex 109.741 108.22 -3
+      vertex 109.819 108.026 0
+      vertex 109.819 108.026 -3
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 -0
+    outer loop
+      vertex 109.741 108.22 -3
+      vertex 109.741 108.22 0
+      vertex 109.819 108.026 0
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 0
+    outer loop
+      vertex 109.649 108.408 -3
+      vertex 109.741 108.22 0
+      vertex 109.741 108.22 -3
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 -0
+    outer loop
+      vertex 109.649 108.408 -3
+      vertex 109.649 108.408 0
+      vertex 109.741 108.22 0
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 0
+    outer loop
+      vertex 109.544 108.59 -3
+      vertex 109.649 108.408 0
+      vertex 109.649 108.408 -3
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 -0
+    outer loop
+      vertex 109.544 108.59 -3
+      vertex 109.544 108.59 0
+      vertex 109.649 108.408 0
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 0
+    outer loop
+      vertex 109.427 108.763 -3
+      vertex 109.544 108.59 0
+      vertex 109.544 108.59 -3
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 -0
+    outer loop
+      vertex 109.427 108.763 -3
+      vertex 109.427 108.763 0
+      vertex 109.544 108.59 0
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 0
+    outer loop
+      vertex 109.298 108.928 -3
+      vertex 109.427 108.763 0
+      vertex 109.427 108.763 -3
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 -0
+    outer loop
+      vertex 109.298 108.928 -3
+      vertex 109.298 108.928 0
+      vertex 109.427 108.763 0
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 0
+    outer loop
+      vertex 109.158 109.084 -3
+      vertex 109.298 108.928 0
+      vertex 109.298 108.928 -3
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 -0
+    outer loop
+      vertex 109.158 109.084 -3
+      vertex 109.158 109.084 0
+      vertex 109.298 108.928 0
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 0
+    outer loop
+      vertex 109.007 109.229 -3
+      vertex 109.158 109.084 0
+      vertex 109.158 109.084 -3
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 -0
+    outer loop
+      vertex 109.007 109.229 -3
+      vertex 109.007 109.229 0
+      vertex 109.158 109.084 0
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 0
+    outer loop
+      vertex 108.847 109.364 -3
+      vertex 109.007 109.229 0
+      vertex 109.007 109.229 -3
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 -0
+    outer loop
+      vertex 108.847 109.364 -3
+      vertex 108.847 109.364 0
+      vertex 109.007 109.229 0
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 0
+    outer loop
+      vertex 108.678 109.487 -3
+      vertex 108.847 109.364 0
+      vertex 108.847 109.364 -3
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 -0
+    outer loop
+      vertex 108.678 109.487 -3
+      vertex 108.678 109.487 0
+      vertex 108.847 109.364 0
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 0
+    outer loop
+      vertex 108.5 109.598 -3
+      vertex 108.678 109.487 0
+      vertex 108.678 109.487 -3
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 -0
+    outer loop
+      vertex 108.5 109.598 -3
+      vertex 108.5 109.598 0
+      vertex 108.678 109.487 0
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 0
+    outer loop
+      vertex 108.315 109.696 -3
+      vertex 108.5 109.598 0
+      vertex 108.5 109.598 -3
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 -0
+    outer loop
+      vertex 108.315 109.696 -3
+      vertex 108.315 109.696 0
+      vertex 108.5 109.598 0
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 0
+    outer loop
+      vertex 108.124 109.782 -3
+      vertex 108.315 109.696 0
+      vertex 108.315 109.696 -3
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 -0
+    outer loop
+      vertex 108.124 109.782 -3
+      vertex 108.124 109.782 0
+      vertex 108.315 109.696 0
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 0
+    outer loop
+      vertex 107.927 109.853 -3
+      vertex 108.124 109.782 0
+      vertex 108.124 109.782 -3
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 -0
+    outer loop
+      vertex 107.927 109.853 -3
+      vertex 107.927 109.853 0
+      vertex 108.124 109.782 0
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 0
+    outer loop
+      vertex 107.726 109.911 -3
+      vertex 107.927 109.853 0
+      vertex 107.927 109.853 -3
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 -0
+    outer loop
+      vertex 107.726 109.911 -3
+      vertex 107.726 109.911 0
+      vertex 107.927 109.853 0
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 0
+    outer loop
+      vertex 107.521 109.954 -3
+      vertex 107.726 109.911 0
+      vertex 107.726 109.911 -3
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 -0
+    outer loop
+      vertex 107.521 109.954 -3
+      vertex 107.521 109.954 0
+      vertex 107.726 109.911 0
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 0
+    outer loop
+      vertex 107.314 109.984 -3
+      vertex 107.521 109.954 0
+      vertex 107.521 109.954 -3
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 -0
+    outer loop
+      vertex 107.314 109.984 -3
+      vertex 107.314 109.984 0
+      vertex 107.521 109.954 0
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 0
+    outer loop
+      vertex 107.105 109.998 -3
+      vertex 107.314 109.984 0
+      vertex 107.314 109.984 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 -0
+    outer loop
+      vertex 107.105 109.998 -3
+      vertex 107.105 109.998 0
+      vertex 107.314 109.984 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 107.105 109.998 0
+      vertex 107.105 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 107.002 109.998 -3
+      vertex 107.002 109.998 0
+      vertex 107.105 109.998 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 107 110 -3
+      vertex 107.002 109.998 0
+      vertex 107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 -0
+    outer loop
+      vertex 107 110 -3
+      vertex 107 110 0
+      vertex 107.002 109.998 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -107 110 -3
+      vertex 107 110 0
+      vertex 107 110 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -107 110 -3
+      vertex -107 110 0
+      vertex 107 110 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107 110 0
+      vertex -107 110 -3
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -107.002 109.998 -3
+      vertex -107.002 109.998 0
+      vertex -107 110 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -107.105 109.998 -3
+      vertex -107.002 109.998 0
+      vertex -107.002 109.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -107.105 109.998 -3
+      vertex -107.105 109.998 0
+      vertex -107.002 109.998 0
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -107.314 109.984 -3
+      vertex -107.105 109.998 0
+      vertex -107.105 109.998 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -107.314 109.984 -3
+      vertex -107.314 109.984 0
+      vertex -107.105 109.998 0
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -107.521 109.954 -3
+      vertex -107.314 109.984 0
+      vertex -107.314 109.984 -3
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -107.521 109.954 -3
+      vertex -107.521 109.954 0
+      vertex -107.314 109.984 0
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -107.726 109.911 -3
+      vertex -107.521 109.954 0
+      vertex -107.521 109.954 -3
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -107.726 109.911 -3
+      vertex -107.726 109.911 0
+      vertex -107.521 109.954 0
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -107.927 109.853 -3
+      vertex -107.726 109.911 0
+      vertex -107.726 109.911 -3
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -107.927 109.853 -3
+      vertex -107.927 109.853 0
+      vertex -107.726 109.911 0
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -108.124 109.782 -3
+      vertex -107.927 109.853 0
+      vertex -107.927 109.853 -3
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -108.124 109.782 -3
+      vertex -108.124 109.782 0
+      vertex -107.927 109.853 0
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -108.315 109.696 -3
+      vertex -108.124 109.782 0
+      vertex -108.124 109.782 -3
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -108.315 109.696 -3
+      vertex -108.315 109.696 0
+      vertex -108.124 109.782 0
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -108.5 109.598 -3
+      vertex -108.315 109.696 0
+      vertex -108.315 109.696 -3
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -108.5 109.598 -3
+      vertex -108.5 109.598 0
+      vertex -108.315 109.696 0
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -108.678 109.487 -3
+      vertex -108.5 109.598 0
+      vertex -108.5 109.598 -3
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -108.678 109.487 -3
+      vertex -108.678 109.487 0
+      vertex -108.5 109.598 0
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -108.847 109.364 -3
+      vertex -108.678 109.487 0
+      vertex -108.678 109.487 -3
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -108.847 109.364 -3
+      vertex -108.847 109.364 0
+      vertex -108.678 109.487 0
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -109.007 109.229 -3
+      vertex -108.847 109.364 0
+      vertex -108.847 109.364 -3
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -109.007 109.229 -3
+      vertex -109.007 109.229 0
+      vertex -108.847 109.364 0
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -109.158 109.084 -3
+      vertex -109.007 109.229 0
+      vertex -109.007 109.229 -3
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -109.158 109.084 -3
+      vertex -109.158 109.084 0
+      vertex -109.007 109.229 0
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -109.298 108.928 -3
+      vertex -109.158 109.084 0
+      vertex -109.158 109.084 -3
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -109.298 108.928 -3
+      vertex -109.298 108.928 0
+      vertex -109.158 109.084 0
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -109.427 108.763 -3
+      vertex -109.298 108.928 0
+      vertex -109.298 108.928 -3
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -109.427 108.763 -3
+      vertex -109.427 108.763 0
+      vertex -109.298 108.928 0
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -109.544 108.59 -3
+      vertex -109.427 108.763 0
+      vertex -109.427 108.763 -3
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -109.544 108.59 -3
+      vertex -109.544 108.59 0
+      vertex -109.427 108.763 0
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -109.649 108.408 -3
+      vertex -109.544 108.59 0
+      vertex -109.544 108.59 -3
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -109.649 108.408 -3
+      vertex -109.649 108.408 0
+      vertex -109.544 108.59 0
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -109.741 108.22 -3
+      vertex -109.649 108.408 0
+      vertex -109.649 108.408 -3
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -109.741 108.22 -3
+      vertex -109.741 108.22 0
+      vertex -109.649 108.408 0
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -109.819 108.026 -3
+      vertex -109.741 108.22 0
+      vertex -109.741 108.22 -3
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -109.819 108.026 -3
+      vertex -109.819 108.026 0
+      vertex -109.741 108.22 0
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -109.884 107.827 -3
+      vertex -109.819 108.026 0
+      vertex -109.819 108.026 -3
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -109.884 107.827 -3
+      vertex -109.884 107.827 0
+      vertex -109.819 108.026 0
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -109.934 107.624 -3
+      vertex -109.884 107.827 0
+      vertex -109.884 107.827 -3
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -109.934 107.624 -3
+      vertex -109.934 107.624 0
+      vertex -109.884 107.827 0
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -109.971 107.418 -3
+      vertex -109.934 107.624 0
+      vertex -109.934 107.624 -3
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -109.971 107.418 -3
+      vertex -109.971 107.418 0
+      vertex -109.934 107.624 0
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -109.993 107.209 -3
+      vertex -109.971 107.418 0
+      vertex -109.971 107.418 -3
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -109.993 107.209 -3
+      vertex -109.993 107.209 0
+      vertex -109.971 107.418 0
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -110 107 -3
+      vertex -109.993 107.209 0
+      vertex -109.993 107.209 -3
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -110 107 -3
+      vertex -110 107 0
+      vertex -109.993 107.209 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -110 -107 -3
+      vertex -110 107 0
+      vertex -110 107 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -110 -107 -3
+      vertex -110 -107 0
+      vertex -110 107 0
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -109.993 -107.209 -3
+      vertex -110 -107 0
+      vertex -110 -107 -3
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -109.993 -107.209 -3
+      vertex -109.993 -107.209 0
+      vertex -110 -107 0
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -109.971 -107.418 -3
+      vertex -109.993 -107.209 0
+      vertex -109.993 -107.209 -3
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -109.971 -107.418 -3
+      vertex -109.971 -107.418 0
+      vertex -109.993 -107.209 0
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -109.934 -107.624 -3
+      vertex -109.971 -107.418 0
+      vertex -109.971 -107.418 -3
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -109.934 -107.624 -3
+      vertex -109.934 -107.624 0
+      vertex -109.971 -107.418 0
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -109.884 -107.827 -3
+      vertex -109.934 -107.624 0
+      vertex -109.934 -107.624 -3
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -109.884 -107.827 -3
+      vertex -109.884 -107.827 0
+      vertex -109.934 -107.624 0
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -109.819 -108.026 -3
+      vertex -109.884 -107.827 0
+      vertex -109.884 -107.827 -3
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -109.819 -108.026 -3
+      vertex -109.819 -108.026 0
+      vertex -109.884 -107.827 0
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -109.741 -108.22 -3
+      vertex -109.819 -108.026 0
+      vertex -109.819 -108.026 -3
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -109.741 -108.22 -3
+      vertex -109.741 -108.22 0
+      vertex -109.819 -108.026 0
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -109.649 -108.408 -3
+      vertex -109.741 -108.22 0
+      vertex -109.741 -108.22 -3
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -109.649 -108.408 -3
+      vertex -109.649 -108.408 0
+      vertex -109.741 -108.22 0
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -109.544 -108.59 -3
+      vertex -109.649 -108.408 0
+      vertex -109.649 -108.408 -3
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -109.544 -108.59 -3
+      vertex -109.544 -108.59 0
+      vertex -109.649 -108.408 0
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -109.427 -108.763 -3
+      vertex -109.544 -108.59 0
+      vertex -109.544 -108.59 -3
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -109.427 -108.763 -3
+      vertex -109.427 -108.763 0
+      vertex -109.544 -108.59 0
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -109.298 -108.928 -3
+      vertex -109.427 -108.763 0
+      vertex -109.427 -108.763 -3
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -109.298 -108.928 -3
+      vertex -109.298 -108.928 0
+      vertex -109.427 -108.763 0
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -109.158 -109.084 -3
+      vertex -109.298 -108.928 0
+      vertex -109.298 -108.928 -3
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -109.158 -109.084 -3
+      vertex -109.158 -109.084 0
+      vertex -109.298 -108.928 0
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -109.007 -109.229 -3
+      vertex -109.158 -109.084 0
+      vertex -109.158 -109.084 -3
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -109.007 -109.229 -3
+      vertex -109.007 -109.229 0
+      vertex -109.158 -109.084 0
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -108.847 -109.364 -3
+      vertex -109.007 -109.229 0
+      vertex -109.007 -109.229 -3
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -108.847 -109.364 -3
+      vertex -108.847 -109.364 0
+      vertex -109.007 -109.229 0
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -108.678 -109.487 -3
+      vertex -108.847 -109.364 0
+      vertex -108.847 -109.364 -3
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -108.678 -109.487 -3
+      vertex -108.678 -109.487 0
+      vertex -108.847 -109.364 0
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -108.5 -109.598 -3
+      vertex -108.678 -109.487 0
+      vertex -108.678 -109.487 -3
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -108.5 -109.598 -3
+      vertex -108.5 -109.598 0
+      vertex -108.678 -109.487 0
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -108.315 -109.696 -3
+      vertex -108.5 -109.598 0
+      vertex -108.5 -109.598 -3
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -108.315 -109.696 -3
+      vertex -108.315 -109.696 0
+      vertex -108.5 -109.598 0
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -108.124 -109.782 -3
+      vertex -108.315 -109.696 0
+      vertex -108.315 -109.696 -3
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -108.124 -109.782 -3
+      vertex -108.124 -109.782 0
+      vertex -108.315 -109.696 0
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -107.927 -109.853 -3
+      vertex -108.124 -109.782 0
+      vertex -108.124 -109.782 -3
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -107.927 -109.853 -3
+      vertex -107.927 -109.853 0
+      vertex -108.124 -109.782 0
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -107.726 -109.911 -3
+      vertex -107.927 -109.853 0
+      vertex -107.927 -109.853 -3
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -107.726 -109.911 -3
+      vertex -107.726 -109.911 0
+      vertex -107.927 -109.853 0
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -107.521 -109.954 -3
+      vertex -107.726 -109.911 0
+      vertex -107.726 -109.911 -3
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -107.521 -109.954 -3
+      vertex -107.521 -109.954 0
+      vertex -107.726 -109.911 0
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -107.314 -109.984 -3
+      vertex -107.521 -109.954 0
+      vertex -107.521 -109.954 -3
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -107.314 -109.984 -3
+      vertex -107.314 -109.984 0
+      vertex -107.521 -109.954 0
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -107.105 -109.998 -3
+      vertex -107.314 -109.984 0
+      vertex -107.314 -109.984 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -107.105 -109.998 -3
+      vertex -107.105 -109.998 0
+      vertex -107.314 -109.984 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -107.105 -109.998 0
+      vertex -107.105 -109.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -107.002 -109.998 -3
+      vertex -107.002 -109.998 0
+      vertex -107.105 -109.998 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -107 -110 -3
+      vertex -107.002 -109.998 0
+      vertex -107.002 -109.998 -3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -107 -110 -3
+      vertex -107 -110 0
+      vertex -107.002 -109.998 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 107 -110 -3
+      vertex -107 -110 0
+      vertex -107 -110 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 107 -110 -3
+      vertex 107 -110 0
+      vertex -107 -110 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 107.002 -109.998 -3
+      vertex 107 -110 0
+      vertex 107 -110 -3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 107.002 -109.998 -3
+      vertex 107.002 -109.998 0
+      vertex 107 -110 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/resources/profiles/Creality/k1max.svg
+++ b/resources/profiles/Creality/k1max.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="290mm" height="290mm" version="1.1" viewBox="0 0 290 290" xmlns="http://www.w3.org/2000/svg">
+  <rect x=".25" y=".25" width="289.5" height="289.5" fill="none" stroke="#fff" stroke-width=".5"/>
+</svg>

--- a/resources/profiles/Creality/k1max_bed.stl
+++ b/resources/profiles/Creality/k1max_bed.stl
@@ -1,0 +1,2774 @@
+solid OpenSCAD_Model
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.105 -149.998 -3
+      vertex 147.002 -149.998 -3
+      vertex 147.314 -149.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.314 -149.984 -3
+      vertex 147.002 -149.998 -3
+      vertex 147.521 -149.954 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 150 -147 -3
+      vertex 147.002 -149.998 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.521 -149.954 -3
+      vertex 147.002 -149.998 -3
+      vertex 147.726 -149.911 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.726 -149.911 -3
+      vertex 147.002 -149.998 -3
+      vertex 147.927 -149.853 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.927 -149.853 -3
+      vertex 147.002 -149.998 -3
+      vertex 148.124 -149.782 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.124 -149.782 -3
+      vertex 147.002 -149.998 -3
+      vertex 148.315 -149.696 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.315 -149.696 -3
+      vertex 147.002 -149.998 -3
+      vertex 148.5 -149.598 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.5 -149.598 -3
+      vertex 147.002 -149.998 -3
+      vertex 148.678 -149.487 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.678 -149.487 -3
+      vertex 147.002 -149.998 -3
+      vertex 148.847 -149.364 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.847 -149.364 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.007 -149.229 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.007 -149.229 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.158 -149.084 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.158 -149.084 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.298 -148.928 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.298 -148.928 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.427 -148.763 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.427 -148.763 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.544 -148.59 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.544 -148.59 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.649 -148.408 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.649 -148.408 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.741 -148.22 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.741 -148.22 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.819 -148.026 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.819 -148.026 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.884 -147.827 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.884 -147.827 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.934 -147.624 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.934 -147.624 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.971 -147.418 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.971 -147.418 -3
+      vertex 147.002 -149.998 -3
+      vertex 149.993 -147.209 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.993 -147.209 -3
+      vertex 147.002 -149.998 -3
+      vertex 150 -147 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 150 -147 -3
+      vertex 147.002 149.998 -3
+      vertex 150 147 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 149.971 147.418 -3
+      vertex 149.993 147.209 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 149.884 147.827 -3
+      vertex 149.934 147.624 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 149.741 148.22 -3
+      vertex 147.002 149.998 -3
+      vertex 149.649 148.408 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 149.741 148.22 -3
+      vertex 149.819 148.026 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 149.007 149.229 -3
+      vertex 149.158 149.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 149.427 148.763 -3
+      vertex 147.002 149.998 -3
+      vertex 149.298 148.928 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 149.427 148.763 -3
+      vertex 149.544 148.59 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 149.298 148.928 -3
+      vertex 147.002 149.998 -3
+      vertex 149.158 149.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 147.927 149.853 -3
+      vertex 148.124 149.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 148.847 149.364 -3
+      vertex 147.002 149.998 -3
+      vertex 148.678 149.487 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 148.847 149.364 -3
+      vertex 149.007 149.229 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 148.678 149.487 -3
+      vertex 147.002 149.998 -3
+      vertex 148.5 149.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 148.5 149.598 -3
+      vertex 147.002 149.998 -3
+      vertex 148.315 149.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 148.315 149.696 -3
+      vertex 147.002 149.998 -3
+      vertex 148.124 149.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 149.649 148.408 -3
+      vertex 147.002 149.998 -3
+      vertex 149.544 148.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.726 149.911 -3
+      vertex 147.002 149.998 -3
+      vertex 147.521 149.954 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 147.726 149.911 -3
+      vertex 147.927 149.853 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 149.819 148.026 -3
+      vertex 149.884 147.827 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 147.314 149.984 -3
+      vertex 147.521 149.954 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 149.934 147.624 -3
+      vertex 149.971 147.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 147.105 149.998 -3
+      vertex 147.314 149.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 150 147 -3
+      vertex 147.002 149.998 -3
+      vertex 149.993 147.209 -3
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -147 150 -3
+      vertex 147 150 -3
+      vertex -147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex 147 150 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 -149.998 -3
+      vertex -147.002 149.998 -3
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -150 -147 -3
+      vertex -150 147 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147.314 149.984 -3
+      vertex -147.105 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147.521 149.954 -3
+      vertex -147.314 149.984 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147.726 149.911 -3
+      vertex -147.521 149.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147.927 149.853 -3
+      vertex -147.726 149.911 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -148.124 149.782 -3
+      vertex -147.927 149.853 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -148.315 149.696 -3
+      vertex -148.124 149.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -148.5 149.598 -3
+      vertex -148.315 149.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -148.678 149.487 -3
+      vertex -148.5 149.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -148.847 149.364 -3
+      vertex -148.678 149.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.007 149.229 -3
+      vertex -148.847 149.364 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.158 149.084 -3
+      vertex -149.007 149.229 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.298 148.928 -3
+      vertex -149.158 149.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.427 148.763 -3
+      vertex -149.298 148.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.544 148.59 -3
+      vertex -149.427 148.763 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.649 148.408 -3
+      vertex -149.544 148.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.741 148.22 -3
+      vertex -149.649 148.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.819 148.026 -3
+      vertex -149.741 148.22 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.884 147.827 -3
+      vertex -149.819 148.026 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.934 147.624 -3
+      vertex -149.884 147.827 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.971 147.418 -3
+      vertex -149.934 147.624 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -149.993 147.209 -3
+      vertex -149.971 147.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -150 147 -3
+      vertex -149.993 147.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -150 147 -3
+      vertex -147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.002 -149.998 -3
+      vertex -147.002 -149.998 -3
+      vertex -147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -149.971 -147.418 -3
+      vertex -149.993 -147.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.884 -147.827 -3
+      vertex -149.934 -147.624 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.741 -148.22 -3
+      vertex -147.002 -149.998 -3
+      vertex -149.649 -148.408 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.741 -148.22 -3
+      vertex -149.819 -148.026 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -149.007 -149.229 -3
+      vertex -149.158 -149.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.427 -148.763 -3
+      vertex -147.002 -149.998 -3
+      vertex -149.298 -148.928 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.427 -148.763 -3
+      vertex -149.544 -148.59 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.298 -148.928 -3
+      vertex -147.002 -149.998 -3
+      vertex -149.158 -149.084 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -147.927 -149.853 -3
+      vertex -148.124 -149.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.847 -149.364 -3
+      vertex -147.002 -149.998 -3
+      vertex -148.678 -149.487 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.847 -149.364 -3
+      vertex -149.007 -149.229 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.678 -149.487 -3
+      vertex -147.002 -149.998 -3
+      vertex -148.5 -149.598 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.5 -149.598 -3
+      vertex -147.002 -149.998 -3
+      vertex -148.315 -149.696 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.315 -149.696 -3
+      vertex -147.002 -149.998 -3
+      vertex -148.124 -149.782 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.649 -148.408 -3
+      vertex -147.002 -149.998 -3
+      vertex -149.544 -148.59 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.726 -149.911 -3
+      vertex -147.002 -149.998 -3
+      vertex -147.521 -149.954 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.726 -149.911 -3
+      vertex -147.927 -149.853 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.819 -148.026 -3
+      vertex -149.884 -147.827 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.314 -149.984 -3
+      vertex -147.521 -149.954 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -149.934 -147.624 -3
+      vertex -149.971 -147.418 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -147.105 -149.998 -3
+      vertex -147.314 -149.984 -3
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.002 -149.998 -3
+      vertex 147 -150 -3
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex 147 -150 -3
+      vertex -147 -150 -3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -150 -147 -3
+      vertex -147.002 -149.998 -3
+      vertex -149.993 -147.209 -3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.314 -149.984 0
+      vertex 147.002 -149.998 0
+      vertex 147.105 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.521 -149.954 0
+      vertex 147.002 -149.998 0
+      vertex 147.314 -149.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 147.002 -149.998 0
+      vertex 150 -147 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.726 -149.911 0
+      vertex 147.002 -149.998 0
+      vertex 147.521 -149.954 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.927 -149.853 0
+      vertex 147.002 -149.998 0
+      vertex 147.726 -149.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.124 -149.782 0
+      vertex 147.002 -149.998 0
+      vertex 147.927 -149.853 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.315 -149.696 0
+      vertex 147.002 -149.998 0
+      vertex 148.124 -149.782 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.5 -149.598 0
+      vertex 147.002 -149.998 0
+      vertex 148.315 -149.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.678 -149.487 0
+      vertex 147.002 -149.998 0
+      vertex 148.5 -149.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.847 -149.364 0
+      vertex 147.002 -149.998 0
+      vertex 148.678 -149.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.007 -149.229 0
+      vertex 147.002 -149.998 0
+      vertex 148.847 -149.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.158 -149.084 0
+      vertex 147.002 -149.998 0
+      vertex 149.007 -149.229 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.298 -148.928 0
+      vertex 147.002 -149.998 0
+      vertex 149.158 -149.084 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.427 -148.763 0
+      vertex 147.002 -149.998 0
+      vertex 149.298 -148.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.544 -148.59 0
+      vertex 147.002 -149.998 0
+      vertex 149.427 -148.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.649 -148.408 0
+      vertex 147.002 -149.998 0
+      vertex 149.544 -148.59 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.741 -148.22 0
+      vertex 147.002 -149.998 0
+      vertex 149.649 -148.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.819 -148.026 0
+      vertex 147.002 -149.998 0
+      vertex 149.741 -148.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.884 -147.827 0
+      vertex 147.002 -149.998 0
+      vertex 149.819 -148.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.934 -147.624 0
+      vertex 147.002 -149.998 0
+      vertex 149.884 -147.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.971 -147.418 0
+      vertex 147.002 -149.998 0
+      vertex 149.934 -147.624 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.993 -147.209 0
+      vertex 147.002 -149.998 0
+      vertex 149.971 -147.418 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 150 -147 0
+      vertex 147.002 -149.998 0
+      vertex 149.993 -147.209 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 150 147 0
+      vertex 147.002 149.998 0
+      vertex 150 -147 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.993 147.209 0
+      vertex 149.971 147.418 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 149.934 147.624 0
+      vertex 149.884 147.827 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.649 148.408 0
+      vertex 147.002 149.998 0
+      vertex 149.741 148.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 149.819 148.026 0
+      vertex 149.741 148.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.158 149.084 0
+      vertex 149.007 149.229 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.298 148.928 0
+      vertex 147.002 149.998 0
+      vertex 149.427 148.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 149.544 148.59 0
+      vertex 149.427 148.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.158 149.084 0
+      vertex 147.002 149.998 0
+      vertex 149.298 148.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.124 149.782 0
+      vertex 147.927 149.853 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.678 149.487 0
+      vertex 147.002 149.998 0
+      vertex 148.847 149.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 149.007 149.229 0
+      vertex 148.847 149.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.5 149.598 0
+      vertex 147.002 149.998 0
+      vertex 148.678 149.487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.315 149.696 0
+      vertex 147.002 149.998 0
+      vertex 148.5 149.598 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.124 149.782 0
+      vertex 147.002 149.998 0
+      vertex 148.315 149.696 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.544 148.59 0
+      vertex 147.002 149.998 0
+      vertex 149.649 148.408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.521 149.954 0
+      vertex 147.002 149.998 0
+      vertex 147.726 149.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 147.927 149.853 0
+      vertex 147.726 149.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 149.884 147.827 0
+      vertex 149.819 148.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 147.521 149.954 0
+      vertex 147.314 149.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.971 147.418 0
+      vertex 149.934 147.624 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.314 149.984 0
+      vertex 147.105 149.998 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.993 147.209 0
+      vertex 147.002 149.998 0
+      vertex 150 147 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 149.998 0
+      vertex 147 150 0
+      vertex -147 150 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex 147 150 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.002 149.998 0
+      vertex -147.002 149.998 0
+      vertex 147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -150 147 0
+      vertex -150 -147 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.105 149.998 0
+      vertex -147.314 149.984 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.314 149.984 0
+      vertex -147.521 149.954 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.521 149.954 0
+      vertex -147.726 149.911 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.726 149.911 0
+      vertex -147.927 149.853 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.927 149.853 0
+      vertex -148.124 149.782 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -148.124 149.782 0
+      vertex -148.315 149.696 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -148.315 149.696 0
+      vertex -148.5 149.598 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -148.5 149.598 0
+      vertex -148.678 149.487 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -148.678 149.487 0
+      vertex -148.847 149.364 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -148.847 149.364 0
+      vertex -149.007 149.229 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.007 149.229 0
+      vertex -149.158 149.084 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.158 149.084 0
+      vertex -149.298 148.928 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.298 148.928 0
+      vertex -149.427 148.763 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.427 148.763 0
+      vertex -149.544 148.59 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.544 148.59 0
+      vertex -149.649 148.408 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.649 148.408 0
+      vertex -149.741 148.22 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.741 148.22 0
+      vertex -149.819 148.026 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.819 148.026 0
+      vertex -149.884 147.827 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.884 147.827 0
+      vertex -149.934 147.624 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.934 147.624 0
+      vertex -149.971 147.418 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.971 147.418 0
+      vertex -149.993 147.209 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -149.993 147.209 0
+      vertex -150 147 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 149.998 0
+      vertex -150 147 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 149.998 0
+      vertex -147.002 -149.998 0
+      vertex 147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -149.993 -147.209 0
+      vertex -149.971 -147.418 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -149.934 -147.624 0
+      vertex -149.884 -147.827 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -149.649 -148.408 0
+      vertex -147.002 -149.998 0
+      vertex -149.741 -148.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -149.819 -148.026 0
+      vertex -149.741 -148.22 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -149.158 -149.084 0
+      vertex -149.007 -149.229 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -149.298 -148.928 0
+      vertex -147.002 -149.998 0
+      vertex -149.427 -148.763 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -149.544 -148.59 0
+      vertex -149.427 -148.763 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -149.158 -149.084 0
+      vertex -147.002 -149.998 0
+      vertex -149.298 -148.928 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -148.124 -149.782 0
+      vertex -147.927 -149.853 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -148.678 -149.487 0
+      vertex -147.002 -149.998 0
+      vertex -148.847 -149.364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -149.007 -149.229 0
+      vertex -148.847 -149.364 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -148.5 -149.598 0
+      vertex -147.002 -149.998 0
+      vertex -148.678 -149.487 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -148.315 -149.696 0
+      vertex -147.002 -149.998 0
+      vertex -148.5 -149.598 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -148.124 -149.782 0
+      vertex -147.002 -149.998 0
+      vertex -148.315 -149.696 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -149.544 -148.59 0
+      vertex -147.002 -149.998 0
+      vertex -149.649 -148.408 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -147.521 -149.954 0
+      vertex -147.002 -149.998 0
+      vertex -147.726 -149.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -147.927 -149.853 0
+      vertex -147.726 -149.911 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -149.884 -147.827 0
+      vertex -149.819 -148.026 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex -147.521 -149.954 0
+      vertex -147.314 -149.984 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -149.971 -147.418 0
+      vertex -149.934 -147.624 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -147.314 -149.984 0
+      vertex -147.105 -149.998 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.002 -149.998 0
+      vertex 147 -150 0
+      vertex 147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -147 -150 0
+      vertex 147 -150 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -149.993 -147.209 0
+      vertex -147.002 -149.998 0
+      vertex -150 -147 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 147.105 -149.998 -3
+      vertex 147.002 -149.998 0
+      vertex 147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 147.105 -149.998 -3
+      vertex 147.105 -149.998 0
+      vertex 147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 147.314 -149.984 -3
+      vertex 147.105 -149.998 0
+      vertex 147.105 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 -0.997764 0
+    outer loop
+      vertex 147.314 -149.984 -3
+      vertex 147.314 -149.984 0
+      vertex 147.105 -149.998 0
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 147.521 -149.954 -3
+      vertex 147.314 -149.984 0
+      vertex 147.314 -149.984 -3
+    endloop
+  endfacet
+  facet normal 0.143429 -0.989661 0
+    outer loop
+      vertex 147.521 -149.954 -3
+      vertex 147.521 -149.954 0
+      vertex 147.314 -149.984 0
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 147.726 -149.911 -3
+      vertex 147.521 -149.954 0
+      vertex 147.521 -149.954 -3
+    endloop
+  endfacet
+  facet normal 0.205289 -0.978701 0
+    outer loop
+      vertex 147.726 -149.911 -3
+      vertex 147.726 -149.911 0
+      vertex 147.521 -149.954 0
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 147.927 -149.853 -3
+      vertex 147.726 -149.911 0
+      vertex 147.726 -149.911 -3
+    endloop
+  endfacet
+  facet normal 0.277246 -0.960799 0
+    outer loop
+      vertex 147.927 -149.853 -3
+      vertex 147.927 -149.853 0
+      vertex 147.726 -149.911 0
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 148.124 -149.782 -3
+      vertex 147.927 -149.853 0
+      vertex 147.927 -149.853 -3
+    endloop
+  endfacet
+  facet normal 0.339058 -0.940766 0
+    outer loop
+      vertex 148.124 -149.782 -3
+      vertex 148.124 -149.782 0
+      vertex 147.927 -149.853 0
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 148.315 -149.696 -3
+      vertex 148.124 -149.782 0
+      vertex 148.124 -149.782 -3
+    endloop
+  endfacet
+  facet normal 0.410563 -0.911832 0
+    outer loop
+      vertex 148.315 -149.696 -3
+      vertex 148.315 -149.696 0
+      vertex 148.124 -149.782 0
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 148.5 -149.598 -3
+      vertex 148.315 -149.696 0
+      vertex 148.315 -149.696 -3
+    endloop
+  endfacet
+  facet normal 0.468107 -0.883672 0
+    outer loop
+      vertex 148.5 -149.598 -3
+      vertex 148.5 -149.598 0
+      vertex 148.315 -149.696 0
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 148.678 -149.487 -3
+      vertex 148.5 -149.598 0
+      vertex 148.5 -149.598 -3
+    endloop
+  endfacet
+  facet normal 0.529142 -0.848533 0
+    outer loop
+      vertex 148.678 -149.487 -3
+      vertex 148.678 -149.487 0
+      vertex 148.5 -149.598 0
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 148.847 -149.364 -3
+      vertex 148.678 -149.487 0
+      vertex 148.678 -149.487 -3
+    endloop
+  endfacet
+  facet normal 0.588456 -0.808529 0
+    outer loop
+      vertex 148.847 -149.364 -3
+      vertex 148.847 -149.364 0
+      vertex 148.678 -149.487 0
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 149.007 -149.229 -3
+      vertex 148.847 -149.364 0
+      vertex 148.847 -149.364 -3
+    endloop
+  endfacet
+  facet normal 0.644871 -0.764291 0
+    outer loop
+      vertex 149.007 -149.229 -3
+      vertex 149.007 -149.229 0
+      vertex 148.847 -149.364 0
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 149.158 -149.084 -3
+      vertex 149.007 -149.229 0
+      vertex 149.007 -149.229 -3
+    endloop
+  endfacet
+  facet normal 0.692631 -0.721292 0
+    outer loop
+      vertex 149.158 -149.084 -3
+      vertex 149.158 -149.084 0
+      vertex 149.007 -149.229 0
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 149.298 -148.928 -3
+      vertex 149.158 -149.084 0
+      vertex 149.158 -149.084 -3
+    endloop
+  endfacet
+  facet normal 0.744242 -0.66791 0
+    outer loop
+      vertex 149.298 -148.928 -3
+      vertex 149.298 -148.928 0
+      vertex 149.158 -149.084 0
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 149.427 -148.763 -3
+      vertex 149.298 -148.928 0
+      vertex 149.298 -148.928 -3
+    endloop
+  endfacet
+  facet normal 0.787807 -0.615922 0
+    outer loop
+      vertex 149.427 -148.763 -3
+      vertex 149.427 -148.763 0
+      vertex 149.298 -148.928 0
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 149.544 -148.59 -3
+      vertex 149.427 -148.763 0
+      vertex 149.427 -148.763 -3
+    endloop
+  endfacet
+  facet normal 0.828349 -0.560213 0
+    outer loop
+      vertex 149.544 -148.59 -3
+      vertex 149.544 -148.59 0
+      vertex 149.427 -148.763 0
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 149.649 -148.408 -3
+      vertex 149.544 -148.59 0
+      vertex 149.544 -148.59 -3
+    endloop
+  endfacet
+  facet normal 0.866186 -0.499722 0
+    outer loop
+      vertex 149.649 -148.408 -3
+      vertex 149.649 -148.408 0
+      vertex 149.544 -148.59 0
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 149.741 -148.22 -3
+      vertex 149.649 -148.408 0
+      vertex 149.649 -148.408 -3
+    endloop
+  endfacet
+  facet normal 0.898217 -0.439553 0
+    outer loop
+      vertex 149.741 -148.22 -3
+      vertex 149.741 -148.22 0
+      vertex 149.649 -148.408 0
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 149.819 -148.026 -3
+      vertex 149.741 -148.22 0
+      vertex 149.741 -148.22 -3
+    endloop
+  endfacet
+  facet normal 0.927816 -0.373039 0
+    outer loop
+      vertex 149.819 -148.026 -3
+      vertex 149.819 -148.026 0
+      vertex 149.741 -148.22 0
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 149.884 -147.827 -3
+      vertex 149.819 -148.026 0
+      vertex 149.819 -148.026 -3
+    endloop
+  endfacet
+  facet normal 0.950577 -0.31049 0
+    outer loop
+      vertex 149.884 -147.827 -3
+      vertex 149.884 -147.827 0
+      vertex 149.819 -148.026 0
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 149.934 -147.624 -3
+      vertex 149.884 -147.827 0
+      vertex 149.884 -147.827 -3
+    endloop
+  endfacet
+  facet normal 0.970981 -0.239158 0
+    outer loop
+      vertex 149.934 -147.624 -3
+      vertex 149.934 -147.624 0
+      vertex 149.884 -147.827 0
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 149.971 -147.418 -3
+      vertex 149.934 -147.624 0
+      vertex 149.934 -147.624 -3
+    endloop
+  endfacet
+  facet normal 0.98425 -0.176783 0
+    outer loop
+      vertex 149.971 -147.418 -3
+      vertex 149.971 -147.418 0
+      vertex 149.934 -147.624 0
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 149.993 -147.209 -3
+      vertex 149.971 -147.418 0
+      vertex 149.971 -147.418 -3
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex 149.993 -147.209 -3
+      vertex 149.993 -147.209 0
+      vertex 149.971 -147.418 0
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 150 -147 -3
+      vertex 149.993 -147.209 0
+      vertex 149.993 -147.209 -3
+    endloop
+  endfacet
+  facet normal 0.99944 -0.0334741 0
+    outer loop
+      vertex 150 -147 -3
+      vertex 150 -147 0
+      vertex 149.993 -147.209 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 150 147 -3
+      vertex 150 -147 0
+      vertex 150 -147 -3
+    endloop
+  endfacet
+  facet normal 1 0 -0
+    outer loop
+      vertex 150 147 -3
+      vertex 150 147 0
+      vertex 150 -147 0
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 0
+    outer loop
+      vertex 149.993 147.209 -3
+      vertex 150 147 0
+      vertex 150 147 -3
+    endloop
+  endfacet
+  facet normal 0.99944 0.0334741 -0
+    outer loop
+      vertex 149.993 147.209 -3
+      vertex 149.993 147.209 0
+      vertex 150 147 0
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex 149.971 147.418 -3
+      vertex 149.993 147.209 0
+      vertex 149.993 147.209 -3
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 -0
+    outer loop
+      vertex 149.971 147.418 -3
+      vertex 149.971 147.418 0
+      vertex 149.993 147.209 0
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 0
+    outer loop
+      vertex 149.934 147.624 -3
+      vertex 149.971 147.418 0
+      vertex 149.971 147.418 -3
+    endloop
+  endfacet
+  facet normal 0.98425 0.176783 -0
+    outer loop
+      vertex 149.934 147.624 -3
+      vertex 149.934 147.624 0
+      vertex 149.971 147.418 0
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 0
+    outer loop
+      vertex 149.884 147.827 -3
+      vertex 149.934 147.624 0
+      vertex 149.934 147.624 -3
+    endloop
+  endfacet
+  facet normal 0.970981 0.239158 -0
+    outer loop
+      vertex 149.884 147.827 -3
+      vertex 149.884 147.827 0
+      vertex 149.934 147.624 0
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 0
+    outer loop
+      vertex 149.819 148.026 -3
+      vertex 149.884 147.827 0
+      vertex 149.884 147.827 -3
+    endloop
+  endfacet
+  facet normal 0.950577 0.31049 -0
+    outer loop
+      vertex 149.819 148.026 -3
+      vertex 149.819 148.026 0
+      vertex 149.884 147.827 0
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 0
+    outer loop
+      vertex 149.741 148.22 -3
+      vertex 149.819 148.026 0
+      vertex 149.819 148.026 -3
+    endloop
+  endfacet
+  facet normal 0.927816 0.373039 -0
+    outer loop
+      vertex 149.741 148.22 -3
+      vertex 149.741 148.22 0
+      vertex 149.819 148.026 0
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 0
+    outer loop
+      vertex 149.649 148.408 -3
+      vertex 149.741 148.22 0
+      vertex 149.741 148.22 -3
+    endloop
+  endfacet
+  facet normal 0.898217 0.439553 -0
+    outer loop
+      vertex 149.649 148.408 -3
+      vertex 149.649 148.408 0
+      vertex 149.741 148.22 0
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 0
+    outer loop
+      vertex 149.544 148.59 -3
+      vertex 149.649 148.408 0
+      vertex 149.649 148.408 -3
+    endloop
+  endfacet
+  facet normal 0.866186 0.499722 -0
+    outer loop
+      vertex 149.544 148.59 -3
+      vertex 149.544 148.59 0
+      vertex 149.649 148.408 0
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 0
+    outer loop
+      vertex 149.427 148.763 -3
+      vertex 149.544 148.59 0
+      vertex 149.544 148.59 -3
+    endloop
+  endfacet
+  facet normal 0.828349 0.560213 -0
+    outer loop
+      vertex 149.427 148.763 -3
+      vertex 149.427 148.763 0
+      vertex 149.544 148.59 0
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 0
+    outer loop
+      vertex 149.298 148.928 -3
+      vertex 149.427 148.763 0
+      vertex 149.427 148.763 -3
+    endloop
+  endfacet
+  facet normal 0.787807 0.615922 -0
+    outer loop
+      vertex 149.298 148.928 -3
+      vertex 149.298 148.928 0
+      vertex 149.427 148.763 0
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 0
+    outer loop
+      vertex 149.158 149.084 -3
+      vertex 149.298 148.928 0
+      vertex 149.298 148.928 -3
+    endloop
+  endfacet
+  facet normal 0.744242 0.66791 -0
+    outer loop
+      vertex 149.158 149.084 -3
+      vertex 149.158 149.084 0
+      vertex 149.298 148.928 0
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 0
+    outer loop
+      vertex 149.007 149.229 -3
+      vertex 149.158 149.084 0
+      vertex 149.158 149.084 -3
+    endloop
+  endfacet
+  facet normal 0.692631 0.721292 -0
+    outer loop
+      vertex 149.007 149.229 -3
+      vertex 149.007 149.229 0
+      vertex 149.158 149.084 0
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 0
+    outer loop
+      vertex 148.847 149.364 -3
+      vertex 149.007 149.229 0
+      vertex 149.007 149.229 -3
+    endloop
+  endfacet
+  facet normal 0.644871 0.764291 -0
+    outer loop
+      vertex 148.847 149.364 -3
+      vertex 148.847 149.364 0
+      vertex 149.007 149.229 0
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 0
+    outer loop
+      vertex 148.678 149.487 -3
+      vertex 148.847 149.364 0
+      vertex 148.847 149.364 -3
+    endloop
+  endfacet
+  facet normal 0.588456 0.808529 -0
+    outer loop
+      vertex 148.678 149.487 -3
+      vertex 148.678 149.487 0
+      vertex 148.847 149.364 0
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 0
+    outer loop
+      vertex 148.5 149.598 -3
+      vertex 148.678 149.487 0
+      vertex 148.678 149.487 -3
+    endloop
+  endfacet
+  facet normal 0.529142 0.848533 -0
+    outer loop
+      vertex 148.5 149.598 -3
+      vertex 148.5 149.598 0
+      vertex 148.678 149.487 0
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 0
+    outer loop
+      vertex 148.315 149.696 -3
+      vertex 148.5 149.598 0
+      vertex 148.5 149.598 -3
+    endloop
+  endfacet
+  facet normal 0.468107 0.883672 -0
+    outer loop
+      vertex 148.315 149.696 -3
+      vertex 148.315 149.696 0
+      vertex 148.5 149.598 0
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 0
+    outer loop
+      vertex 148.124 149.782 -3
+      vertex 148.315 149.696 0
+      vertex 148.315 149.696 -3
+    endloop
+  endfacet
+  facet normal 0.410563 0.911832 -0
+    outer loop
+      vertex 148.124 149.782 -3
+      vertex 148.124 149.782 0
+      vertex 148.315 149.696 0
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 0
+    outer loop
+      vertex 147.927 149.853 -3
+      vertex 148.124 149.782 0
+      vertex 148.124 149.782 -3
+    endloop
+  endfacet
+  facet normal 0.339058 0.940766 -0
+    outer loop
+      vertex 147.927 149.853 -3
+      vertex 147.927 149.853 0
+      vertex 148.124 149.782 0
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 0
+    outer loop
+      vertex 147.726 149.911 -3
+      vertex 147.927 149.853 0
+      vertex 147.927 149.853 -3
+    endloop
+  endfacet
+  facet normal 0.277246 0.960799 -0
+    outer loop
+      vertex 147.726 149.911 -3
+      vertex 147.726 149.911 0
+      vertex 147.927 149.853 0
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 0
+    outer loop
+      vertex 147.521 149.954 -3
+      vertex 147.726 149.911 0
+      vertex 147.726 149.911 -3
+    endloop
+  endfacet
+  facet normal 0.205289 0.978701 -0
+    outer loop
+      vertex 147.521 149.954 -3
+      vertex 147.521 149.954 0
+      vertex 147.726 149.911 0
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 0
+    outer loop
+      vertex 147.314 149.984 -3
+      vertex 147.521 149.954 0
+      vertex 147.521 149.954 -3
+    endloop
+  endfacet
+  facet normal 0.143429 0.989661 -0
+    outer loop
+      vertex 147.314 149.984 -3
+      vertex 147.314 149.984 0
+      vertex 147.521 149.954 0
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 0
+    outer loop
+      vertex 147.105 149.998 -3
+      vertex 147.314 149.984 0
+      vertex 147.314 149.984 -3
+    endloop
+  endfacet
+  facet normal 0.0668359 0.997764 -0
+    outer loop
+      vertex 147.105 149.998 -3
+      vertex 147.105 149.998 0
+      vertex 147.314 149.984 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 147.105 149.998 0
+      vertex 147.105 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 147.002 149.998 -3
+      vertex 147.002 149.998 0
+      vertex 147.105 149.998 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 147 150 -3
+      vertex 147.002 149.998 0
+      vertex 147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 -0
+    outer loop
+      vertex 147 150 -3
+      vertex 147 150 0
+      vertex 147.002 149.998 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -147 150 -3
+      vertex 147 150 0
+      vertex 147 150 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -147 150 -3
+      vertex -147 150 0
+      vertex 147 150 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147 150 0
+      vertex -147 150 -3
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -147.002 149.998 -3
+      vertex -147.002 149.998 0
+      vertex -147 150 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -147.105 149.998 -3
+      vertex -147.002 149.998 0
+      vertex -147.002 149.998 -3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -147.105 149.998 -3
+      vertex -147.105 149.998 0
+      vertex -147.002 149.998 0
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -147.314 149.984 -3
+      vertex -147.105 149.998 0
+      vertex -147.105 149.998 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 0.997764 0
+    outer loop
+      vertex -147.314 149.984 -3
+      vertex -147.314 149.984 0
+      vertex -147.105 149.998 0
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -147.521 149.954 -3
+      vertex -147.314 149.984 0
+      vertex -147.314 149.984 -3
+    endloop
+  endfacet
+  facet normal -0.143429 0.989661 0
+    outer loop
+      vertex -147.521 149.954 -3
+      vertex -147.521 149.954 0
+      vertex -147.314 149.984 0
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -147.726 149.911 -3
+      vertex -147.521 149.954 0
+      vertex -147.521 149.954 -3
+    endloop
+  endfacet
+  facet normal -0.205289 0.978701 0
+    outer loop
+      vertex -147.726 149.911 -3
+      vertex -147.726 149.911 0
+      vertex -147.521 149.954 0
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -147.927 149.853 -3
+      vertex -147.726 149.911 0
+      vertex -147.726 149.911 -3
+    endloop
+  endfacet
+  facet normal -0.277246 0.960799 0
+    outer loop
+      vertex -147.927 149.853 -3
+      vertex -147.927 149.853 0
+      vertex -147.726 149.911 0
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -148.124 149.782 -3
+      vertex -147.927 149.853 0
+      vertex -147.927 149.853 -3
+    endloop
+  endfacet
+  facet normal -0.339058 0.940766 0
+    outer loop
+      vertex -148.124 149.782 -3
+      vertex -148.124 149.782 0
+      vertex -147.927 149.853 0
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -148.315 149.696 -3
+      vertex -148.124 149.782 0
+      vertex -148.124 149.782 -3
+    endloop
+  endfacet
+  facet normal -0.410563 0.911832 0
+    outer loop
+      vertex -148.315 149.696 -3
+      vertex -148.315 149.696 0
+      vertex -148.124 149.782 0
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -148.5 149.598 -3
+      vertex -148.315 149.696 0
+      vertex -148.315 149.696 -3
+    endloop
+  endfacet
+  facet normal -0.468107 0.883672 0
+    outer loop
+      vertex -148.5 149.598 -3
+      vertex -148.5 149.598 0
+      vertex -148.315 149.696 0
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -148.678 149.487 -3
+      vertex -148.5 149.598 0
+      vertex -148.5 149.598 -3
+    endloop
+  endfacet
+  facet normal -0.529142 0.848533 0
+    outer loop
+      vertex -148.678 149.487 -3
+      vertex -148.678 149.487 0
+      vertex -148.5 149.598 0
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -148.847 149.364 -3
+      vertex -148.678 149.487 0
+      vertex -148.678 149.487 -3
+    endloop
+  endfacet
+  facet normal -0.588456 0.808529 0
+    outer loop
+      vertex -148.847 149.364 -3
+      vertex -148.847 149.364 0
+      vertex -148.678 149.487 0
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -149.007 149.229 -3
+      vertex -148.847 149.364 0
+      vertex -148.847 149.364 -3
+    endloop
+  endfacet
+  facet normal -0.644871 0.764291 0
+    outer loop
+      vertex -149.007 149.229 -3
+      vertex -149.007 149.229 0
+      vertex -148.847 149.364 0
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -149.158 149.084 -3
+      vertex -149.007 149.229 0
+      vertex -149.007 149.229 -3
+    endloop
+  endfacet
+  facet normal -0.692631 0.721292 0
+    outer loop
+      vertex -149.158 149.084 -3
+      vertex -149.158 149.084 0
+      vertex -149.007 149.229 0
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -149.298 148.928 -3
+      vertex -149.158 149.084 0
+      vertex -149.158 149.084 -3
+    endloop
+  endfacet
+  facet normal -0.744242 0.66791 0
+    outer loop
+      vertex -149.298 148.928 -3
+      vertex -149.298 148.928 0
+      vertex -149.158 149.084 0
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -149.427 148.763 -3
+      vertex -149.298 148.928 0
+      vertex -149.298 148.928 -3
+    endloop
+  endfacet
+  facet normal -0.787807 0.615922 0
+    outer loop
+      vertex -149.427 148.763 -3
+      vertex -149.427 148.763 0
+      vertex -149.298 148.928 0
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -149.544 148.59 -3
+      vertex -149.427 148.763 0
+      vertex -149.427 148.763 -3
+    endloop
+  endfacet
+  facet normal -0.828349 0.560213 0
+    outer loop
+      vertex -149.544 148.59 -3
+      vertex -149.544 148.59 0
+      vertex -149.427 148.763 0
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -149.649 148.408 -3
+      vertex -149.544 148.59 0
+      vertex -149.544 148.59 -3
+    endloop
+  endfacet
+  facet normal -0.866186 0.499722 0
+    outer loop
+      vertex -149.649 148.408 -3
+      vertex -149.649 148.408 0
+      vertex -149.544 148.59 0
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -149.741 148.22 -3
+      vertex -149.649 148.408 0
+      vertex -149.649 148.408 -3
+    endloop
+  endfacet
+  facet normal -0.898217 0.439553 0
+    outer loop
+      vertex -149.741 148.22 -3
+      vertex -149.741 148.22 0
+      vertex -149.649 148.408 0
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -149.819 148.026 -3
+      vertex -149.741 148.22 0
+      vertex -149.741 148.22 -3
+    endloop
+  endfacet
+  facet normal -0.927816 0.373039 0
+    outer loop
+      vertex -149.819 148.026 -3
+      vertex -149.819 148.026 0
+      vertex -149.741 148.22 0
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -149.884 147.827 -3
+      vertex -149.819 148.026 0
+      vertex -149.819 148.026 -3
+    endloop
+  endfacet
+  facet normal -0.950577 0.31049 0
+    outer loop
+      vertex -149.884 147.827 -3
+      vertex -149.884 147.827 0
+      vertex -149.819 148.026 0
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -149.934 147.624 -3
+      vertex -149.884 147.827 0
+      vertex -149.884 147.827 -3
+    endloop
+  endfacet
+  facet normal -0.970981 0.239158 0
+    outer loop
+      vertex -149.934 147.624 -3
+      vertex -149.934 147.624 0
+      vertex -149.884 147.827 0
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -149.971 147.418 -3
+      vertex -149.934 147.624 0
+      vertex -149.934 147.624 -3
+    endloop
+  endfacet
+  facet normal -0.98425 0.176783 0
+    outer loop
+      vertex -149.971 147.418 -3
+      vertex -149.971 147.418 0
+      vertex -149.934 147.624 0
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -149.993 147.209 -3
+      vertex -149.971 147.418 0
+      vertex -149.971 147.418 -3
+    endloop
+  endfacet
+  facet normal -0.994505 0.104685 0
+    outer loop
+      vertex -149.993 147.209 -3
+      vertex -149.993 147.209 0
+      vertex -149.971 147.418 0
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -150 147 -3
+      vertex -149.993 147.209 0
+      vertex -149.993 147.209 -3
+    endloop
+  endfacet
+  facet normal -0.99944 0.0334741 0
+    outer loop
+      vertex -150 147 -3
+      vertex -150 147 0
+      vertex -149.993 147.209 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -150 -147 -3
+      vertex -150 147 0
+      vertex -150 147 -3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -150 -147 -3
+      vertex -150 -147 0
+      vertex -150 147 0
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -149.993 -147.209 -3
+      vertex -150 -147 0
+      vertex -150 -147 -3
+    endloop
+  endfacet
+  facet normal -0.99944 -0.0334741 0
+    outer loop
+      vertex -149.993 -147.209 -3
+      vertex -149.993 -147.209 0
+      vertex -150 -147 0
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -149.971 -147.418 -3
+      vertex -149.993 -147.209 0
+      vertex -149.993 -147.209 -3
+    endloop
+  endfacet
+  facet normal -0.994505 -0.104685 0
+    outer loop
+      vertex -149.971 -147.418 -3
+      vertex -149.971 -147.418 0
+      vertex -149.993 -147.209 0
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -149.934 -147.624 -3
+      vertex -149.971 -147.418 0
+      vertex -149.971 -147.418 -3
+    endloop
+  endfacet
+  facet normal -0.98425 -0.176783 0
+    outer loop
+      vertex -149.934 -147.624 -3
+      vertex -149.934 -147.624 0
+      vertex -149.971 -147.418 0
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -149.884 -147.827 -3
+      vertex -149.934 -147.624 0
+      vertex -149.934 -147.624 -3
+    endloop
+  endfacet
+  facet normal -0.970981 -0.239158 0
+    outer loop
+      vertex -149.884 -147.827 -3
+      vertex -149.884 -147.827 0
+      vertex -149.934 -147.624 0
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -149.819 -148.026 -3
+      vertex -149.884 -147.827 0
+      vertex -149.884 -147.827 -3
+    endloop
+  endfacet
+  facet normal -0.950577 -0.31049 0
+    outer loop
+      vertex -149.819 -148.026 -3
+      vertex -149.819 -148.026 0
+      vertex -149.884 -147.827 0
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -149.741 -148.22 -3
+      vertex -149.819 -148.026 0
+      vertex -149.819 -148.026 -3
+    endloop
+  endfacet
+  facet normal -0.927816 -0.373039 0
+    outer loop
+      vertex -149.741 -148.22 -3
+      vertex -149.741 -148.22 0
+      vertex -149.819 -148.026 0
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -149.649 -148.408 -3
+      vertex -149.741 -148.22 0
+      vertex -149.741 -148.22 -3
+    endloop
+  endfacet
+  facet normal -0.898217 -0.439553 0
+    outer loop
+      vertex -149.649 -148.408 -3
+      vertex -149.649 -148.408 0
+      vertex -149.741 -148.22 0
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -149.544 -148.59 -3
+      vertex -149.649 -148.408 0
+      vertex -149.649 -148.408 -3
+    endloop
+  endfacet
+  facet normal -0.866186 -0.499722 0
+    outer loop
+      vertex -149.544 -148.59 -3
+      vertex -149.544 -148.59 0
+      vertex -149.649 -148.408 0
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -149.427 -148.763 -3
+      vertex -149.544 -148.59 0
+      vertex -149.544 -148.59 -3
+    endloop
+  endfacet
+  facet normal -0.828349 -0.560213 0
+    outer loop
+      vertex -149.427 -148.763 -3
+      vertex -149.427 -148.763 0
+      vertex -149.544 -148.59 0
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -149.298 -148.928 -3
+      vertex -149.427 -148.763 0
+      vertex -149.427 -148.763 -3
+    endloop
+  endfacet
+  facet normal -0.787807 -0.615922 0
+    outer loop
+      vertex -149.298 -148.928 -3
+      vertex -149.298 -148.928 0
+      vertex -149.427 -148.763 0
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -149.158 -149.084 -3
+      vertex -149.298 -148.928 0
+      vertex -149.298 -148.928 -3
+    endloop
+  endfacet
+  facet normal -0.744242 -0.66791 0
+    outer loop
+      vertex -149.158 -149.084 -3
+      vertex -149.158 -149.084 0
+      vertex -149.298 -148.928 0
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -149.007 -149.229 -3
+      vertex -149.158 -149.084 0
+      vertex -149.158 -149.084 -3
+    endloop
+  endfacet
+  facet normal -0.692631 -0.721292 0
+    outer loop
+      vertex -149.007 -149.229 -3
+      vertex -149.007 -149.229 0
+      vertex -149.158 -149.084 0
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -148.847 -149.364 -3
+      vertex -149.007 -149.229 0
+      vertex -149.007 -149.229 -3
+    endloop
+  endfacet
+  facet normal -0.644871 -0.764291 0
+    outer loop
+      vertex -148.847 -149.364 -3
+      vertex -148.847 -149.364 0
+      vertex -149.007 -149.229 0
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -148.678 -149.487 -3
+      vertex -148.847 -149.364 0
+      vertex -148.847 -149.364 -3
+    endloop
+  endfacet
+  facet normal -0.588456 -0.808529 0
+    outer loop
+      vertex -148.678 -149.487 -3
+      vertex -148.678 -149.487 0
+      vertex -148.847 -149.364 0
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -148.5 -149.598 -3
+      vertex -148.678 -149.487 0
+      vertex -148.678 -149.487 -3
+    endloop
+  endfacet
+  facet normal -0.529142 -0.848533 0
+    outer loop
+      vertex -148.5 -149.598 -3
+      vertex -148.5 -149.598 0
+      vertex -148.678 -149.487 0
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -148.315 -149.696 -3
+      vertex -148.5 -149.598 0
+      vertex -148.5 -149.598 -3
+    endloop
+  endfacet
+  facet normal -0.468107 -0.883672 0
+    outer loop
+      vertex -148.315 -149.696 -3
+      vertex -148.315 -149.696 0
+      vertex -148.5 -149.598 0
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -148.124 -149.782 -3
+      vertex -148.315 -149.696 0
+      vertex -148.315 -149.696 -3
+    endloop
+  endfacet
+  facet normal -0.410563 -0.911832 0
+    outer loop
+      vertex -148.124 -149.782 -3
+      vertex -148.124 -149.782 0
+      vertex -148.315 -149.696 0
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -147.927 -149.853 -3
+      vertex -148.124 -149.782 0
+      vertex -148.124 -149.782 -3
+    endloop
+  endfacet
+  facet normal -0.339058 -0.940766 0
+    outer loop
+      vertex -147.927 -149.853 -3
+      vertex -147.927 -149.853 0
+      vertex -148.124 -149.782 0
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -147.726 -149.911 -3
+      vertex -147.927 -149.853 0
+      vertex -147.927 -149.853 -3
+    endloop
+  endfacet
+  facet normal -0.277246 -0.960799 0
+    outer loop
+      vertex -147.726 -149.911 -3
+      vertex -147.726 -149.911 0
+      vertex -147.927 -149.853 0
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -147.521 -149.954 -3
+      vertex -147.726 -149.911 0
+      vertex -147.726 -149.911 -3
+    endloop
+  endfacet
+  facet normal -0.205289 -0.978701 0
+    outer loop
+      vertex -147.521 -149.954 -3
+      vertex -147.521 -149.954 0
+      vertex -147.726 -149.911 0
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -147.314 -149.984 -3
+      vertex -147.521 -149.954 0
+      vertex -147.521 -149.954 -3
+    endloop
+  endfacet
+  facet normal -0.143429 -0.989661 0
+    outer loop
+      vertex -147.314 -149.984 -3
+      vertex -147.314 -149.984 0
+      vertex -147.521 -149.954 0
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -147.105 -149.998 -3
+      vertex -147.314 -149.984 0
+      vertex -147.314 -149.984 -3
+    endloop
+  endfacet
+  facet normal -0.0668359 -0.997764 0
+    outer loop
+      vertex -147.105 -149.998 -3
+      vertex -147.105 -149.998 0
+      vertex -147.314 -149.984 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -147.105 -149.998 0
+      vertex -147.105 -149.998 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -147.002 -149.998 -3
+      vertex -147.002 -149.998 0
+      vertex -147.105 -149.998 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -147 -150 -3
+      vertex -147.002 -149.998 0
+      vertex -147.002 -149.998 -3
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -147 -150 -3
+      vertex -147 -150 0
+      vertex -147.002 -149.998 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 147 -150 -3
+      vertex -147 -150 0
+      vertex -147 -150 -3
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 147 -150 -3
+      vertex 147 -150 0
+      vertex -147 -150 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 147.002 -149.998 -3
+      vertex 147 -150 0
+      vertex 147 -150 -3
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 147.002 -149.998 -3
+      vertex 147.002 -149.998 0
+      vertex 147 -150 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
@rtyr: This resolves #9581 (first commit)

This adds **alpha** support for the CR-M4, K1 and K1 Max printers.

Would you be so kind to add thumbnails?

Would you mind verifying my work, as I'm a bit rusty it seems...



On a sidenote, would you mind taking a look (unrelated) at  #10560 as well...

