### PR TITLE
Fix Linux build

### DIFF
--- a/src/libslic3r/CutUtils.cpp
+++ b/src/libslic3r/CutUtils.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 
+#include <boost/log/trivial.hpp>
 #include "CutUtils.hpp"
 #include "Geometry.hpp"
 #include "libslic3r.h"

--- a/src/libslic3r/Measure.cpp
+++ b/src/libslic3r/Measure.cpp
@@ -2,6 +2,7 @@
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
+#include <tbb/parallel_for.h>
 #include "libslic3r/libslic3r.h"
 #include "Measure.hpp"
 #include "MeasureUtils.hpp"

--- a/src/slic3r/GUI/TextLines.cpp
+++ b/src/slic3r/GUI/TextLines.cpp
@@ -4,6 +4,7 @@
 
 #include "libslic3r/Model.hpp"
 
+#include "libslic3r/ClipperUtils.hpp"
 #include "libslic3r/Emboss.hpp"
 #include "libslic3r/TriangleMeshSlicer.hpp"
 #include "libslic3r/Tesselate.hpp"


### PR DESCRIPTION
Add missing includes, which are needed with at least some builds, even with the recommended settings and the bundled dependencies.