### PR TITLE
feat: initial development of Paint on Brim

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -1234,6 +1234,7 @@ void ModelObject::convert_units(ModelObjectPtrs& new_objects, ConversionType con
 
             vol->supported_facets.assign(volume->supported_facets);
             vol->seam_facets.assign(volume->seam_facets);
+            vol->brim_facets.assign(volume->brim_facets);
             vol->mmu_segmentation_facets.assign(volume->mmu_segmentation_facets);
 
             // Perform conversion only if the target "imperial" state is different from the current one.
@@ -1346,6 +1347,7 @@ void ModelVolume::reset_extra_facets()
 {
     this->supported_facets.reset();
     this->seam_facets.reset();
+    this->brim_facets.reset();
     this->mmu_segmentation_facets.reset();
 }
 
@@ -1912,6 +1914,7 @@ void ModelVolume::assign_new_unique_ids_recursive()
     config.set_new_unique_id();
     supported_facets.set_new_unique_id();
     seam_facets.set_new_unique_id();
+    brim_facets.set_new_unique_id();
     mmu_segmentation_facets.set_new_unique_id();
 }
 
@@ -2215,6 +2218,13 @@ bool model_custom_seam_data_changed(const ModelObject& mo, const ModelObject& mo
     return model_property_changed(mo, mo_new, 
         [](const ModelVolumeType t) { return t == ModelVolumeType::MODEL_PART; }, 
         [](const ModelVolume &mv_old, const ModelVolume &mv_new){ return mv_old.seam_facets.timestamp_matches(mv_new.seam_facets); });
+}
+
+bool model_custom_brim_data_changed(const ModelObject& mo, const ModelObject& mo_new)
+{
+    return model_property_changed(mo, mo_new, 
+        [](const ModelVolumeType t) { return t == ModelVolumeType::MODEL_PART; }, 
+        [](const ModelVolume &mv_old, const ModelVolume &mv_new){ return mv_old.brim_facets.timestamp_matches(mv_new.brim_facets); });
 }
 
 bool model_mmu_segmentation_data_changed(const ModelObject& mo, const ModelObject& mo_new)

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -823,6 +823,9 @@ public:
     // List of seam enforcers/blockers.
     FacetsAnnotation    seam_facets;
 
+    // List of brim facets painted for brim enforcers/blockers.
+    FacetsAnnotation    brim_facets;
+
     // List of mesh facets painted for MMU segmentation.
     FacetsAnnotation    mmu_segmentation_facets;
 

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -932,11 +932,13 @@ public:
         this->config.set_new_unique_id();
         this->supported_facets.set_new_unique_id();
         this->seam_facets.set_new_unique_id();
+        this->brim_facets.set_new_unique_id();
         this->mmu_segmentation_facets.set_new_unique_id();
     }
 
     bool is_fdm_support_painted() const { return !this->supported_facets.empty(); }
     bool is_seam_painted() const { return !this->seam_facets.empty(); }
+    bool is_brim_painted() const { return !this->brim_facets.empty(); }
     bool is_mm_painted() const { return !this->mmu_segmentation_facets.empty(); }
 
 protected:
@@ -976,10 +978,12 @@ private:
         assert(this->config.id().valid());
         assert(this->supported_facets.id().valid());
         assert(this->seam_facets.id().valid());
+        assert(this->brim_facets.id().valid());
         assert(this->mmu_segmentation_facets.id().valid());
         assert(this->id() != this->config.id());
         assert(this->id() != this->supported_facets.id());
         assert(this->id() != this->seam_facets.id());
+        assert(this->id() != this->brim_facets.id());
         assert(this->id() != this->mmu_segmentation_facets.id());
         return true;
     }
@@ -1006,22 +1010,25 @@ private:
         ObjectBase(other),
         name(other.name), source(other.source), m_mesh(other.m_mesh), m_convex_hull(other.m_convex_hull),
         config(other.config), m_type(other.m_type), object(object), m_transformation(other.m_transformation),
-        supported_facets(other.supported_facets), seam_facets(other.seam_facets), mmu_segmentation_facets(other.mmu_segmentation_facets),
+        supported_facets(other.supported_facets), seam_facets(other.seam_facets), brim_facets(other.brim_facets), mmu_segmentation_facets(other.mmu_segmentation_facets),
         cut_info(other.cut_info), text_configuration(other.text_configuration), emboss_shape(other.emboss_shape)
     {
 		assert(this->id().valid()); 
         assert(this->config.id().valid()); 
         assert(this->supported_facets.id().valid());
         assert(this->seam_facets.id().valid());
+        assert(this->brim_facets.id().valid());
         assert(this->mmu_segmentation_facets.id().valid());
         assert(this->id() != this->config.id());
         assert(this->id() != this->supported_facets.id());
         assert(this->id() != this->seam_facets.id());
+        assert(this->id() != this->brim_facets.id());
         assert(this->id() != this->mmu_segmentation_facets.id());
 		assert(this->id() == other.id());
         assert(this->config.id() == other.config.id());
         assert(this->supported_facets.id() == other.supported_facets.id());
         assert(this->seam_facets.id() == other.seam_facets.id());
+        assert(this->brim_facets.id() == other.brim_facets.id());
         assert(this->mmu_segmentation_facets.id() == other.mmu_segmentation_facets.id());
         this->set_material_id(other.material_id());
     }
@@ -1034,10 +1041,12 @@ private:
         assert(this->config.id().valid()); 
         assert(this->supported_facets.id().valid());
         assert(this->seam_facets.id().valid());
+        assert(this->brim_facets.id().valid());
         assert(this->mmu_segmentation_facets.id().valid());
         assert(this->id() != this->config.id());
         assert(this->id() != this->supported_facets.id());
         assert(this->id() != this->seam_facets.id());
+        assert(this->id() != this->brim_facets.id());
         assert(this->id() != this->mmu_segmentation_facets.id());
 		assert(this->id() != other.id());
         assert(this->config.id() == other.config.id());
@@ -1049,10 +1058,12 @@ private:
         assert(this->config.id() != other.config.id()); 
         assert(this->supported_facets.id() != other.supported_facets.id());
         assert(this->seam_facets.id() != other.seam_facets.id());
+        assert(this->brim_facets.id() != other.brim_facets.id());
         assert(this->mmu_segmentation_facets.id() != other.mmu_segmentation_facets.id());
         assert(this->id() != this->config.id());
         assert(this->supported_facets.empty());
         assert(this->seam_facets.empty());
+        assert(this->brim_facets.empty());
         assert(this->mmu_segmentation_facets.empty());
     }
 
@@ -1061,11 +1072,12 @@ private:
 	friend class cereal::access;
 	friend class UndoRedo::StackImpl;
 	// Used for deserialization, therefore no IDs are allocated.
-	ModelVolume() : ObjectBase(-1), config(-1), supported_facets(-1), seam_facets(-1), mmu_segmentation_facets(-1), object(nullptr) {
+	ModelVolume() : ObjectBase(-1), config(-1), supported_facets(-1), seam_facets(-1), brim_facets(-1), mmu_segmentation_facets(-1), object(nullptr) {
 		assert(this->id().invalid());
         assert(this->config.id().invalid());
         assert(this->supported_facets.id().invalid());
         assert(this->seam_facets.id().invalid());
+        assert(this->brim_facets.id().invalid());
         assert(this->mmu_segmentation_facets.id().invalid());
 	}
 	template<class Archive> void load(Archive &ar) {
@@ -1073,6 +1085,7 @@ private:
         ar(name, source, m_mesh, m_type, m_material_id, m_transformation, m_is_splittable, has_convex_hull, cut_info);
         cereal::load_by_value(ar, supported_facets);
         cereal::load_by_value(ar, seam_facets);
+        cereal::load_by_value(ar, brim_facets);
         cereal::load_by_value(ar, mmu_segmentation_facets);
         cereal::load_by_value(ar, config);
         cereal::load(ar, text_configuration);
@@ -1091,6 +1104,7 @@ private:
         ar(name, source, m_mesh, m_type, m_material_id, m_transformation, m_is_splittable, has_convex_hull, cut_info);
         cereal::save_by_value(ar, supported_facets);
         cereal::save_by_value(ar, seam_facets);
+        cereal::save_by_value(ar, brim_facets);
         cereal::save_by_value(ar, mmu_segmentation_facets);
         cereal::save_by_value(ar, config);
         cereal::save(ar, text_configuration);
@@ -1387,6 +1401,10 @@ bool model_custom_supports_data_changed(const ModelObject& mo, const ModelObject
 // Test whether the now ModelObject has newer custom seam data than the old one.
 // The function assumes that volumes list is synchronized.
 bool model_custom_seam_data_changed(const ModelObject& mo, const ModelObject& mo_new);
+
+// Test whether the now ModelObject has newer custom brim data than the old one.
+// The function assumes that volumes list is synchronized.
+bool model_custom_brim_data_changed(const ModelObject& mo, const ModelObject& mo_new);
 
 // Test whether the now ModelObject has newer MMU segmentation data than the old one.
 // The function assumes that volumes list is synchronized.

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -78,6 +78,8 @@ static inline void model_volume_list_copy_configs(ModelObject &model_object_dst,
         mv_dst.supported_facets.assign(mv_src.supported_facets);
         assert(mv_dst.seam_facets.id() == mv_src.seam_facets.id());
         mv_dst.seam_facets.assign(mv_src.seam_facets);
+        assert(mv_dst.brim_facets.id() == mv_src.brim_facets.id());
+        mv_dst.brim_facets.assign(mv_src.brim_facets);
         assert(mv_dst.mmu_segmentation_facets.id() == mv_src.mmu_segmentation_facets.id());
         mv_dst.mmu_segmentation_facets.assign(mv_src.mmu_segmentation_facets);
         //FIXME what to do with the materials?
@@ -1204,6 +1206,8 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
                 }
             } else if (model_custom_seam_data_changed(model_object, model_object_new)) {
                 update_apply_status(this->invalidate_step(psGCodeExport));
+            } else if (model_custom_brim_data_changed(model_object, model_object_new)) {
+                // todo: apply update logic for brim data changes
             }
         }
         if (! solid_or_modifier_differ) {

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3152,6 +3152,7 @@ void PrintObject::project_and_append_custom_facets(
 {
     for (const ModelVolume* mv : this->model_object()->volumes)
         if (mv->is_model_part()) {
+            // todo: update conditional here to support brim facets
             const indexed_triangle_set custom_facets = seam
                     ? mv->seam_facets.get_facets_strict(*mv, type)
                     : mv->supported_facets.get_facets_strict(*mv, type);

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -74,6 +74,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/Gizmos/GLGizmoPainterBase.hpp
     GUI/Gizmos/GLGizmoSeam.cpp
     GUI/Gizmos/GLGizmoSeam.hpp
+    GUI/Gizmos/GLGizmoBrim.cpp
+    GUI/Gizmos/GLGizmoBrim.hpp
     GUI/Gizmos/GLGizmoSimplify.cpp
     GUI/Gizmos/GLGizmoSimplify.hpp
     GUI/Gizmos/GLGizmoSVG.cpp

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6226,7 +6226,8 @@ void GLCanvas3D::_render_sequential_clearance()
     case GLGizmosManager::EType::Emboss:
     case GLGizmosManager::EType::Simplify:
     case GLGizmosManager::EType::FdmSupports:
-    case GLGizmosManager::EType::Seam: { return; }
+    case GLGizmosManager::EType::Seam:
+    case GLGizmosManager::EType::Brim: { return; }
     default: { break; }
     }
  

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrim.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrim.cpp
@@ -1,0 +1,215 @@
+///|/ Copyright (c) Prusa Research 2020
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "GLGizmoBrim.hpp"
+
+#include "libslic3r/Model.hpp"
+
+//#include "slic3r/GUI/3DScene.hpp"
+#include "slic3r/GUI/GLCanvas3D.hpp"
+#include "slic3r/GUI/GUI_App.hpp"
+#include "slic3r/GUI/ImGuiWrapper.hpp"
+#include "slic3r/GUI/Plater.hpp"
+#include "slic3r/GUI/GUI_ObjectList.hpp"
+#include "slic3r/Utils/UndoRedo.hpp"
+
+#include <GL/glew.h>
+
+
+namespace Slic3r::GUI {
+
+
+
+void GLGizmoBrim::on_shutdown()
+{
+    m_parent.toggle_model_objects_visibility(true);
+}
+
+
+
+bool GLGizmoBrim::on_init()
+{
+    m_shortcut_key = WXK_CONTROL_P;
+
+    m_desc["clipping_of_view"] = _L("Clipping of view") + ": ";
+    m_desc["reset_direction"]  = _L("Reset direction");
+    m_desc["cursor_size"]      = _L("Brush size") + ": ";
+    m_desc["cursor_type"]      = _L("Brush shape") + ": ";
+    m_desc["enforce_caption"]  = _L("Left mouse button") + ": ";
+    m_desc["enforce"]          = _L("Enforce brim");
+    m_desc["block_caption"]    = _L("Right mouse button") + ": ";
+    m_desc["block"]            = _L("Block brim");
+    m_desc["remove_caption"]   = _L("Shift + Left mouse button") + ": ";
+    m_desc["remove"]           = _L("Remove selection");
+    m_desc["remove_all"]       = _L("Remove all selection");
+    m_desc["circle"]           = _L("Circle");
+    m_desc["sphere"]           = _L("Sphere");
+
+    return true;
+}
+
+
+
+std::string GLGizmoBrim::on_get_name() const
+{
+    return _u8L("Brim painting");
+}
+
+void GLGizmoBrim::render_painter_gizmo()
+{
+    const Selection& selection = m_parent.get_selection();
+
+    glsafe(::glEnable(GL_BLEND));
+    glsafe(::glEnable(GL_DEPTH_TEST));
+
+    render_triangles(selection);
+
+    m_c->object_clipper()->render_cut();
+    m_c->instances_hider()->render_cut();
+    render_cursor();
+
+    glsafe(::glDisable(GL_BLEND));
+}
+
+void GLGizmoBrim::on_render_input_window(float x, float y, float bottom_limit)
+{
+    if (! m_c->selection_info()->model_object())
+        return;
+
+    const float approx_height = m_imgui->scaled(12.5f);
+    y = std::min(y, bottom_limit - approx_height);
+    m_imgui->set_next_window_pos(x, y, ImGuiCond_Always);
+    m_imgui->begin(get_name(), ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse);
+
+    // First calculate width of all the texts that are could possibly be shown. We will decide set the dialog width based on that:
+    const float clipping_slider_left = std::max(m_imgui->calc_text_size(m_desc.at("clipping_of_view")).x,
+                                                m_imgui->calc_text_size(m_desc.at("reset_direction")).x)
+                                           + m_imgui->scaled(1.5f);
+    const float cursor_size_slider_left = m_imgui->calc_text_size(m_desc.at("cursor_size")).x + m_imgui->scaled(1.f);
+
+    const float cursor_type_radio_left   = m_imgui->calc_text_size(m_desc["cursor_type"]).x + m_imgui->scaled(1.f);
+    const float cursor_type_radio_sphere = m_imgui->calc_text_size(m_desc["sphere"]).x + m_imgui->scaled(2.5f);
+    const float cursor_type_radio_circle = m_imgui->calc_text_size(m_desc["circle"]).x + m_imgui->scaled(2.5f);
+
+    const float button_width = m_imgui->calc_text_size(m_desc.at("remove_all")).x + m_imgui->scaled(1.f);
+    const float minimal_slider_width = m_imgui->scaled(4.f);
+
+    float caption_max    = 0.f;
+    float total_text_max = 0.f;
+    for (const auto &t : std::array<std::string, 3>{"enforce", "block", "remove"}) {
+        caption_max    = std::max(caption_max, m_imgui->calc_text_size(m_desc[t + "_caption"]).x);
+        total_text_max = std::max(total_text_max, m_imgui->calc_text_size(m_desc[t]).x);
+    }
+    total_text_max += caption_max + m_imgui->scaled(1.f);
+    caption_max    += m_imgui->scaled(1.f);
+
+    const float sliders_left_width = std::max(cursor_size_slider_left, clipping_slider_left);
+    const float slider_icon_width  = m_imgui->get_slider_icon_size().x;
+    float       window_width       = minimal_slider_width + sliders_left_width + slider_icon_width;
+    window_width = std::max(window_width, total_text_max);
+    window_width = std::max(window_width, button_width);
+    window_width = std::max(window_width, cursor_type_radio_left + cursor_type_radio_sphere + cursor_type_radio_circle);
+
+    auto draw_text_with_caption = [this, &caption_max](const wxString& caption, const wxString& text) {
+        m_imgui->text_colored(ImGuiWrapper::COL_ORANGE_LIGHT, caption);
+        ImGui::SameLine(caption_max);
+        m_imgui->text(text);
+    };
+
+    for (const auto &t : std::array<std::string, 3>{"enforce", "block", "remove"})
+        draw_text_with_caption(m_desc.at(t + "_caption"), m_desc.at(t));
+
+    ImGui::Separator();
+
+    const float max_tooltip_width = ImGui::GetFontSize() * 20.0f;
+
+    ImGui::AlignTextToFramePadding();
+    m_imgui->text(m_desc.at("cursor_size"));
+    ImGui::SameLine(sliders_left_width);
+    ImGui::PushItemWidth(window_width - sliders_left_width - slider_icon_width);
+    m_imgui->slider_float("##cursor_radius", &m_cursor_radius, CursorRadiusMin, CursorRadiusMax, "%.2f", 1.0f, true, _L("Alt + Mouse wheel"));
+
+    ImGui::AlignTextToFramePadding();
+    m_imgui->text(m_desc.at("cursor_type"));
+
+    float cursor_type_offset = cursor_type_radio_left + (window_width - cursor_type_radio_left - cursor_type_radio_sphere - cursor_type_radio_circle + m_imgui->scaled(0.5f)) / 2.f;
+    ImGui::SameLine(cursor_type_offset);
+    ImGui::PushItemWidth(cursor_type_radio_sphere);
+    if (m_imgui->radio_button(m_desc["sphere"], m_cursor_type == TriangleSelector::CursorType::SPHERE))
+        m_cursor_type = TriangleSelector::CursorType::SPHERE;
+
+    if (ImGui::IsItemHovered())
+        m_imgui->tooltip(_L("Paints all facets inside, regardless of their orientation."), max_tooltip_width);
+
+    ImGui::SameLine(cursor_type_offset + cursor_type_radio_sphere);
+    ImGui::PushItemWidth(cursor_type_radio_circle);
+    if (m_imgui->radio_button(m_desc["circle"], m_cursor_type == TriangleSelector::CursorType::CIRCLE))
+        m_cursor_type = TriangleSelector::CursorType::CIRCLE;
+
+    if (ImGui::IsItemHovered())
+        m_imgui->tooltip(_L("Ignores facets facing away from the camera."), max_tooltip_width);
+
+    ImGui::Separator();
+    if (m_c->object_clipper()->get_position() == 0.f) {
+        ImGui::AlignTextToFramePadding();
+        m_imgui->text(m_desc.at("clipping_of_view"));
+    }
+    else {
+        if (m_imgui->button(m_desc.at("reset_direction"))) {
+            wxGetApp().CallAfter([this](){
+                    m_c->object_clipper()->set_position_by_ratio(-1., false);
+                });
+        }
+    }
+
+    auto clp_dist = float(m_c->object_clipper()->get_position());
+    ImGui::SameLine(sliders_left_width);
+    ImGui::PushItemWidth(window_width - sliders_left_width - slider_icon_width);
+    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L("Ctrl + Mouse wheel")))
+        m_c->object_clipper()->set_position_by_ratio(clp_dist, true);
+
+    ImGui::Separator();
+    if (m_imgui->button(m_desc.at("remove_all"))) {
+        Plater::TakeSnapshot snapshot(wxGetApp().plater(), _L("Reset selection"), UndoRedo::SnapshotType::GizmoAction);
+        ModelObject         *mo  = m_c->selection_info()->model_object();
+        int                  idx = -1;
+        for (ModelVolume *mv : mo->volumes)
+            if (mv->is_model_part()) {
+                ++idx;
+                m_triangle_selectors[idx]->reset();
+                m_triangle_selectors[idx]->request_update_render_data();
+            }
+
+        update_model_object();
+        m_parent.set_as_dirty();
+    }
+
+    m_imgui->end();
+}
+
+void GLGizmoBrim::update_model_object() const
+{
+    // todo: implement the model update of the Slic3r model structure
+}
+
+PainterGizmoType GLGizmoBrim::get_painter_type() const
+{
+    return PainterGizmoType::BRIM;
+}
+
+wxString GLGizmoBrim::handle_snapshot_action_name(bool shift_down, GLGizmoPainterBase::Button button_down) const
+{
+    wxString action_name;
+    if (shift_down)
+        action_name = _L("Remove selection");
+    else {
+        if (button_down == Button::Left)
+            action_name = _L("Enforce brim");
+        else
+            action_name = _L("Block brim");
+    }
+    return action_name;
+}
+
+} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrim.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrim.hpp
@@ -1,0 +1,52 @@
+///|/ Copyright (c) Prusa Research 2019 - 2023
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_GLGizmoBrim_hpp_
+#define slic3r_GLGizmoBrimg_hpp_
+
+#include "GLGizmoPainterBase.hpp"
+
+#include "slic3r/GUI/I18N.hpp"
+
+namespace Slic3r::GUI {
+
+class GLGizmoBrim : public GLGizmoPainterBase
+{
+public:
+    GLGizmoBrim(GLCanvas3D& parent, const std::string& icon_filename, unsigned int sprite_id)
+        : GLGizmoPainterBase(parent, icon_filename, sprite_id) {}
+
+    void render_painter_gizmo() override;
+
+protected:
+    void on_render_input_window(float x, float y, float bottom_limit) override;
+    std::string on_get_name() const override;
+    PainterGizmoType get_painter_type() const override;
+
+    wxString handle_snapshot_action_name(bool shift_down, Button button_down) const override;
+
+    std::string get_gizmo_entering_text() const override { return _u8L("Entering Brim painting"); }
+    std::string get_gizmo_leaving_text() const override { return _u8L("Leaving Brim painting"); }
+    std::string get_action_snapshot_name() const override { return _u8L("Paint-on brim editing"); }
+
+private:
+    bool on_init() override;
+
+    void update_model_object() const override;
+    void update_from_model_object() override;
+
+    void on_opening() override {}
+    void on_shutdown() override;
+
+    // This map holds all translated description texts, so they can be easily referenced during layout calculations
+    // etc. When language changes, GUI is recreated and this class constructed again, so the change takes effect.
+    std::map<std::string, wxString> m_desc;
+};
+
+
+
+} // namespace Slic3r::GUI
+
+
+#endif // slic3r_GLGizmoBrim_hpp_

--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.hpp
@@ -31,7 +31,8 @@ class Selection;
 enum class PainterGizmoType {
     FDM_SUPPORTS,
     SEAM,
-    MMU_SEGMENTATION
+    MMU_SEGMENTATION,
+    BRIM
 };
 
 class TriangleSelectorGUI : public TriangleSelector {

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -24,6 +24,7 @@
 #include "slic3r/GUI/Gizmos/GLGizmoCut.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoHollow.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoSeam.hpp"
+#include "slic3r/GUI/Gizmos/GLGizmoBrim.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoSimplify.hpp"
 #include "slic3r/GUI/Gizmos/GLGizmoEmboss.hpp"
@@ -112,6 +113,7 @@ bool GLGizmosManager::init()
     m_gizmos.emplace_back(new GLGizmoSlaSupports(m_parent, "sla_supports.svg", 6));
     m_gizmos.emplace_back(new GLGizmoFdmSupports(m_parent, "fdm_supports.svg", 7));
     m_gizmos.emplace_back(new GLGizmoSeam(m_parent, "seam.svg", 8));
+    m_gizmos.emplace_back(new GLGizmoBrim(m_parent, "brim.svg", 8)); // todo: get support from the design team for the svg
     m_gizmos.emplace_back(new GLGizmoMmuSegmentation(m_parent, "mmu_segmentation.svg", 9));
     m_gizmos.emplace_back(new GLGizmoMeasure(m_parent, "measure.svg", 10));
     m_gizmos.emplace_back(new GLGizmoEmboss(m_parent));
@@ -293,6 +295,8 @@ bool GLGizmosManager::gizmo_event(SLAGizmoEventType action, const Vec2d& mouse_p
         return dynamic_cast<GLGizmoFdmSupports*>(m_gizmos[FdmSupports].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
     else if (m_current == Seam)
         return dynamic_cast<GLGizmoSeam*>(m_gizmos[Seam].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
+    else if (m_current == Seam)
+        return dynamic_cast<GLGizmoBrim*>(m_gizmos[Brim].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
     else if (m_current == MmuSegmentation)
         return dynamic_cast<GLGizmoMmuSegmentation*>(m_gizmos[MmuSegmentation].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
     else if (m_current == Measure)

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -113,9 +113,9 @@ bool GLGizmosManager::init()
     m_gizmos.emplace_back(new GLGizmoSlaSupports(m_parent, "sla_supports.svg", 6));
     m_gizmos.emplace_back(new GLGizmoFdmSupports(m_parent, "fdm_supports.svg", 7));
     m_gizmos.emplace_back(new GLGizmoSeam(m_parent, "seam.svg", 8));
-    m_gizmos.emplace_back(new GLGizmoBrim(m_parent, "brim.svg", 8)); // todo: get support from the design team for the svg
-    m_gizmos.emplace_back(new GLGizmoMmuSegmentation(m_parent, "mmu_segmentation.svg", 9));
-    m_gizmos.emplace_back(new GLGizmoMeasure(m_parent, "measure.svg", 10));
+    m_gizmos.emplace_back(new GLGizmoBrim(m_parent, "brim.svg", 9));
+    m_gizmos.emplace_back(new GLGizmoMmuSegmentation(m_parent, "mmu_segmentation.svg", 10));
+    m_gizmos.emplace_back(new GLGizmoMeasure(m_parent, "measure.svg", 11));
     m_gizmos.emplace_back(new GLGizmoEmboss(m_parent));
     m_gizmos.emplace_back(new GLGizmoSVG(m_parent));
     m_gizmos.emplace_back(new GLGizmoSimplify(m_parent));

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -295,7 +295,7 @@ bool GLGizmosManager::gizmo_event(SLAGizmoEventType action, const Vec2d& mouse_p
         return dynamic_cast<GLGizmoFdmSupports*>(m_gizmos[FdmSupports].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
     else if (m_current == Seam)
         return dynamic_cast<GLGizmoSeam*>(m_gizmos[Seam].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
-    else if (m_current == Seam)
+    else if (m_current == Brim)
         return dynamic_cast<GLGizmoBrim*>(m_gizmos[Brim].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);
     else if (m_current == MmuSegmentation)
         return dynamic_cast<GLGizmoMmuSegmentation*>(m_gizmos[MmuSegmentation].get())->gizmo_event(action, mouse_position, shift_down, alt_down, control_down);

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.hpp
@@ -80,6 +80,7 @@ public:
         SlaSupports,
         FdmSupports,
         Seam,
+        Brim,
         MmuSegmentation,
         Measure,
         Emboss,

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -99,6 +99,7 @@ static const std::map<const wchar_t, std::string> font_icons_large = {
 //    {ImGui::SinkingObjectMarker     , "move"                            },
 //    {ImGui::CustomSupportsMarker    , "fdm_supports"                    },
 //    {ImGui::CustomSeamMarker        , "seam"                            },
+//    {ImGui::CustomBrimMarker        , "brim"                            },
 //    {ImGui::MmuSegmentationMarker   , "mmu_segmentation"                },
 //    {ImGui::VarLayerHeightMarker    , "layers"                          },
     {ImGui::DocumentationButton     , "notification_documentation"      },

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -1651,6 +1651,7 @@ void NotificationManager::UpdatedItemsInfoNotification::add_type(InfoItemType ty
 		switch ((*it).first) {
 		case InfoItemType::CustomSupports:      text += format(_L_PLURAL("%1$d object was loaded with custom supports.",		"%1$d objects were loaded with custom supports.",		(*it).second), (*it).second) + "\n"; break;
 		case InfoItemType::CustomSeam:          text += format(_L_PLURAL("%1$d object was loaded with custom seam.",			"%1$d objects were loaded with custom seam.",			(*it).second), (*it).second) + "\n"; break;
+		case InfoItemType::CustomBrim:          text += format(_L_PLURAL("%1$d object was loaded with custom brim.",			"%1$d objects were loaded with custom brim.",			(*it).second), (*it).second) + "\n"; break;
 		case InfoItemType::MmuSegmentation:     text += format(_L_PLURAL("%1$d object was loaded with multimaterial painting.", "%1$d objects were loaded with multimaterial painting.",(*it).second), (*it).second) + "\n"; break;
 		case InfoItemType::VariableLayerHeight: text += format(_L_PLURAL("%1$d object was loaded with variable layer height.",	"%1$d objects were loaded with variable layer height.", (*it).second), (*it).second) + "\n"; break;
 		case InfoItemType::Sinking:             text += format(_L_PLURAL("%1$d object was loaded with partial sinking.",		"%1$d objects were loaded with partial sinking.",		(*it).second), (*it).second) + "\n"; break;
@@ -1671,6 +1672,7 @@ void NotificationManager::UpdatedItemsInfoNotification::render_left_sign(ImGuiWr
 	switch (type) {
 	case InfoItemType::CustomSupports:      text = ImGui::CustomSupportsMarker; break;
 	case InfoItemType::CustomSeam:          text = ImGui::CustomSeamMarker; break;
+	case InfoItemType::CustomBrim:          text = ImGui::CustomBrimMarker; break;
 	case InfoItemType::MmuSegmentation:     text = ImGui::MmuSegmentationMarker; break;
 	case InfoItemType::VariableLayerHeight: text = ImGui::VarLayerHeightMarker; break;
 	case InfoItemType::Sinking:             text = ImGui::SinkingObjectMarker; break;

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -70,6 +70,7 @@ const std::map<InfoItemType, InfoItemAtributes> INFO_ITEMS{
 //           info_item Type                         info_item Name              info_item BitmapName
             { InfoItemType::CustomSupports,      {L("Paint-on supports"),       "fdm_supports_" },     },
             { InfoItemType::CustomSeam,          {L("Paint-on seam"),           "seam_" },             },
+            { InfoItemType::CustomBrim,          {L("Paint-on brim"),           "brim_" },             },
             { InfoItemType::CutConnectors,       {L("Connectors"),              "cut_connectors" },    },
             { InfoItemType::MmuSegmentation,     {L("Multimaterial painting"),  "mmu_segmentation_"},  },
             { InfoItemType::Sinking,             {L("Sinking"),                 "sinking"},            },

--- a/src/slic3r/GUI/ObjectDataViewModel.hpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.hpp
@@ -55,6 +55,7 @@ enum class InfoItemType
     Undef,
     CustomSupports,
     CustomSeam,
+    CustomBrim,
     CutConnectors,
     MmuSegmentation,
     Sinking,

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3667,6 +3667,7 @@ bool Plater::priv::replace_volume_with_stl(int object_idx, int volume_idx, const
         // We need to make sure that the painted data point to existing triangles.
         new_volume->supported_facets.assign(old_volume->supported_facets);
         new_volume->seam_facets.assign(old_volume->seam_facets);
+        new_volume->brim_facets.assign(old_volume->brim_facets);
         new_volume->mmu_segmentation_facets.assign(old_volume->mmu_segmentation_facets);
     }
     std::swap(old_model_object->volumes[volume_idx], old_model_object->volumes.back());
@@ -7864,13 +7865,14 @@ void Plater::clear_before_change_mesh(int obj_idx, const std::string &notificati
 {
     ModelObject* mo = model().objects[obj_idx];
 
-    // If there are custom supports/seams/mmu segmentation, remove them. Fixed mesh
+    // If there are custom supports/seams/brim/mmu segmentation, remove them. Fixed mesh
     // may be different and they would make no sense.
     bool paint_removed = false;
     for (ModelVolume* mv : mo->volumes) {
-        paint_removed |= ! mv->supported_facets.empty() || ! mv->seam_facets.empty() || ! mv->mmu_segmentation_facets.empty();
+        paint_removed |= ! mv->supported_facets.empty() || ! mv->seam_facets.empty() || ! mv->brim_facets.empty() || ! mv->mmu_segmentation_facets.empty();
         mv->supported_facets.reset();
         mv->seam_facets.reset();
+        mv->brim_facets.reset();
         mv->mmu_segmentation_facets.reset();
     }
     if (paint_removed) {


### PR DESCRIPTION
The purpose of this work is to introduce support for the Paint on Brims feature. Many people from the community have asked for this feature, including myself, and I'd like to help contribute it. 

I'm totally new to PrusaSlicer development and mostly work in Go instead of C++, so please bear with me through this, but I would like to help contribute it. Guidance and any advise would be much appreciated 😄 

Related issues and community posts:
> If there are others, feel free to include them in the comments section and I'll update this.

https://github.com/prusa3d/PrusaSlicer/issues/8283
https://forum.prusa3d.com/forum/prusaslicer/brim-painting/

----

**TODOs for Me**

- [ ]  Localization of the Paint on Brim text - refer to the [Localization Guide](https://github.com/prusa3d/PrusaSlicer/blob/master/doc/Localization_guide.md)
- [ ] Finish svg designs for the "Paint on Brim" sidebar icons `brim.svg` and `brim_.svg`. See `resources/icons/seam.svg` and `resources/icons/seam_.svg` for examples.
- [ ] Add `CustomBrimMarker` to `imconfig.h` for ImGui.
- [ ] Review `Brim.hpp` and `Brim.cpp` to understand how brims work and the "islands" of polygons that define them.
- [ ] Modify `PrintObject::project_and_append_custom_facets` to support brim facets.
- [ ] Look at `libslic3r/GCode/SeamPlacer.cpp` which uses paint on seam facets as inspiration for a `BrimPlacer` or at least modifications to the existing `Brim.cpp` implementation based on the model from the brim facets.
- [ ] Update `PrintApply.cpp` logic for when `model_custom_brim_data_changed` has changed
