### PR TITLE
Reduce shell thickness and amount of solid infill

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -435,7 +435,7 @@ void Preset::set_visible_from_appconfig(const AppConfig &app_config)
 
 static std::vector<std::string> s_Preset_print_options {
     "layer_height", "first_layer_height", "perimeters", "spiral_vase", "slice_closing_radius", "slicing_mode",
-    "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
+    "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness", "reduce_shell_thickness",
     "extra_perimeters", "extra_perimeters_on_overhangs", "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",
     "seam_position","staggered_inner_seams", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
     "infill_every_layers", /*"infill_only_where_needed",*/ "solid_infill_every_layers", "fill_angle", "bridge_angle",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -515,6 +515,12 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->set_default_value(new ConfigOptionInt(3));
 
+    def = this->add("reduce_shell_thickness", coBool);
+    def->label = L("Reduce shell thickness");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("Reduce shell thickness detection threshold and amount of solid infill.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("bottom_solid_min_thickness", coFloat);
     def->label = L_CONTEXT("Bottom", "Layers");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -649,6 +649,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                perimeter_speed))
     // Total number of perimeters.
     ((ConfigOptionInt,                  perimeters))
+    ((ConfigOptionBool,                 reduce_shell_thickness))	
     ((ConfigOptionFloatOrPercent,       small_perimeter_speed))
     ((ConfigOptionFloat,                solid_infill_below_area))
     ((ConfigOptionInt,                  solid_infill_extruder))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -809,6 +809,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_only_where_needed"
             || opt_key == "infill_every_layers"
             || opt_key == "solid_infill_every_layers"
+            || opt_key == "reduce_shell_thickness"
             || opt_key == "bottom_solid_min_thickness"
             || opt_key == "top_solid_layers"
             || opt_key == "top_solid_min_thickness"
@@ -1476,7 +1477,8 @@ void PrintObject::discover_vertical_shells()
 	                        ++ i) {
                             at_least_one_top_projected = true;
 	                        const DiscoverVerticalShellsCacheEntry &cache = cache_top_botom_regions[i];
-                            combine_holes(cache.holes);
+                            if (!region_config.reduce_shell_thickness.value)
+                                combine_holes(cache.holes);
                             combine_shells(cache.top_surfaces);
 	                    }
                         if (!at_least_one_top_projected && i < int(cache_top_botom_regions.size())) {
@@ -1505,7 +1507,8 @@ void PrintObject::discover_vertical_shells()
 	                        -- i) {
                                 at_least_one_bottom_projected = true;
 	                        const DiscoverVerticalShellsCacheEntry &cache = cache_top_botom_regions[i];
-							combine_holes(cache.holes);
+							if (!region_config.reduce_shell_thickness.value)
+								combine_holes(cache.holes);
                             combine_shells(cache.bottom_surfaces);
 	                    }
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -249,8 +249,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
                     "infill_speed", "bridge_speed" })
         toggle_field(el, have_infill || has_solid_infill);
 
-    toggle_field("top_solid_min_thickness", ! has_spiral_vase && has_top_solid_infill);
-    toggle_field("bottom_solid_min_thickness", ! has_spiral_vase && has_bottom_solid_infill);
+    toggle_field("top_solid_min_thickness", ! has_spiral_vase && has_top_solid_infill && config->opt_bool("reduce_shell_thickness"));
+    toggle_field("bottom_solid_min_thickness", ! has_spiral_vase && has_bottom_solid_infill && config->opt_bool("reduce_shell_thickness"));
 
     // Gap fill is newly allowed in between perimeter lines even for empty infill (see GH #1476).
     toggle_field("gap_fill_speed", have_perimeters);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1464,6 +1464,7 @@ void TabPrint::build()
         line.append_option(optgroup->get_option("top_solid_min_thickness"));
         line.append_option(optgroup->get_option("bottom_solid_min_thickness"));
         optgroup->append_line(line);
+        optgroup->append_single_option_line("reduce_shell_thickness");
 		line = { "", "" };
 	    line.full_width = 1;
 	    line.widget = [this](wxWindow* parent) {


### PR DESCRIPTION
This PR addresses "[one of the most hated feature of PrusaSlicer: too much solid infill and the way it is printed.](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.6.0-alpha5)", see also #11246 (**Unwanted solid infill still impossible to remove, since years ... Again and again ...**) and #10102 (**Provide a way to disable the Vertical Shell thickness completely**).

Though PR doesn't resolve it completely, as I didn't find the way to disable it completely while keeping bottom layers above bridges, it still provides significant improvement in terms of solid infill amount and allows implementation some other features.

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/ae6c9ac6-fd0a-4589-bc83-ab325b6bcd61)

Default:
![280462267-ea0853a2-4777-470b-9372-12872c1c0868](https://github.com/prusa3d/PrusaSlicer/assets/8691781/02e9b7b2-89c1-4a90-9940-b426abd4e5cc)

Reduced:
![280462298-c9f49fb3-1f87-438b-9221-fb2ed61e3b12](https://github.com/prusa3d/PrusaSlicer/assets/8691781/3143cb60-e87f-4653-90bc-d637d569cb3e)

Default:
![280462718-c9029ddb-a20b-47f3-b2b1-e77e08e97b12](https://github.com/prusa3d/PrusaSlicer/assets/8691781/0fbdf255-e01e-47bb-a962-5081a61a8626)

Reduced:
![280462812-52fcf437-f262-42b3-979a-ca1234f8c171](https://github.com/prusa3d/PrusaSlicer/assets/8691781/22728a98-30d2-49c8-8a24-c73b56b5558a)

