### PR TITLE
add missing includes

### DIFF
--- a/src/libslic3r/CutUtils.cpp
+++ b/src/libslic3r/CutUtils.cpp
@@ -7,6 +7,7 @@
 #include "TriangleSelector.hpp"
 #include "ObjectID.hpp"
 
+#include <boost/log/trivial.hpp>
 
 namespace Slic3r {
 

--- a/src/libslic3r/Measure.cpp
+++ b/src/libslic3r/Measure.cpp
@@ -4,9 +4,10 @@
 
 #include "libslic3r/Geometry/Circle.hpp"
 #include "libslic3r/SurfaceMesh.hpp"
-#include <numeric>
+
 
 #include <numeric>
+#include <tbb/parallel_for.h>
 
 #define DEBUG_EXTRACT_ALL_FEATURES_AT_ONCE 0
 

--- a/src/slic3r/GUI/TextLines.cpp
+++ b/src/slic3r/GUI/TextLines.cpp
@@ -10,6 +10,7 @@
 
 #include "libslic3r/AABBTreeLines.hpp"
 #include "libslic3r/ExPolygonsIndex.hpp"
+#include "libslic3r/ClipperUtils.hpp"
 
 #include "slic3r/GUI/Selection.hpp"
 #include "slic3r/GUI/GLCanvas3D.hpp"


### PR DESCRIPTION
In prusa 2.6.0-rc1 there are missing includes that cause flatpak builds (at least) to fail, this PR add it
