### PR TITLE
Draft shield loops

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2468,7 +2468,12 @@ LayerResult GCodeGenerator::process_layer(
             m_avoid_crossing_perimeters.use_external_mp();
             Flow layer_skirt_flow = print.skirt_flow().with_height(float(m_skirt_done.back() - (m_skirt_done.size() == 1 ? 0. : m_skirt_done[m_skirt_done.size() - 2])));
             double mm3_per_mm = layer_skirt_flow.mm3_per_mm();
-            for (size_t i = loops.first; i < loops.second; ++i) {
+
+            size_t i_start = loops.first;
+            if (print.config().draft_shield != dsDisabled && layer.id() > 0)
+                i_start = loops.second - print.config().draft_shield_loops.value;
+
+            for (size_t i = i_start; i < loops.second; ++i) {
                 // Adjust flow according to this layer's layer height.
                 //FIXME using the support_material_speed of the 1st object printed.
                 gcode += this->extrude_skirt(dynamic_cast<const ExtrusionLoop&>(*print.skirt().entities[i]),

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -452,6 +452,7 @@ static std::vector<std::string> s_Preset_print_options {
     "bridge_speed", "gap_fill_speed", "gap_fill_enabled", "travel_speed", "travel_speed_z", "first_layer_speed", "first_layer_speed_over_raft", "perimeter_acceleration", "infill_acceleration",
     "external_perimeter_acceleration", "top_solid_infill_acceleration", "solid_infill_acceleration", "travel_acceleration", "wipe_tower_acceleration",
     "bridge_acceleration", "first_layer_acceleration", "first_layer_acceleration_over_raft", "default_acceleration", "skirts", "skirt_distance", "skirt_height", "draft_shield",
+    "draft_shield_loops",
     "min_skirt_length", "brim_width", "brim_separation", "brim_type", "support_material", "support_material_auto", "support_material_threshold", "support_material_enforce_layers",
     "raft_layers", "raft_first_layer_density", "raft_first_layer_expansion", "raft_contact_distance", "raft_expansion",
     "support_material_pattern", "support_material_with_sheath", "support_material_spacing", "support_material_closing_radius", "support_material_style",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2525,13 +2525,13 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("skirt_height", coInt);
     def->label = L("Skirt height");
-    def->tooltip = L("Height of skirt expressed in layers.");
+    def->tooltip = L("Height of skirt expressed in layers. For draft shield it's layers will all loops.");
     def->sidetext = L("layers");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionInt(1));
 
     def = this->add("draft_shield", coEnum);
-    def->label = L("Draft shield");
+    def->label = L("");
     def->tooltip = L("With draft shield active, the skirt will be printed skirt_distance from the object, possibly intersecting brim.\n"
                      "Enabled = skirt is as tall as the highest printed object.\n"
                      "Limited = skirt is as tall as specified by skirt_height.\n"
@@ -2543,6 +2543,13 @@ void PrintConfigDef::init_fff_params()
     });
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<DraftShield>(dsDisabled));
+
+    def = this->add("draft_shield_loops", coInt);
+    def->label = L("loops");
+    def->tooltip = L("Number of loops for the draft shield. Skirt height layers have all loops.");
+    def->min = 1;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(1));
 
     def = this->add("skirts", coInt);
     def->label = L("Loops (minimum)");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -815,6 +815,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,              default_acceleration))
     ((ConfigOptionInts,               disable_fan_first_layers))
     ((ConfigOptionEnum<DraftShield>,  draft_shield))
+    ((ConfigOptionInt,                draft_shield_loops))
     ((ConfigOptionFloat,              duplicate_distance))
     ((ConfigOptionFloat,              external_perimeter_acceleration))
     ((ConfigOptionFloat,              extruder_clearance_height))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -213,6 +213,16 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
             }
         }
     }
+
+    if (config->option<ConfigOptionInt>("skirts")->value > 0 && config->option<ConfigOptionInt>("draft_shield_loops")->value > config->option<ConfigOptionInt>("skirts")->value) {
+        MessageDialog dialog(m_msg_dlg_parent, "Draft shield loops can not be more than skirt loops", _L("Draft shield"), wxICON_WARNING | wxOK);
+        dialog.ShowModal();
+
+        DynamicPrintConfig new_conf = *config;
+        new_conf.set_key_value("draft_shield_loops", new ConfigOptionInt(config->option<ConfigOptionInt>("skirts")->value));
+        apply(config, &new_conf);
+    }
+
 }
 
 void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
@@ -265,9 +275,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         toggle_field(el, have_default_acceleration);
 
     bool have_skirt = config->opt_int("skirts") > 0;
-    toggle_field("skirt_height", have_skirt && config->opt_enum<DraftShield>("draft_shield") != dsEnabled);
-    for (auto el : { "skirt_distance", "draft_shield", "min_skirt_length" })
+    for (auto el : {"skirt_distance", "draft_shield", "draft_shield_loops", "min_skirt_length"})
         toggle_field(el, have_skirt);
+
+    toggle_field("draft_shield_loops", config->opt_enum<DraftShield>("draft_shield") != dsDisabled);
 
     bool have_brim = config->opt_enum<BrimType>("brim_type") != btNoBrim;
     for (auto el : { "brim_width", "brim_separation" })

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1530,7 +1530,13 @@ void TabPrint::build()
         optgroup->append_single_option_line("skirts", category_path + "skirt");
         optgroup->append_single_option_line("skirt_distance", category_path + "skirt");
         optgroup->append_single_option_line("skirt_height", category_path + "skirt");
-        optgroup->append_single_option_line("draft_shield", category_path + "skirt");
+        
+        line = { L("Draft shield"), "" };
+        line.label_path = category_path + "skirt";
+        line.append_option(optgroup->get_option("draft_shield"));
+        line.append_option(optgroup->get_option("draft_shield_loops"));
+        optgroup->append_line(line);
+
         optgroup->append_single_option_line("min_skirt_length", category_path + "skirt");
 
         optgroup = page->new_optgroup(L("Brim"));


### PR DESCRIPTION
This PR is adds draft shield brim to improve its stability (as Cura does). It looks like

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/7a6eee6b-347c-4be3-b36c-bb207eea4783)

Option page:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/7ed77cd7-8c0d-409b-bca3-cc18686f04ed)


We can set more layers with all loops with Skirt height option:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/f8077214-22d3-4e9c-b9c1-555dd8900968)



