### PR TITLE
Adjust `gcode_flavor` for Ender-3 S1 family

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -1861,7 +1861,7 @@ inherits = *ENDER3V2NEO*; *0.6nozzle*
 
 
 [printer:*ENDER3S1*]
-inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*
+inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*; *32bitmainboard*
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 270
 printer_model = ENDER3S1
@@ -1883,7 +1883,7 @@ inherits = *ENDER3S1*; *0.6nozzle*
 
 
 [printer:*ENDER3S1PRO*]
-inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*
+inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*; *32bitmainboard*
 bed_shape = 5x0,215x0,215x220,5x220
 max_print_height = 270
 printer_model = ENDER3S1PRO
@@ -1905,7 +1905,7 @@ inherits = *ENDER3S1PRO*; *0.6nozzle*
 
 
 [printer:*ENDER3S1PLUS*]
-inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*
+inherits = *common*; *storedabl*; *spriteextruder*; *pauseprint*; *32bitmainboard*
 bed_shape = 5x5,295x5,295x295,5x295
 max_print_height = 300
 printer_model = ENDER3S1PLUS


### PR DESCRIPTION
This PR adjusts the default `gcode_flavor` from `marlin` to `marlin2`  for the Ender-3 S1 family by adding `32bitmainboard` to the printer definitions.