### PR TITLE
Bugfix: Prevent overhang fan speeds from spilling into infill

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -560,16 +560,18 @@ std::vector<PerExtruderAdjustments> CoolingBuffer::parse_layer_gcode(const std::
             } else
                 line.time = 0;
             line.time_max = line.time;
-        } else if (boost::contains(sline, ";_SET_FAN_SPEED")) {
+        }
+
+        if (boost::contains(sline, ";_SET_FAN_SPEED")) {
             auto speed_start = sline.find_last_of('D');
             int  speed       = 0;
             for (char num : sline.substr(speed_start + 1)) {
                 speed = speed * 10 + (num - '0');
             }
-            line.type = CoolingLine::TYPE_SET_FAN_SPEED;
+            line.type |= CoolingLine::TYPE_SET_FAN_SPEED;
             line.fan_speed = speed;
         } else if (boost::contains(sline, ";_RESET_FAN_SPEED")) {
-            line.type = CoolingLine::TYPE_RESET_FAN_SPEED;
+            line.type |= CoolingLine::TYPE_RESET_FAN_SPEED;
         }
 
         if (line.type != 0)


### PR DESCRIPTION
This is a small fix for #11648. There are a few different ways to fix it, but this seemed most correct in my limited testing.