### PR TITLE
Improve ExtrusionLine::simplify, eliminating many very-short extrusion segments which led to blemishes in thin-wall models sliced with arachne

### DIFF
--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -44,14 +44,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     if (junctions.size() <= min_path_size)
         return;
 
-    printf("BEFORE ExtrusionLine::simplify on %zu points:\n", junctions.size());
-    for (size_t point_idx = 0; point_idx < junctions.size(); point_idx++) {
-        const ExtrusionJunction &cur = junctions[point_idx];
-        const ExtrusionJunction &prev = point_idx ? junctions[point_idx - 1] : cur;
-        printf("  %zu: %.3f, %.3f, w %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
-               unscaled(cur.w), unscaled(cur - prev).norm());
-    }
-
     /* ExtrusionLines are treated as (open) polylines, so in case an ExtrusionLine is actually a closed polygon, its
      * starting and ending points will be equal (or almost equal). Therefore, the simplification of the ExtrusionLine
      * should not touch the first and last points. As a result, start simplifying from point at index 1.
@@ -104,7 +96,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
         if (length2 < scaled<coord_t>(0.025))
         {
             // We're allowed to always delete segments of less than 5 micron. The width in this case doesn't matter that much.
-            printf("  Too short: %zu len %.3f\n", point_idx, unscaled(sqrt(length2)));
             continue;
         }
 
@@ -113,7 +104,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
 
         if (base_length_2 == 0) // Two line segments form a line back and forth with no area.
         {
-            printf("  Base length zero: %zu, len %.3f\n", point_idx, unscaled(sqrt(length2)));
             continue; // Remove the junction (vertex).
         }
         //We want to check if the height of the triangle formed by previous, current and next vertices is less than allowed_error_distance_squared.
@@ -130,8 +120,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
             // We shouldn't remove middle junctions of colinear segments if the area changed for the C-P segment is exceeding the maximum allowed
              && extrusion_area_error <= maximum_extrusion_area_deviation)
         {
-            printf("  Colinear: %zu, height %.3f, area error %.3f < %.3f\n", point_idx, unscaled(sqrt(height_2)),
-                   unscaled(sqrt(extrusion_area_error)), unscaled(sqrt(maximum_extrusion_area_deviation)));
             // Remove the current junction (vertex).
             continue;
         }
@@ -146,26 +134,19 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
                 // We should instead move this point to a location where both edges are kept and then remove the previous point that we wanted to keep.
                 // By taking the intersection of these two lines, we get a point that preserves the direction (so it makes the corner a bit more pointy).
                 // We just need to be sure that the intersection point does not introduce an artifact itself.
-                //      o  prev_prev
-                //      |
-                //      o  prev
-                //       \  cur
-                // inte + o------------o next
-                //
+                //                o < prev_prev
+                //                |
+                //                o < prev
+                //                  \  < short segment
+                // intersection > +   o-------------------o < next
+                //                    ^ current
                 Point intersection_point;
                 bool has_intersection = Line(previous_previous.p, previous.p).intersection_infinite(Line(current.p, next.p), &intersection_point);
                 if (!has_intersection
                     || Line::distance_to_infinite_squared(intersection_point, previous.p, current.p) > double(allowed_error_distance_squared)
                     || (intersection_point - previous.p).cast<int64_t>().squaredNorm() > smallest_line_segment_squared  // The intersection point is way too far from the 'previous'
-                    || (intersection_point - current.p).cast<int64_t>().squaredNorm() > smallest_line_segment_squared)     // and 'current' points, so it shouldn't replace 'current'
+                    || (intersection_point - current.p).cast<int64_t>().squaredNorm() > smallest_line_segment_squared)  // and 'current' points, so it shouldn't replace 'current'
                 {
-                    printf("  NO BETTER SPOT: %zu, length %.3f < %.3f, height %.3f < %.3f, intersect %d %.3f, %.3f, len %.3f, %.3f, %.3f\n", point_idx,
-                           unscaled(sqrt(length2)), unscaled(sqrt(smallest_line_segment_squared)),
-                           unscaled(sqrt(height_2)), unscaled(sqrt(allowed_error_distance_squared)),
-                           has_intersection, unscaled(intersection_point.x()), unscaled(intersection_point.y()),
-                           unscaled((intersection_point - previous.p).cast<int64_t>().norm()),
-                           unscaled((intersection_point - current.p).cast<int64_t>().norm()),
-                           unscaled((intersection_point - next.p).cast<int64_t>().norm()));
                     // We can't find a better spot for it, but the size of the line is more than 5 micron.
                     // So the only thing we can do here is leave it in...
                 }
@@ -184,16 +165,12 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
                     accumulated_area_removed = removed_area_next; // So that in the next iteration it's the area between the origin, [previous] and [current]
                     previous_previous = previous;
                     previous = new_to_add; // Note that "previous" is only updated if we don't remove the junction (vertex).
-                    printf("  Replaced %zu with: %zu, at %.3f, %.3f\n", new_junctions.size(), point_idx,
-                           unscaled(intersection_point.x()), unscaled(intersection_point.y()));
                     new_junctions.push_back(new_to_add);
                     continue;
                 }
             }
             else
             {
-                printf("  Next segment small: %zu, next %.3f < %.3f\n", point_idx,
-                       unscaled(sqrt(next_length2)), unscaled(sqrt(4 * smallest_line_segment_squared)));
                 continue; // Remove the junction (vertex).
             }
         }
@@ -201,7 +178,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
         accumulated_area_removed = removed_area_next; // So that in the next iteration it's the area between the origin, [previous] and [current]
         previous_previous = previous;
         previous = current; // Note that "previous" is only updated if we don't remove the junction (vertex).
-        printf("  %zu => %zu\n", point_idx, new_junctions.size());
         new_junctions.push_back(current);
     }
 
@@ -216,14 +192,6 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     }
 
     junctions = new_junctions;
-
-    printf("AFTER ExtrusionLine::simplify on %zu points:\n", junctions.size());
-    for (size_t point_idx = 0; point_idx < junctions.size(); point_idx++) {
-        const ExtrusionJunction &cur = junctions[point_idx];
-        const ExtrusionJunction &prev = point_idx ? junctions[point_idx - 1] : cur;
-        printf("  %zu: %.3f, %.3f, w %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
-               unscaled(cur.w), unscaled(cur - prev).norm());
-    }
 }
 
 int64_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A, ExtrusionJunction B, ExtrusionJunction C) {

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -48,12 +48,10 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     for (size_t point_idx = 0; point_idx < junctions.size(); point_idx++) {
         const ExtrusionJunction &cur = junctions[point_idx];
         const ExtrusionJunction &prev = point_idx ? junctions[point_idx - 1] : cur;
-        printf("  %zu: %.3f, %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
-               unscaled(cur - prev).norm());
+        printf("  %zu: %.3f, %.3f, w %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
+               unscaled(cur.w), unscaled(cur - prev).norm());
     }
-    
-    // TODO: Weighted average of widths.
-    
+
     /* ExtrusionLines are treated as (open) polylines, so in case an ExtrusionLine is actually a closed polygon, its
      * starting and ending points will be equal (or almost equal). Therefore, the simplification of the ExtrusionLine
      * should not touch the first and last points. As a result, start simplifying from point at index 1.
@@ -62,12 +60,11 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     // Starting junction should always exist in the simplified path
     new_junctions.emplace_back(junctions.front());
 
-    /* XXX Initially, previous_previous is always the same as previous because, for open ExtrusionLines the last junction
-     * cannot be taken into consideration when checking the points at index 1. For closed ExtrusionLines, the first and
-     * last junctions are anyway the same.
+    ExtrusionJunction previous = junctions.front();
+    /* For open ExtrusionLines the last junction cannot be taken into consideration when checking the points at index 1.
+     * For closed ExtrusionLines, the first and last junctions are the same, so use the prior to last juction.
      * */
     ExtrusionJunction previous_previous = this->is_closed ? junctions[junctions.size() - 2] : junctions.front();
-    ExtrusionJunction previous = junctions.front();
 
     /* When removing a vertex, we check the height of the triangle of the area
      being removed from the original polygon by the simplification. However,
@@ -219,15 +216,14 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     }
 
     junctions = new_junctions;
-    
+
     printf("AFTER ExtrusionLine::simplify on %zu points:\n", junctions.size());
     for (size_t point_idx = 0; point_idx < junctions.size(); point_idx++) {
         const ExtrusionJunction &cur = junctions[point_idx];
         const ExtrusionJunction &prev = point_idx ? junctions[point_idx - 1] : cur;
-        printf("  %zu: %.3f, %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
-               unscaled(cur - prev).norm());
+        printf("  %zu: %.3f, %.3f, w %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
+               unscaled(cur.w), unscaled(cur - prev).norm());
     }
-    return;
 }
 
 int64_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A, ExtrusionJunction B, ExtrusionJunction C) {

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -51,9 +51,9 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
         printf("  %zu: %.3f, %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
                unscaled(cur - prev).norm());
     }
-
+    
     // TODO: Weighted average of widths.
-
+    
     /* ExtrusionLines are treated as (open) polylines, so in case an ExtrusionLine is actually a closed polygon, its
      * starting and ending points will be equal (or almost equal). Therefore, the simplification of the ExtrusionLine
      * should not touch the first and last points. As a result, start simplifying from point at index 1.
@@ -219,7 +219,7 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
     }
 
     junctions = new_junctions;
-
+    
     printf("AFTER ExtrusionLine::simplify on %zu points:\n", junctions.size());
     for (size_t point_idx = 0; point_idx < junctions.size(); point_idx++) {
         const ExtrusionJunction &cur = junctions[point_idx];
@@ -227,6 +227,7 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
         printf("  %zu: %.3f, %.3f, len %.3f\n", point_idx, unscaled(cur.p[0]), unscaled(cur.p[1]),
                unscaled(cur - prev).norm());
     }
+    return;
 }
 
 int64_t ExtrusionLine::calculateExtrusionAreaDeviationError(ExtrusionJunction A, ExtrusionJunction B, ExtrusionJunction C) {

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -58,6 +58,11 @@ void ExtrusionLine::simplify(const int64_t smallest_line_segment_squared, const 
      * */
     ExtrusionJunction previous_previous = this->is_closed ? junctions[junctions.size() - 2] : junctions.front();
 
+    /* TODO: When deleting, combining, or modifying junctions, it would
+     * probably be good to set the new junction's width to a weighted average
+     * of the junctions it is derived from.
+     */
+
     /* When removing a vertex, we check the height of the triangle of the area
      being removed from the original polygon by the simplification. However,
      when consecutively removing multiple vertices the height of the previously

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -276,7 +276,6 @@ void PrintObject::make_perimeters()
     );
 #else
     for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
-        printf("!!! LAYER %zu !!!\n", layer_idx);
         m_print->throw_if_canceled();
         m_layers[layer_idx]->make_perimeters();
     }

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -263,6 +263,7 @@ void PrintObject::make_perimeters()
     }
 
     BOOST_LOG_TRIVIAL(debug) << "Generating perimeters in parallel - start";
+#if 0
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, m_layers.size()),
         [this](const tbb::blocked_range<size_t>& range) {
@@ -273,6 +274,13 @@ void PrintObject::make_perimeters()
             }
         }
     );
+#else
+    for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
+        printf("!!! LAYER %zu !!!\n", layer_idx);
+        m_print->throw_if_canceled();
+        m_layers[layer_idx]->make_perimeters();
+    }
+#endif
     m_print->throw_if_canceled();
     BOOST_LOG_TRIVIAL(debug) << "Generating perimeters in parallel - end";
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -263,7 +263,6 @@ void PrintObject::make_perimeters()
     }
 
     BOOST_LOG_TRIVIAL(debug) << "Generating perimeters in parallel - start";
-#if 0
     tbb::parallel_for(
         tbb::blocked_range<size_t>(0, m_layers.size()),
         [this](const tbb::blocked_range<size_t>& range) {
@@ -274,12 +273,6 @@ void PrintObject::make_perimeters()
             }
         }
     );
-#else
-    for (size_t layer_idx = 0; layer_idx < m_layers.size(); ++ layer_idx) {
-        m_print->throw_if_canceled();
-        m_layers[layer_idx]->make_perimeters();
-    }
-#endif
     m_print->throw_if_canceled();
     BOOST_LOG_TRIVIAL(debug) << "Generating perimeters in parallel - end";
 


### PR DESCRIPTION
This change makes ExtrusionLine::simplify() able to remove more very-short segments, which arachne seems to tend to produce frequently on thin-walled models with curvature. Interestingly, Cura does not seem to have this problem. From what I can see, when Arachne was ported over from Cura, a significant amount of logic was added to polyline simplification, but some of that logic was flawed. In particular, the simplification code in Cura seems to be in [PolygonRef::simplify()](https://github.com/Ultimaker/libArachne/blob/5f80a8c9558bedb60d18711facab282546da70fc/src/utils/polygon.cpp#L320), but during porting logic was added to avoid removing a point prior to a long segment and instead replace the two prior points with the intersection of the prior and next segments, but only if that intersection does not move the points too much. Unfortunately that test compared the intersection to the point at the other end of the long segment, thus the length test would always fail and the point would never be removed.

I made the following changes:

- When considering replacing two points with the intersection of the adjoining segments, test the distance between the intersection and the two points prev and current, rather than prev and next. This change removes most extrusion blemishes around the perimeter.
- For a closed polygon, allow removing the first/last point (which are the same). This can remove a single extrusion blemish per perimeter. In order to do so, we consider removing the last point, and pull the next and next_next points from the second and third points of the newly-filtered path.

While working with this code I noticed a few potential issues/future improvements:

- As points are removed or replaced, their width is not updated. In most cases this probably results in negligible errors. However, I could imagine that if a point is removed between two nearly-collinear long segments and the segments have different widths, significant error could be introduced. Consider either not merging segments with negligible width differences, and/or updating widths with a length-weighted average when merging segments.
- Why is arachne generating so many nearly-zero-length segments in the first place? Consider changing it to no longer do so. Given that the nearly-zero-length segments seem to have a slightly different width than neighboring segments, I suspect that whatever heuristics arachne uses to determine width are generating these.
- The logic is pretty complex and challenging to reason about. Perhaps going back to simpler simplification logic such as Cura uses would produce more consistent results.

I believe this fixes #11807. Here's a photo of the model from that issue with this change:
![PXL_20231201_052558340](https://github.com/prusa3d/PrusaSlicer/assets/673922/a6fcaafb-60b4-4464-a70a-284944920cfc)

I think it probably also fixes #11573. I'll do a test in a moment.