### PR TITLE
Provide very minimum accessibility of PrusaSlicer

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SLIC3R_GUI_SOURCES
     GUI/ConfigSnapshotDialog.hpp
     GUI/3DScene.cpp
     GUI/3DScene.hpp
+    GUI/Accessibility.cpp
     GUI/format.hpp
     GUI/GLShadersManager.hpp
     GUI/GLShadersManager.cpp

--- a/src/slic3r/GUI/Accessibility.cpp
+++ b/src/slic3r/GUI/Accessibility.cpp
@@ -1,0 +1,27 @@
+///|/ Copyright (c) Prusa Research 2023 Dawid Pieper @dawidpieper
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+
+#include <wx/string.h>
+
+#include "Accessibility.hpp"
+
+namespace Slic3r { namespace GUI {
+
+		wxString Accessibility::GetLastLabelString() {return Accessibility::sLastLabel;}
+
+		void Accessibility::SetNextLabelString(wxString labelString) {
+			Accessibility::sLastLabel = labelString.Clone();
+			Accessibility::bLabelAvailable = true;
+		}
+
+		void Accessibility::ClearLabelString() {
+			Accessibility::sLastLabel = "";
+			Accessibility::bLabelAvailable = false;
+		}
+
+		bool Accessibility::IsLabelAvailable() {return Accessibility::bLabelAvailable;}
+
+	} // GUI
+} // Slic3r

--- a/src/slic3r/GUI/Accessibility.hpp
+++ b/src/slic3r/GUI/Accessibility.hpp
@@ -1,0 +1,29 @@
+///|/ Copyright (c) Prusa Research 2023 Dawid Pieper @dawidpieper
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef SLIC3R_GUI_ACCESSIBILITY_HPP
+#define SLIC3R_GUI_ACCESSIBILITY_HPP
+
+#include <wx/string.h>
+
+namespace Slic3r { namespace GUI {
+
+	class Accessibility {
+		
+		public:
+		static wxString GetLastLabelString();
+		static void SetNextLabelString(wxString labelString);
+		static void ClearLabelString();
+		static bool IsLabelAvailable();
+		
+		private:
+		inline static wxString sLastLabel = "";
+		inline static bool bLabelAvailable = false;
+		
+	};
+
+	} // GUI
+} // Slic3r
+
+#endif /* SLIC3R_GUI_ACCESSIBILITY_HPP */

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -18,6 +18,7 @@
 #include "OG_CustomCtrl.hpp"
 #include "MsgDialog.hpp"
 #include "format.hpp"
+#include "Accessibility.hpp"
 
 #include <utility>
 #include <wx/bookctrl.h>
@@ -124,6 +125,8 @@ const t_field& OptionsGroup::build_field(const t_config_option_key& id, const Co
 		if (!m_disabled)
 			this->back_to_sys_value(opt_id);
 	};
+
+	Accessibility::ClearLabelString();
 
 	// assign function objects for callbacks, etc.
     return field;
@@ -256,6 +259,7 @@ void OptionsGroup::append_separator()
 
 void OptionsGroup::activate_line(Line& line)
 {
+    if(!line.label.IsEmpty()) Accessibility::SetNextLabelString(line.label);
     if (line.is_separator())
         return;
 

--- a/src/slic3r/GUI/Widgets/BitmapToggleButton.cpp
+++ b/src/slic3r/GUI/Widgets/BitmapToggleButton.cpp
@@ -5,7 +5,7 @@
 BitmapToggleButton::BitmapToggleButton(wxWindow* parent, const wxString& label, wxWindowID id)
 {
     if (label.IsEmpty())
-        wxBitmapToggleButton::Create(parent, id, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE | wxBU_EXACTFIT);
+        wxBitmapToggleButton::Create(parent, id, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE | wxBU_EXACTFIT | wxBU_NOTEXT);
     else {
 #ifdef __linux__
         wxSize label_size = parent->GetTextExtent(label);
@@ -14,7 +14,7 @@ BitmapToggleButton::BitmapToggleButton(wxWindow* parent, const wxString& label, 
         wxSize def_size = wxDefaultSize;
 #endif
         // Call Create() from wxToggleButton instead of wxBitmapToggleButton to allow add Label text under Linux
-        wxToggleButton::Create(parent, id, label, wxDefaultPosition, def_size, wxBORDER_NONE | wxBU_EXACTFIT);
+        wxToggleButton::Create(parent, id, label, wxDefaultPosition, def_size, wxBORDER_NONE | wxBU_EXACTFIT | wxBU_NOTEXT);
     }
 
 #ifdef __WXMSW__

--- a/src/slic3r/GUI/Widgets/CheckBox.cpp
+++ b/src/slic3r/GUI/Widgets/CheckBox.cpp
@@ -1,4 +1,5 @@
 #include "CheckBox.hpp"
+#include "slic3r/GUI/Accessibility.hpp"
 
 //#include "../wxExtensions.hpp"
 
@@ -13,6 +14,11 @@ CheckBox::CheckBox(wxWindow* parent, const wxString& name)
     , m_on_focused(this, "check_on_focused", px_cnt)
     , m_off_focused(this, "check_off_focused", px_cnt)
 {
+    if(Slic3r::GUI::Accessibility::IsLabelAvailable())
+     m_accessibility_label = Slic3r::GUI::Accessibility::GetLastLabelString();
+    else
+     m_accessibility_label = "";
+
 #ifdef __WXOSX__ // State not fully implement on MacOS
     Bind(wxEVT_SET_FOCUS, &CheckBox::updateBitmap, this);
     Bind(wxEVT_KILL_FOCUS, &CheckBox::updateBitmap, this);
@@ -55,6 +61,8 @@ void CheckBox::update()
 #endif
 
     update_size();
+
+    this->SetLabel(m_accessibility_label+((val)?(" X"):("")));
 }
 
 #ifdef __WXMSW__

--- a/src/slic3r/GUI/Widgets/CheckBox.hpp
+++ b/src/slic3r/GUI/Widgets/CheckBox.hpp
@@ -40,6 +40,8 @@ private:
     ScalableBitmap  m_off_disabled;
     ScalableBitmap  m_on_focused;
     ScalableBitmap  m_off_focused;
+
+    wxString m_accessibility_label;
 };
 
 #endif // !slic3r_GUI_CheckBox_hpp_

--- a/src/slic3r/GUI/Widgets/SpinInput.cpp
+++ b/src/slic3r/GUI/Widgets/SpinInput.cpp
@@ -4,6 +4,7 @@
 #include "UIColors.hpp"
 
 #include "../GUI_App.hpp"
+#include "../Accessibility.hpp"
 
 #include <wx/dcgraph.h>
 #include <wx/panel.h>
@@ -286,6 +287,10 @@ void SpinInput::Create(wxWindow *parent,
     state_handler.attach({&label_color, &text_color});
     state_handler.update_binds();
 
+    if(Slic3r::GUI::Accessibility::IsLabelAvailable())
+        wxStaticText *virtualLabel = new wxStaticText(
+            this, wxID_ANY, Slic3r::GUI::Accessibility::GetLastLabelString(), wxDefaultPosition, wxSize(0, 0), wxST_NO_AUTORESIZE
+        );
     text_ctrl = new wxTextCtrl(this, wxID_ANY, text, {20, 4}, wxDefaultSize, style | wxBORDER_NONE | wxTE_PROCESS_ENTER, wxTextValidator(wxFILTER_NUMERIC));
 #ifdef __WXOSX__
     text_ctrl->OSXDisableAllSmartSubstitutions();

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -5,6 +5,7 @@
 #include <wx/panel.h>
 
 #include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/Accessibility.hpp"
 
 BEGIN_EVENT_TABLE(TextInput, wxPanel)
 
@@ -55,6 +56,11 @@ void TextInput::Create(wxWindow *     parent,
 
     state_handler.attach({&label_color, &text_color});
     state_handler.update_binds();
+
+    if(Slic3r::GUI::Accessibility::IsLabelAvailable())
+        wxStaticText *virtualLabel = new wxStaticText(
+            this, wxID_ANY, Slic3r::GUI::Accessibility::GetLastLabelString(), wxDefaultPosition, wxSize(0, 0), wxST_NO_AUTORESIZE
+        );
 
     text_ctrl = new wxTextCtrl(this, wxID_ANY, text, {4, 4}, size, style | wxBORDER_NONE);
 #ifdef __WXOSX__


### PR DESCRIPTION
# Partialy fixes #7595

This Pull Request is a starting point for making PrusaSlicer minimally accessible to blind people using screen readers.
There is no denying that it is actually a workaround. The idea in which the GUI was created is very far from the WX accessibility guidelines, and therefore the only options are to create a number of workarounds or rewrite a significant part of the code, which, as I was given to understand, is not being considered.

## What does work
* MINIMUM accessibility is ensured, that is, most labels are read correctly. Checked on Windows, I will try to test it on Linux and Mac in the near future as well.
* A workaround was required for checkboxes, as ```wxBitmapToggleButton`` does not support proper accessibility events, I would be greatly obliged to consider replacing its implementation with ```wxCheckbox``.
* The screen reader correctly reads all checkboxes, buttons and data input fields on the print, filament and printer settings tabs.

## What does not work
* In the case of choices, their headers are not read, I will look into this next.
* The tab key navigation of the controls in the bed preview still does not work properly.
* The data in the tables are not being read.
* There is no access to the toolbar.
* Some less important buttons are not labeled.

## Status
In my opinion, PrusaSlicer after implementing this PR has minimal accessibility, it can be used, albeit with limitations, by blind people using screen readers.

I would ask you to let me know if this PR has a chance of being merged, if so, I am willing to continue the work.