### PR TITLE
Fix compilation error with C++17 standard

### DIFF
--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -148,12 +148,12 @@ indexed_triangle_set cgal_to_indexed_triangle_set(const _Mesh &cgalmesh)
     const auto &vertices = cgalmesh.vertices();
     int vsize = int(vertices.size());
 
-    for (auto &vi : vertices) {
+    for (const auto &vi : vertices) {
         auto &v = cgalmesh.point(vi); // Don't ask...
         its.vertices.emplace_back(to_vec3f(v));
     }
 
-    for (auto &face : faces) {
+    for (const auto &face : faces) {
         auto vtc = cgalmesh.vertices_around_face(cgalmesh.halfedge(face));
 
         int i = 0;


### PR DESCRIPTION
In Debian unstable, which now defaults to c++17 standard when compiling, the build fails with the following errors:


```
    /<<PKGBUILDDIR>>/src/libslic3r/MeshBoolean.cpp: In instantiation of ‘indexed_triangle_set Slic3r::MeshBoolean::cgal::cgal_to_indexed_triangle_set(const _M>
    /<<PKGBUILDDIR>>/src/libslic3r/MeshBoolean.cpp:185:53:   required from here
    /<<PKGBUILDDIR>>/src/libslic3r/MeshBoolean.cpp:151:5: error: cannot bind non-const lvalue reference of type ‘CGAL::SM_Vertex_index&’ to an rvalue of type >
      151 |     for (auto &vi : vertices) {
          |     ^~~
    /<<PKGBUILDDIR>>/src/libslic3r/MeshBoolean.cpp:156:5: error: cannot bind non-const lvalue reference of type ‘CGAL::SM_Face_index&’ to an rvalue of type ‘b>
      156 |     for (auto &face : faces) {
          |     ^~~
    make[3]: *** [src/libslic3r/CMakeFiles/libslic3r_cgal.dir/build.make:121: src/libslic3r/CMakeFiles/libslic3r_cgal.dir/MeshBoolean.cpp.o] Error 1
```

This PR fixes that by changing the `auto &` type to `const auto &` in the for loops above.
