### PR TITLE
Internal perimeters first on overhangs

### DIFF
--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -689,6 +689,7 @@ void Layer::make_perimeters()
     		                && config.opt_serialize("perimeter_extrusion_width") == other_config.opt_serialize("perimeter_extrusion_width")
     		                && config.thin_walls                  == other_config.thin_walls
     		                && config.external_perimeters_first   == other_config.external_perimeters_first
+                            && config.first_internal_on_overhangs == other_config.first_internal_on_overhangs
     		                && config.infill_overlap              == other_config.infill_overlap
                             && config.fuzzy_skin                  == other_config.fuzzy_skin
                             && config.fuzzy_skin_thickness        == other_config.fuzzy_skin_thickness

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -439,7 +439,7 @@ static std::vector<std::string> s_Preset_print_options {
     "layer_height", "first_layer_height", "perimeters", "spiral_vase", "slice_closing_radius", "slicing_mode",
     "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
     "extra_perimeters", "extra_perimeters_on_overhangs", "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",
-    "seam_position","staggered_inner_seams", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
+    "seam_position","staggered_inner_seams", "external_perimeters_first", "first_internal_on_overhangs", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
     "infill_every_layers", /*"infill_only_where_needed",*/ "solid_infill_every_layers", "fill_angle", "bridge_angle",
     "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first",
     "ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -913,6 +913,14 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("first_internal_on_overhangs", coBool);
+    def->label = L("Internal perimeters first on overhangs");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("Print contour perimeters from the innermost to the outermost one for layers with overhengs. "
+                   "It overrides \"External perimeters first\" option.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("extra_perimeters", coBool);
     def->label = L("Extra perimeters if needed");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -624,6 +624,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                fill_angle))
     ((ConfigOptionPercent,              fill_density))
     ((ConfigOptionEnum<InfillPattern>,  fill_pattern))
+    ((ConfigOptionBool,                 first_internal_on_overhangs))
     ((ConfigOptionEnum<FuzzySkinType>,  fuzzy_skin))
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_dist))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -715,6 +715,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "perimeter_extrusion_width"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first"
+            || opt_key == "first_internal_on_overhangs"
             || opt_key == "arc_fitting") {
             steps.emplace_back(posPerimeters);
         } else if (

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -223,6 +223,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
                     "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "enable_dynamic_overhang_speeds"})
         toggle_field(el, have_perimeters);
 
+    toggle_field("first_internal_on_overhangs", have_perimeters && config->opt_bool("external_perimeters_first"));
+
     for (size_t i = 0; i < 4; i++) {
         toggle_field("overhang_speed_" + std::to_string(i), config->opt_bool("enable_dynamic_overhang_speeds"));
     }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1485,6 +1485,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("seam_position", category_path + "seam-position");
         optgroup->append_single_option_line("staggered_inner_seams", category_path + "staggered-inner-seams");
         optgroup->append_single_option_line("external_perimeters_first", category_path + "external-perimeters-first");
+        optgroup->append_single_option_line("first_internal_on_overhangs", category_path + "external-perimeters-first");
         optgroup->append_single_option_line("gap_fill_enabled", category_path + "fill-gaps");
         optgroup->append_single_option_line("perimeter_generator");
 


### PR DESCRIPTION
Now there is option "External perimeters first", that is good for precise dimensions, but bad for overhangs. This PR adds option for automatic perimeters order for layers with overhangs present.

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/8efdd630-650f-4bdc-a521-d4390602b403)

When both option enabled external perimeters are printed first, but not for layers with overhangs:

Without overhangs:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/c2b0e0ac-4afc-40d2-a7ed-d8fa29e323e9) 
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/6d7ca62a-ed31-49cb-acb0-9be791b29789)

With overhangs:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/653ecdc7-bc48-46d0-93b2-f233782eea13)
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/56e3f926-ab59-4eb9-8429-ed750dbbb2ba)


Current limitation: this algorithm is applied for the whole layer, not just for region with overhangs:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/5dae9a17-fbc3-4711-af58-4bb28864b9cf)
