### PR TITLE
Combine infill with internal perimeters

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -31,7 +31,16 @@ Flow LayerRegion::flow(FlowRole role) const
 
 Flow LayerRegion::flow(FlowRole role, double layer_height) const
 {
-    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id() == 0);
+    if (this->region().config().infill_every_layers > 1 && role == frPerimeter && 
+        m_layer->id() > this->region().config().infill_every_layers - 1){
+        Layer *player = m_layer->lower_layer;
+        for (int i = 1; i <= this->region().config().infill_every_layers - 1;i++) {
+                layer_height += player->height;
+                player = player->lower_layer;
+        };
+    }
+
+    return m_region->flow(*m_layer->object(), role, layer_height, m_layer->id());
 }
 
 Flow LayerRegion::bridging_flow(FlowRole role, bool force_thick_bridges) const

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1115,6 +1115,10 @@ void PerimeterGenerator::process_arachne(
     // extra perimeters for each one
     // detect how many perimeters must be generated for this island
     int        loop_number = params.config.perimeters + surface.extra_perimeters - 1; // 0-indexed loops
+    if (params.config.infill_every_layers > 1 && params.layer_id > 0 &&
+        params.layer_id % params.config.infill_every_layers != 0)
+        loop_number = 0;
+
     ExPolygons last        = offset_ex(surface.expolygon.simplify_p(params.scaled_resolution), - float(ext_perimeter_width / 2. - ext_perimeter_spacing / 2.));
     Polygons   last_p      = to_polygons(last);
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1555,10 +1555,11 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("infill_every_layers", coInt);
-    def->label = L("Combine infill every");
+    def->label = L("Combine infill with perimeters every");
     def->category = L("Infill");
-    def->tooltip = L("This feature allows to combine infill and speed up your print by extruding thicker "
-                   "infill layers while preserving thin perimeters, thus accuracy.");
+    def->tooltip = L("This feature allows to combine infill with internal perimeters and speed up your print by extruding thicker "
+                    "infill and internal perimeters layers while preserving thin perimeters, thus accuracy. "
+                    "Internal perimeters will be combined only in Arachne and when external perimeters are printed first.");
     def->sidetext = L("layers");
     def->full_label = L("Combine infill every n layers");
     def->min = 1;

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -715,7 +715,8 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "perimeter_extrusion_width"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first"
-            || opt_key == "arc_fitting") {
+            || opt_key == "arc_fitting"
+            || opt_key == "infill_every_layers") {
             steps.emplace_back(posPerimeters);
         } else if (
                opt_key == "gap_fill_enabled"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -229,7 +229,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_infill = config->option<ConfigOptionPercent>("fill_density")->value > 0;
     // infill_extruder uses the same logic as in Print::extruders()
-    for (auto el : { "fill_pattern", "infill_every_layers", "infill_only_where_needed",
+    for (auto el : { "fill_pattern", "infill_only_where_needed",
                     "solid_infill_every_layers", "solid_infill_below_area", "infill_extruder", "infill_anchor_max" })
         toggle_field(el, have_infill);
     // Only allow configuration of open anchors if the anchoring is enabled.


### PR DESCRIPTION
This PR add also internal perimeters to combining infill.
Limitation: only in Arachne and when external perimeters are printed first.

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/49402375-8462-458f-8539-88b2c7fdc2dd)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/e913a4a0-d0e4-4d38-9885-2aa97fbbbc28)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/608cf5a5-490c-4146-a8ec-0b40203ce596)


