### PR TITLE
format/AnycubicSLA: use float instead of float_t

### DIFF
--- a/src/libslic3r/Format/AnycubicSLA.cpp
+++ b/src/libslic3r/Format/AnycubicSLA.cpp
@@ -104,21 +104,21 @@ typedef struct anycubicsla_format_header
 {
     char          tag[12];
     std::uint32_t payload_size;
-    std::float_t  pixel_size_um;
-    std::float_t  layer_height_mm;
-    std::float_t  exposure_time_s;
-    std::float_t  delay_before_exposure_s;
-    std::float_t  bottom_exposure_time_s;
-    std::float_t  bottom_layer_count;
-    std::float_t  lift_distance_mm;
-    std::float_t  lift_speed_mms;
-    std::float_t  retract_speed_mms;
-    std::float_t  volume_ml;
+    float         pixel_size_um;
+    float         layer_height_mm;
+    float         exposure_time_s;
+    float         delay_before_exposure_s;
+    float         bottom_exposure_time_s;
+    float         bottom_layer_count;
+    float         lift_distance_mm;
+    float         lift_speed_mms;
+    float         retract_speed_mms;
+    float         volume_ml;
     std::uint32_t antialiasing;
     std::uint32_t res_x;
     std::uint32_t res_y;
-    std::float_t  weight_g;
-    std::float_t  price;
+    float         weight_g;
+    float         price;
     std::uint32_t price_currency;
     std::uint32_t per_layer_override; // ? unknown meaning ?
     std::uint32_t print_time_s;
@@ -149,19 +149,19 @@ typedef struct anycubicsla_format_layer
 {
     std::uint32_t image_offset;
     std::uint32_t image_size;
-    std::float_t  lift_distance_mm;
-    std::float_t  lift_speed_mms;
-    std::float_t  exposure_time_s;
-    std::float_t  layer_height_mm;
-    std::float_t  layer44; // unkown - usually 0
-    std::float_t  layer48; // unkown - usually 0
+    float         lift_distance_mm;
+    float         lift_speed_mms;
+    float         exposure_time_s;
+    float         layer_height_mm;
+    float         layer44; // unkown - usually 0
+    float         layer48; // unkown - usually 0
 } anycubicsla_format_layer;
 
 typedef struct anycubicsla_format_misc
 {
-    std::float_t bottom_layer_height_mm;
-    std::float_t bottom_lift_distance_mm;
-    std::float_t bottom_lift_speed_mms;
+    float bottom_layer_height_mm;
+    float bottom_lift_distance_mm;
+    float bottom_lift_speed_mms;
 
 } anycubicsla_format_misc;
 
@@ -192,9 +192,9 @@ private:
 
 namespace {
 
-std::float_t get_cfg_value_f(const DynamicConfig &cfg,
-                             const std::string   &key,
-                             const std::float_t  &def = 0.f)
+float get_cfg_value_f(const DynamicConfig &cfg,
+                      const std::string   &key,
+                      const float         &def = 0.f)
 {
     if (cfg.has(key)) {
         if (auto opt = cfg.option(key))
@@ -276,10 +276,10 @@ void fill_header(anycubicsla_format_header &h,
 {
     CNumericLocalesSetter locales_setter;
 
-    std::float_t bottle_weight_g;
-    std::float_t bottle_volume_ml;
-    std::float_t bottle_cost;
-    std::float_t material_density;
+    float        bottle_weight_g;
+    float        bottle_volume_ml;
+    float        bottle_cost;
+    float        material_density;
     auto        &cfg     = print.full_print_config();
     auto         mat_opt = cfg.option("material_notes");
     std::string  mnotes  = mat_opt? cfg.option("material_notes")->serialize() : "";
@@ -416,7 +416,7 @@ static void anycubicsla_write_int32(std::ofstream &out, std::uint32_t val)
     out.write((const char *) &i3, 1);
     out.write((const char *) &i4, 1);
 }
-static void anycubicsla_write_float(std::ofstream &out, std::float_t val)
+static void anycubicsla_write_float(std::ofstream &out, float val)
 {
     std::uint32_t *f = (std::uint32_t *) &val;
     anycubicsla_write_int32(out, *f);


### PR DESCRIPTION
Format/AnycubicSLA.cpp failed to build on i386 (and m68k):

https://buildd.debian.org/status/fetch.php?pkg=slic3r-prusa&arch=i386&ver=2.6.0%2Bdfsg-1&stamp=1690032193&raw=0

```
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp: In function ‘void Slic3r::{anonymous}::fill_header(Slic3r::anycubicsla_format_header&, Slic3r::anycubicsla_format_misc&, const Slic3r::SLAPrint&, uint32_t)’:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:327:15: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  327 |     crop_value(h.delay_before_exposure_s, 0.0f, 1000.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:327:15: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  327 |     crop_value(h.delay_before_exposure_s, 0.0f, 1000.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:330:15: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  330 |     crop_value(h.lift_distance_mm, 0.0f, 100.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:330:15: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  330 |     crop_value(h.lift_distance_mm, 0.0f, 100.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:336:19: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  336 |         crop_value(h.lift_distance_mm, 0.0f, 100.0f);
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:336:19: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  336 |         crop_value(h.lift_distance_mm, 0.0f, 100.0f);
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:342:15: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  342 |     crop_value(m.bottom_lift_speed_mms, 0.1f, 20.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:342:15: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  342 |     crop_value(m.bottom_lift_speed_mms, 0.1f, 20.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:346:19: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  346 |         crop_value(m.bottom_lift_speed_mms, 0.1f, 20.0f);
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:346:19: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  346 |         crop_value(m.bottom_lift_speed_mms, 0.1f, 20.0f);
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:352:15: error: no matching function for call to ‘crop_value(float_t&, float, float)’
  352 |     crop_value(h.lift_speed_mms, 0.1f, 20.0f);
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note: candidate: ‘template<class T> void Slic3r::{anonymous}::crop_value(T&, T, T)’
  219 | template<class T> void crop_value(T &val, T val_min, T val_max)
      |                        ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:219:24: note:   template argument deduction/substitution failed:
/<<PKGBUILDDIR>>/src/libslic3r/Format/AnycubicSLA.cpp:352:15: note:   deduced conflicting types for parameter ‘T’ (‘long double’ and ‘float’)
  352 |     crop_value(h.lift_speed_mms, 0.1f, 20.0f);
```

This problem has been seen in Debian on i386 and m68k.

@ole00 The problem is that `float` has a well-defined size, but `float_t` is actually implementation defined.

IEEE 754 `float` is 4 bytes.
`0.0f` is 4 bytes.

But:
https://en.cppreference.com/w/c/numeric/math/float_t
``The types float_t and double_t are floating types at least as wide as float and double, respectively, and such that double_t is at least as wide as float_t. The value of FLT_EVAL_METHOD determines the types of float_t and double_t.``

With gcc on i386 `float_t` is 12 bytes, and the test program from cppreference outputs:
```
2
4  12
8  12
```

C++23 adds `float32_t` and `f32` which do what was likely intended with the use of `float_t`, but since this is not yet widely supported (e.g. `gcc` added support only in its the latest version 13) it is not yet an option.