### PR TITLE
Disable ensure on bed

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1102,6 +1102,8 @@ void ModelObject::ensure_on_bed(bool allow_negative_z)
 {
     double z_offset = 0.0;
 
+    return;
+
     if (allow_negative_z) {
         if (parts_count() == 1) {
             const double min_z = this->min_z();

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4054,7 +4054,8 @@ void GLCanvas3D::do_move(const std::string& snapshot_type)
     for (const std::pair<int, int>& i : done) {
         ModelObject* m = m_model->objects[i.first];
         const double shift_z = m->get_instance_min_z(i.second);
-        if (current_printer_technology() == ptSLA || shift_z > SINKING_Z_THRESHOLD) {
+// SMJ        if (current_printer_technology() == ptSLA || shift_z > SINKING_Z_THRESHOLD) {
+        if (current_printer_technology() == ptSLA) {
             const Vec3d shift(0.0, 0.0, -shift_z);
             m_selection.translate(i.first, i.second, shift);
             m->translate_instance(i.second, shift);


### PR DESCRIPTION
Disable 'gravity' for the plater. Objects can still be placed on the bed by clicking the drop to bed button in the position pane.
relevant to issue #1513

