### PR TITLE
Make initializers explicit to avoid ambiguous wxArrayString overloads

### DIFF
--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -467,7 +467,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     // Always fill in the "printhost_port" combo box from the config and select it.
     {
         Choice* choice = dynamic_cast<Choice*>(m_optgroup->get_field("printhost_port"));
-        choice->set_values({ m_config->opt_string("printhost_port") });
+        choice->set_values(std::vector<std::string>({ m_config->opt_string("printhost_port") }));
         choice->set_selection();
     }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5390,7 +5390,7 @@ void Plater::load_project(const wxString& filename)
 
     p->reset();
 
-    if (! load_files({ into_path(filename) }).empty()) {
+    if (! load_files(std::vector<boost::filesystem::path>({ into_path(filename) })).empty()) {
         // At least one file was loaded.
         p->set_project_filename(filename);
         // Save the names of active presets and project specific config into ProjectDirtyStateManager.


### PR DESCRIPTION
This PR makes some overloaded constructor calls more explicit, to avoid ambiguous overload errors with wxWidgets 3.2.4.

Fixes: #11768 
See there for details.