### PR TITLE
When Z is lifted, never move lower until unlift.

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -355,7 +355,7 @@ bool GCodeWriter::will_move_z(double z) const
         we don't perform an actual Z move. */
     if (m_lifted > 0) {
         double nominal_z = m_pos.z() - m_lifted;
-        if (z >= nominal_z && z <= m_pos.z())
+        if (z <= m_pos.z())
             return false;
     }
     return true;


### PR DESCRIPTION
Surely when Z is lifted, it is never correct to move the nozzle down until unlift is called.
Just accumulate the change into m_lifted.