### PR TITLE
Extended 3D file format support [macOS]

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -429,6 +429,11 @@ set(SLIC3R_SOURCES
     Arachne/WallToolPaths.cpp
 )
 
+if (APPLE)
+#    set_source_files_properties(Format/ModelIO.mm PROPERTIES LANGUAGE CXX)
+    list(APPEND SLIC3R_SOURCES Format/ModelIO.hpp Format/ModelIO.mm)
+endif ()
+
 add_library(libslic3r STATIC ${SLIC3R_SOURCES})
 
 foreach(_source IN ITEMS ${SLIC3R_SOURCES})
@@ -511,8 +516,10 @@ target_link_libraries(libslic3r
     )
 
 if (APPLE)
+    find_library(COREFOUNDATION Foundation REQUIRED)
+    find_library(MODELIO ModelIO REQUIRED)
     # TODO: we need to fix notarization with the separate shared library
-    target_link_libraries(libslic3r OCCTWrapper)
+    target_link_libraries(libslic3r OCCTWrapper ${COREFOUNDATION} ${MODELIO})
 endif ()
 
 if (TARGET OpenVDB::openvdb)

--- a/src/libslic3r/Format/ModelIO.hpp
+++ b/src/libslic3r/Format/ModelIO.hpp
@@ -1,0 +1,18 @@
+#include <string>
+
+namespace Slic3r {
+    /**
+     * Uses ModelIO to convert supported model types to a temporary STL
+     * that can then be consumed by the existing STL loader
+     * @param input_file The File to load
+     * @return Path to the temporary file, or an empty string if conversion failed
+     */
+    std::string make_temp_stl_with_modelio(const std::string& input_file);
+
+    /**
+     * Convenience function to delete the file.
+     * No return value since success isn't required
+     * @param temp_file File path to delete
+     */
+    void delete_temp_file(const std::string& temp_file);
+}

--- a/src/libslic3r/Format/ModelIO.mm
+++ b/src/libslic3r/Format/ModelIO.mm
@@ -1,0 +1,27 @@
+#include "ModelIO.hpp"
+#import <ModelIO/ModelIO.h>
+
+namespace Slic3r {
+
+std::string make_temp_stl_with_modelio(const std::string &input_file)
+{
+    NSURL    *input_url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:input_file.c_str()]];
+    MDLAsset *asset     = [[MDLAsset alloc] initWithURL:input_url];
+
+    NSString *tmp_file_name = [[[NSUUID UUID] UUIDString] stringByAppendingPathExtension:@"stl"];
+    NSURL    *tmp_file_url  = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:tmp_file_name]];
+
+    if ([asset exportAssetToURL:tmp_file_url]) {
+        std::string output_file = std::string([[tmp_file_url path] UTF8String]);
+        return output_file;
+    }
+
+    return std::string();
+}
+void delete_temp_file(const std::string &temp_file)
+{
+    NSString *file_path = [NSString stringWithUTF8String:temp_file.c_str()];
+    [[NSFileManager defaultManager] removeItemAtPath:file_path error:NULL];
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -15,6 +15,10 @@
 #include "Format/3mf.hpp"
 #include "Format/STEP.hpp"
 
+#ifdef __APPLE__
+#include "Format/ModelIO.hpp"
+#endif
+
 #include <float.h>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -124,6 +128,18 @@ Model Model::read_from_file(const std::string& input_file, DynamicPrintConfig* c
     else if (boost::algorithm::iends_with(input_file, ".3mf") || boost::algorithm::iends_with(input_file, ".zip"))
         //FIXME options & LoadAttribute::CheckVersion ? 
         result = load_3mf(input_file.c_str(), *config, *config_substitutions, &model, false);
+#ifdef __APPLE__
+    else if (boost::algorithm::iends_with(input_file, ".usd") || boost::algorithm::iends_with(input_file, ".usda") ||
+             boost::algorithm::iends_with(input_file, ".usdc") || boost::algorithm::iends_with(input_file, ".usdz") ||
+             boost::algorithm::iends_with(input_file, ".abc") || boost::algorithm::iends_with(input_file, ".ply")) {
+        std::string temp_stl = make_temp_stl_with_modelio(input_file);
+        if (temp_stl.empty()) {
+            throw Slic3r::RuntimeError("Failed to convert asset to STL via ModelIO.");
+        }
+        result = load_stl(temp_stl.c_str(), &model);
+        delete_temp_file(temp_stl);
+    }
+#endif
     else
         throw Slic3r::RuntimeError("Unknown file format. Input file must have .stl, .obj, .amf(.xml), .prusa or .step/.stp extension.");
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -481,7 +481,11 @@ static const FileWildcards file_wildcards_by_type[FT_SIZE] = {
     /* FT_AMF */     { "AMF files"sv,       { ".amf"sv, ".zip.amf"sv, ".xml"sv } },
     /* FT_3MF */     { "3MF files"sv,       { ".3mf"sv } },
     /* FT_GCODE */   { "G-code files"sv,    { ".gcode"sv, ".gco"sv, ".g"sv, ".ngc"sv } },
+#ifdef __APPLE__
+    /* FT_MODEL */   { "Known files"sv,     { ".stl"sv, ".obj"sv, ".3mf"sv, ".amf"sv, ".zip.amf"sv, ".xml"sv, ".step"sv, ".stp"sv , ".usd"sv, ".usda"sv, ".usdc"sv, ".usdz"sv, ".abc"sv, ".ply"sv} },
+#else
     /* FT_MODEL */   { "Known files"sv,     { ".stl"sv, ".obj"sv, ".3mf"sv, ".amf"sv, ".zip.amf"sv, ".xml"sv, ".step"sv, ".stp"sv } },
+#endif
     /* FT_PROJECT */ { "Project files"sv,   { ".3mf"sv, ".amf"sv, ".zip.amf"sv } },
     /* FT_FONTS */   { "Font files"sv,      { ".ttc"sv, ".ttf"sv } },
     /* FT_GALLERY */ { "Known files"sv,     { ".stl"sv, ".obj"sv } },
@@ -2013,7 +2017,11 @@ void GUI_App::import_model(wxWindow *parent, wxArrayString& input_files) const
 {
     input_files.Clear();
     wxFileDialog dialog(parent ? parent : GetTopWindow(),
+#ifdef __APPLE__
+        _L("Choose one or more files (STL/3MF/STEP/OBJ/AMF/PRUSA/USD*/ABC/PLY):"),
+#else
         _L("Choose one or more files (STL/3MF/STEP/OBJ/AMF/PRUSA):"),
+#endif
         from_u8(app_config->get_last_dir()), "",
         file_wildcards(FT_MODEL), wxFD_OPEN | wxFD_MULTIPLE | wxFD_FILE_MUST_EXIST);
 


### PR DESCRIPTION
## What does it do?
This PR adds support for a range of 3D file formats for import, making use of [ModelIO](https://developer.apple.com/documentation/modelio) on macOS:

* [Universal Scene Description](https://openusd.org/release/index.html)
* [Alembic](https://www.alembic.io)
* [PLY](https://en.wikipedia.org/wiki/PLY_(file_format)#:~:text=PLY%20is%20a%20computer%20file,list%20of%20nominally%20flat%20polygons.)

## How does it work?

This change only affects macOS users, and since it uses a system framework, it introduces no extra library dependencies. ModelIO is supported since macOS 10.11 which matches the [minimum system requirements](https://help.prusa3d.com/article/minimum-system-requirements_305250) as well.

The way this PR works is that it uses ModelIO to convert the data to a temporary STL that is then imported by the existing STL importer. After import, it clears the temp file.

## Why would someone want this?

With this PR, I no longer need to use other software to convert from 3D formats that I need to deal with in my day to day job. I get a lot of assets in USD and Alembic formats, from content creators who use those for their workflows.
I could ask them to export OBJ/STL, but its extra work for them that they don't verify. I could do the conversion myself in Blender , but with this PR, it streamlines my workflow quite a bit.

I figure since the changes are so minimal, it would be something others find useful as well.

