### PR TITLE
AlterCentric infill

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -130,6 +130,7 @@ static const t_config_enum_values s_keys_map_InfillPattern {
     { "cubic",              ipCubic },
     { "line",               ipLine },
     { "concentric",         ipConcentric },
+    { "altercentric",       ipAlterCentric },
     { "honeycomb",          ipHoneycomb },
     { "3dhoneycomb",        ip3DHoneycomb },
     { "gyroid",             ipGyroid },
@@ -881,6 +882,7 @@ void PrintConfigDef::init_fff_params()
     def->aliases = def_top_fill_pattern->aliases;
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipMonotonic));
 
+        { "altercentric",       L("AlterCentric") },
     def = this->add("external_perimeter_extrusion_width", coFloatOrPercent);
     def->label = L("External perimeters");
     def->category = L("Extrusion Width");
@@ -1303,6 +1305,7 @@ void PrintConfigDef::init_fff_params()
         { "cubic",              L("Cubic")},
         { "line",               L("Line")},
         { "concentric",         L("Concentric")},
+        { "altercentric",       L("AlterCentric")},	
         { "honeycomb",          L("Honeycomb")},
         { "3dhoneycomb",        L("3D Honeycomb")},
         { "gyroid",             L("Gyroid")},

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -84,6 +84,7 @@ enum InfillPattern : int {
     ipLightning,
     ipEnsuring,
     ipCount,
+    ipAlterCentric
 };
 
 enum class IroningType {

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -188,7 +188,7 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
     if (config->option<ConfigOptionPercent>("fill_density")->value == 100) {
         const int fill_pattern = config->option<ConfigOptionEnum<InfillPattern>>("fill_pattern")->value;
         if (bool correct_100p_fill = config->option_def("top_fill_pattern")->enum_def->enum_to_index(fill_pattern).has_value(); 
-            ! correct_100p_fill) {
+            ! correct_100p_fill && fill_pattern != ipAlterCentric) {
             // get fill_pattern name from enum_labels for using this one at dialog_msg
             const ConfigOptionDef *fill_pattern_def = config->option_def("fill_pattern");
             assert(fill_pattern_def != nullptr);


### PR DESCRIPTION
AlterCentric infill - interleaving concentric and monotonic rectilinear infill each layer.

Such interleaving could mitigate blobs problem

Concentric:
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/9b798bb3-65d1-49e3-92a1-c81284523bf1)
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/167a55a3-db17-4048-9204-478146193e6f)

Next layer monotonic rectilinear:
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/d9e2e4cb-624e-4d33-a14a-39b4e26cc8a7)
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/04c30b4c-889a-4033-b531-3849e4876390)


Also it may increase radial strength.


