### PR TITLE
TBB compilation error for versions lower than 2021

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1529,13 +1529,21 @@ void GCodeGenerator::process_layers(
         [&output_stream](std::string s) { output_stream.write(s); }
     );
 
+#if TBB_VERSION_MAJOR >= 2021
     tbb::filter<void, LayerResult> pipeline_to_layerresult = smooth_path_interpolator & generator;
+#else
+    tbb::filter_t<void, LayerResult> pipeline_to_layerresult = smooth_path_interpolator & generator;
+#endif
     if (m_spiral_vase)
         pipeline_to_layerresult = pipeline_to_layerresult & spiral_vase;
     if (m_pressure_equalizer)
         pipeline_to_layerresult = pipeline_to_layerresult & pressure_equalizer;
 
+#if TBB_VERSION_MAJOR >= 2021
     tbb::filter<LayerResult, std::string> pipeline_to_string = cooling;
+#else
+    tbb::filter_t<LayerResult, std::string> pipeline_to_string = cooling;
+#endif
     if (m_find_replace)
         pipeline_to_string = pipeline_to_string & find_replace;
 
@@ -1621,13 +1629,21 @@ void GCodeGenerator::process_layers(
         [&output_stream](std::string s) { output_stream.write(s); }
     );
 
+#if TBB_VERSION_MAJOR >= 2021
     tbb::filter<void, LayerResult> pipeline_to_layerresult = smooth_path_interpolator & generator;
+#else
+    tbb::filter_t<void, LayerResult> pipeline_to_layerresult = smooth_path_interpolator & generator;
+#endif
     if (m_spiral_vase)
         pipeline_to_layerresult = pipeline_to_layerresult & spiral_vase;
     if (m_pressure_equalizer)
         pipeline_to_layerresult = pipeline_to_layerresult & pressure_equalizer;
 
+#if TBB_VERSION_MAJOR >= 2021
     tbb::filter<LayerResult, std::string> pipeline_to_string = cooling;
+#else
+    tbb::filter_t<LayerResult, std::string> pipeline_to_string = cooling;
+#endif
     if (m_find_replace)
         pipeline_to_string = pipeline_to_string & find_replace;
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -53,9 +53,15 @@
 #include <functional>
 #include <limits>
 #include <map>
+#if TBB_VERSION_MAJOR >= 2021
 #include <oneapi/tbb/blocked_range.h>
 #include <oneapi/tbb/concurrent_vector.h>
 #include <oneapi/tbb/parallel_for.h>
+#else
+#include <tbb/blocked_range.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/parallel_for.h>
+#endif
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/src/libslic3r/Support/SupportLayer.hpp
+++ b/src/libslic3r/Support/SupportLayer.hpp
@@ -5,8 +5,13 @@
 #ifndef slic3r_SupportLayer_hpp_
 #define slic3r_SupportLayer_hpp_
 
+#if TBB_VERSION_MAJOR >= 2021
 #include <oneapi/tbb/scalable_allocator.h>
 #include <oneapi/tbb/spin_mutex.h>
+#else
+#include <tbb/scalable_allocator.h>
+#include <tbb/spin_mutex.h>
+#endif
 // for Slic3r::deque
 #include "../libslic3r.h"
 #include "../ClipperUtils.hpp"

--- a/src/libslic3r/SupportSpotsGenerator.cpp
+++ b/src/libslic3r/SupportSpotsGenerator.cpp
@@ -32,8 +32,13 @@
 #include <functional>
 #include <limits>
 #include <math.h>
+#if TBB_VERSION_MAJOR >= 2021
 #include <oneapi/tbb/concurrent_vector.h>
 #include <oneapi/tbb/parallel_for.h>
+#else
+#include <tbb/concurrent_vector.h>
+#include <tbb/parallel_for.h>
+#endif
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
I tried compiling PrusaSlicer with TBB version 2020.3 and found out I couldn't without some fixes. Since I saw some PrusaSlicer code already trying to support older versions I thought a fix might be welcome.