### PR TITLE
Change ERROR: object with no extrusions in the first layer to a warning

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -577,6 +577,9 @@ GCode::ObjectsLayerToPrint GCode::collect_layers_to_print(const PrintObject& obj
 {
     GCode::ObjectsLayerToPrint layers_to_print;
     layers_to_print.reserve(object.layers().size() + object.support_layers().size());
+    const PrintObjectConfig &config = object.config();
+
+
 
     /*
     // Calculate a minimum support layer height as a minimum over all extruders, but not smaller than 10um.
@@ -623,19 +626,19 @@ GCode::ObjectsLayerToPrint GCode::collect_layers_to_print(const PrintObject& obj
         // Check that there are extrusions on the very first layer. The case with empty
         // first layer may result in skirt/brim in the air and maybe other issues.
         if (layers_to_print.size() == 1u) {
-#if 0
-            if (!has_extrusions)
-                throw Slic3r::SlicingError(_u8L("There is an object with no extrusions in the first layer.") + "\n" +
+            if(!config.errors_are_warnings) {
+                if (!has_extrusions)
+                    throw Slic3r::SlicingError(_u8L("There is an object with no extrusions in the first layer.") + "\n" +
                                            _u8L("Object name") + ": " + object.model_object()->name);
-#else
-            if (!has_extrusions) {
-                std::string float_warning;
+            } else {
+                if (!has_extrusions) {
+                    std::string float_warning;
 
-                float_warning += Slic3r::format(_u8L("First layer is empty. This may not be what you want")) +"\n";
-                const_cast<Print*>(object.print())->active_step_add_warning(
-                    PrintStateBase::WarningLevel::CRITICAL, float_warning);
+                    float_warning += Slic3r::format(_u8L("First layer is empty. This may not be what you want")) +"\n";
+                    const_cast<Print*>(object.print())->active_step_add_warning(
+                        PrintStateBase::WarningLevel::CRITICAL, float_warning);
+                }
             }
-#endif
         }
 
         // In case there are extrusions on this layer, check there is a layer to lay it on.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -626,12 +626,11 @@ GCode::ObjectsLayerToPrint GCode::collect_layers_to_print(const PrintObject& obj
         // Check that there are extrusions on the very first layer. The case with empty
         // first layer may result in skirt/brim in the air and maybe other issues.
         if (layers_to_print.size() == 1u) {
-            if(!config.errors_are_warnings) {
-                if (!has_extrusions)
+            if(!has_extrusions) {
+                if(!config.errors_are_warnings) {
                     throw Slic3r::SlicingError(_u8L("There is an object with no extrusions in the first layer.") + "\n" +
                                            _u8L("Object name") + ": " + object.model_object()->name);
-            } else {
-                if (!has_extrusions) {
+                } else {
                     std::string float_warning;
 
                     float_warning += Slic3r::format(_u8L("First layer is empty. This may not be what you want")) +"\n";

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -623,9 +623,19 @@ GCode::ObjectsLayerToPrint GCode::collect_layers_to_print(const PrintObject& obj
         // Check that there are extrusions on the very first layer. The case with empty
         // first layer may result in skirt/brim in the air and maybe other issues.
         if (layers_to_print.size() == 1u) {
+#if 0
             if (!has_extrusions)
                 throw Slic3r::SlicingError(_u8L("There is an object with no extrusions in the first layer.") + "\n" +
                                            _u8L("Object name") + ": " + object.model_object()->name);
+#else
+            if (!has_extrusions) {
+                std::string float_warning;
+
+                float_warning += Slic3r::format(_u8L("First layer is empty. This may not be what you want")) +"\n";
+                const_cast<Print*>(object.print())->active_step_add_warning(
+                    PrintStateBase::WarningLevel::CRITICAL, float_warning);
+            }
+#endif
         }
 
         // In case there are extrusions on this layer, check there is a layer to lay it on.

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -459,7 +459,7 @@ static std::vector<std::string> s_Preset_print_options {
     "support_tree_angle", "support_tree_angle_slow", "support_tree_branch_diameter", "support_tree_branch_diameter_angle", "support_tree_branch_diameter_double_wall", 
     "support_tree_top_rate", "support_tree_branch_distance", "support_tree_tip_diameter",
     "dont_support_bridges", "thick_bridges", "notes", "complete_objects", "extruder_clearance_radius",
-    "extruder_clearance_height", "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
+    "extruder_clearance_height", "gcode_comments", "errors_are_warnings", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",
     "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width",
     "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1439,6 +1439,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(0));
 
+    def = this->add("errors_are_warnings", coBool);
+    def->label = L("Errors are Warnings");
+    def->tooltip = L("Enable this to simply warn for some conditions thar would normally be errors. This may be useful for advanced users.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(0));
+
     def = this->add("gcode_flavor", coEnum);
     def->label = L("G-code flavor");
     def->tooltip = L("Some G/M-code commands, including temperature control and others, are not universal. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -588,6 +588,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                thick_bridges))
     ((ConfigOptionFloat,               xy_size_compensation))
     ((ConfigOptionBool,                wipe_into_objects))
+    ((ConfigOptionBool,                errors_are_warnings))
+
 )
 
 PRINT_CONFIG_CLASS_DEFINE(

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1690,6 +1690,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Output file"));
         optgroup->append_single_option_line("gcode_comments");
         optgroup->append_single_option_line("gcode_label_objects");
+        optgroup->append_single_option_line("errors_are_warnings");
         Option option = optgroup->get_option("output_filename_format");
         option.opt.full_width = true;
         optgroup->append_single_option_line(option);


### PR DESCRIPTION
It is sometimes useful to print on top of an existing print in another color or another material.
With this patch, checking Print Settings->Output options->Errors are Warnings allows 
exporting G-code with no extrusions on the first layer (with warnings) to accomplish that.