### PR TITLE
Fix missing braces around multi-line if ()

### DIFF
--- a/src/libslic3r/GCode/WipeTowerIntegration.cpp
+++ b/src/libslic3r/GCode/WipeTowerIntegration.cpp
@@ -81,10 +81,10 @@ std::string WipeTowerIntegration::append_tcr(GCodeGenerator &gcodegen, const Wip
         if (is_ramming)
             gcodegen.m_wipe.reset_path(); // We don't want wiping on the ramming lines.
         toolchange_gcode_str = gcodegen.set_extruder(new_extruder_id, tcr.print_z); // TODO: toolchange_z vs print_z
-        if (gcodegen.config().wipe_tower)
+        if (gcodegen.config().wipe_tower) {
             deretraction_str += gcodegen.writer().get_travel_to_z_gcode(z, "restore layer Z");
             deretraction_str += gcodegen.unretract();
-
+        }
     }
     assert(toolchange_gcode_str.empty() || toolchange_gcode_str.back() == '\n');
     assert(deretraction_str.empty() || deretraction_str.back() == '\n');


### PR DESCRIPTION
Just a trivial fix for missing braces around if () body that I noticed from code inspection and didn't want to leave unnoticed.

The problem was introduced in this commit and seems like an obvious mistake, missing braces { ... } around the body of an if () that becomes multi-line with the change in that commit:
```
commit 91e79af261631bc54d996a2157c1c28498ba3298
Author: Martin Šach <martin.sachin@gmail.com>
Date:   Thu Nov 9 15:07:34 2023 +0100

    Fix wipe tower integration wiht regard to "no_sparse_layers".
    
    Wipe tower with "no_sparse_layers" enabled was completely broken.
    This commit introduces necessary changes to WipeTowerIntegration.cpp
    for it to work properly.
```