### PR TITLE
Warning suppressions.

### DIFF
--- a/src/slic3r/GUI/I18N.hpp
+++ b/src/slic3r/GUI/I18N.hpp
@@ -4,6 +4,7 @@
 ///|/
 #ifndef _
 #define _(s)    	Slic3r::GUI::I18N::translate((s))
+#undef	_L			// Warning suppression
 #define _L(s)    	Slic3r::GUI::I18N::translate((s))
 #define _u8L(s)     Slic3r::GUI::I18N::translate_utf8((s))
 #endif /* _ */

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4994,9 +4994,9 @@ void Plater::priv::show_action_buttons(const bool ready_to_slice_) const
     if (get_config_bool("background_processing"))
     {
 	    RemovableDriveManager::RemovableDrivesStatus removable_media_status = wxGetApp().removable_drive_manager()->status();
-		if (sidebar->show_reslice(false) |
-			sidebar->show_export(true) |
-			sidebar->show_send(send_gcode_shown) |
+		if (sidebar->show_reslice(false) ||
+			sidebar->show_export(true) ||
+			sidebar->show_send(send_gcode_shown) ||
 			sidebar->show_export_removable(removable_media_status.has_removable_drives))
 //			sidebar->show_eject(removable_media_status.has_eject))
             sidebar->Layout();
@@ -5006,9 +5006,9 @@ void Plater::priv::show_action_buttons(const bool ready_to_slice_) const
 	    RemovableDriveManager::RemovableDrivesStatus removable_media_status;
 	    if (! ready_to_slice) 
 	    	removable_media_status = wxGetApp().removable_drive_manager()->status();
-        if (sidebar->show_reslice(ready_to_slice) |
-            sidebar->show_export(!ready_to_slice) |
-            sidebar->show_send(send_gcode_shown && !ready_to_slice) |
+        if (sidebar->show_reslice(ready_to_slice) ||
+            sidebar->show_export(!ready_to_slice) ||
+            sidebar->show_send(send_gcode_shown && !ready_to_slice) ||
 			sidebar->show_export_removable(!ready_to_slice && removable_media_status.has_removable_drives))
 //            sidebar->show_eject(!ready_to_slice && removable_media_status.has_eject))
             sidebar->Layout();


### PR DESCRIPTION
Two warning suppressions.

Some systems' ctype.h leaks _L (for lower) which conflicts with the _L
macro defined in src/slic3r/GUI/I18N.hpp.

In Plater.cpp, several compound "if" statements generate warnings because the code used essentially "if (inta() | intb() | intc())" instead of
"if (inta()|| intb() || intc())". While both are correct, the former
loses the benefit of short-circuit evaluation since all the functions
must be called to evaluate the final orred-together int; at any rate
the performance benefit is less important than the readability and
the suppression of warnings at compile time.
