### PR TITLE
Limit Arachne maximum width

### DIFF
--- a/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.cpp
@@ -254,17 +254,17 @@ double ExtrusionLine::area() const
 } // namespace Slic3r::Arachne
 
 namespace Slic3r {
-void extrusion_paths_append(ExtrusionPaths &dst, const ClipperLib_Z::Paths &extrusion_paths, const ExtrusionRole role, const Flow &flow)
+void extrusion_paths_append(ExtrusionPaths &dst, const ClipperLib_Z::Paths &extrusion_paths, const ExtrusionRole role, const Flow &flow, float max_width)
 {
     for (const ClipperLib_Z::Path &extrusion_path : extrusion_paths) {
         ThickPolyline thick_polyline = Arachne::to_thick_polyline(extrusion_path);
-        Slic3r::append(dst, PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, role, flow, scaled<float>(0.05), float(SCALED_EPSILON)).paths);
+        Slic3r::append(dst, PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, role, flow, scaled<float>(0.05), float(SCALED_EPSILON), max_width).paths);
     }
 }
 
-void extrusion_paths_append(ExtrusionPaths &dst, const Arachne::ExtrusionLine &extrusion, const ExtrusionRole role, const Flow &flow)
+void extrusion_paths_append(ExtrusionPaths &dst, const Arachne::ExtrusionLine &extrusion, const ExtrusionRole role, const Flow &flow, float max_width)
 {
     ThickPolyline thick_polyline = Arachne::to_thick_polyline(extrusion);
-    Slic3r::append(dst, PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, role, flow, scaled<float>(0.05), float(SCALED_EPSILON)).paths);
+    Slic3r::append(dst, PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, role, flow, scaled<float>(0.05), float(SCALED_EPSILON), max_width).paths);
 }
 } // namespace Slic3r

--- a/src/libslic3r/Arachne/utils/ExtrusionLine.hpp
+++ b/src/libslic3r/Arachne/utils/ExtrusionLine.hpp
@@ -298,8 +298,8 @@ using VariableWidthLines = std::vector<ExtrusionLine>; //<! The ExtrusionLines g
 
 namespace Slic3r {
 
-void extrusion_paths_append(ExtrusionPaths &dst, const ClipperLib_Z::Paths &extrusion_paths, const ExtrusionRole role, const Flow &flow);
-void extrusion_paths_append(ExtrusionPaths &dst, const Arachne::ExtrusionLine &extrusion, const ExtrusionRole role, const Flow &flow);
+void extrusion_paths_append(ExtrusionPaths &dst, const ClipperLib_Z::Paths &extrusion_paths, const ExtrusionRole role, const Flow &flow, float max_width = FLT_MAX);
+void extrusion_paths_append(ExtrusionPaths &dst, const Arachne::ExtrusionLine &extrusion, const ExtrusionRole role, const Flow &flow, float max_width = FLT_MAX);
 
 } // namespace Slic3r
 

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -552,7 +552,13 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
                     for (const ThickPolyline &thick_polyline : thick_polylines) {
                         Flow new_flow = surface_fill.params.flow.with_spacing(float(f->spacing));
 
-                        ExtrusionMultiPath multi_path = PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, surface_fill.params.extrusion_role, new_flow, scaled<float>(0.05), float(SCALED_EPSILON));
+                        assert(!this->object()->print()->config().nozzle_diameter.empty());
+                        float min_nozzle_diameter = float(*std::min_element(this->object()->print()->config().nozzle_diameter.values.begin(), this->object()->print()->config().nozzle_diameter.values.end()));
+                        float max_bead_width = this->object()->config().max_bead_width.value;
+                        if (const auto &max_bead_width_opt = this->object()->config().max_bead_width; max_bead_width_opt.percent)
+						    max_bead_width = (max_bead_width_opt.value * 0.01 * min_nozzle_diameter);
+
+                        ExtrusionMultiPath multi_path = PerimeterGenerator::thick_polyline_to_multi_path(thick_polyline, surface_fill.params.extrusion_role, new_flow, scaled<float>(0.05), float(SCALED_EPSILON), max_bead_width);
                         // Append paths to collection.
                         if (!multi_path.empty()) {
                             if (multi_path.paths.front().first_point() == multi_path.paths.back().last_point())

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -101,7 +101,7 @@ void process_arachne(
     // Infills without the gap fills
     ExPolygons                 &out_fill_expolygons);
 
-ExtrusionMultiPath thick_polyline_to_multi_path(const ThickPolyline &thick_polyline, ExtrusionRole role, const Flow &flow, float tolerance, float merge_tolerance);
+ExtrusionMultiPath thick_polyline_to_multi_path(const ThickPolyline &thick_polyline, ExtrusionRole role, const Flow &flow, float tolerance, float merge_tolerance, float max_width = FLT_MAX);
 
 } // namespace PerimeterGenerator
 } // namespace Slic3r

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -472,7 +472,7 @@ static std::vector<std::string> s_Preset_print_options {
     "wipe_tower_width", "wipe_tower_cone_angle", "wipe_tower_rotation_angle", "wipe_tower_brim_width", "wipe_tower_bridging", "single_extruder_multi_material_priming", "mmu_segmented_region_max_width",
     "mmu_segmented_region_interlocking_depth", "wipe_tower_extruder", "wipe_tower_no_sparse_layers", "wipe_tower_extra_spacing", "compatible_printers", "compatible_printers_condition", "inherits",
     "perimeter_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
-    "wall_distribution_count", "min_feature_size", "min_bead_width"
+    "wall_distribution_count", "min_feature_size", "min_bead_width", "max_bead_width"
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3482,6 +3482,16 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->set_default_value(new ConfigOptionFloatOrPercent(85, true));
 
+    def = this->add("max_bead_width", coFloatOrPercent);
+    def->label = L("Maximum perimeter width");
+    def->category = L("Advanced");
+    def->tooltip  = L("Maximum width of the perimeter. "
+                      "If expressed as a percentage (for example 85%), it will be computed based on the nozzle diameter.");
+    def->sidetext = L("mm or %");
+    def->mode = comExpert;
+    def->min = 0;
+    def->set_default_value(new ConfigOptionFloatOrPercent(250, true));
+
     // Declare retract values for filament profile, overriding the printer's extruder profile.
     for (const char *opt_key : {
         // floats

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -555,6 +555,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                 wall_distribution_count))
     ((ConfigOptionFloatOrPercent,      min_feature_size))
     ((ConfigOptionFloatOrPercent,      min_bead_width))
+    ((ConfigOptionFloatOrPercent,      max_bead_width))
     ((ConfigOptionBool,                support_material))
     // Automatic supports (generated based fdm support point generator).
     ((ConfigOptionBool,                support_material_auto))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -872,6 +872,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "wall_distribution_count"
             || opt_key == "min_feature_size"
             || opt_key == "min_bead_width") {
+            || opt_key == "max_bead_width" 
             steps.emplace_back(posSlice);
         } else if (
                opt_key == "seam_position"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -344,6 +344,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("wall_distribution_count", have_arachne);
     toggle_field("min_feature_size", have_arachne);
     toggle_field("min_bead_width", have_arachne);
+    toggle_field("max_bead_width", have_arachne);
     toggle_field("thin_walls", !have_arachne);
 }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1695,6 +1695,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wall_transition_length");
         optgroup->append_single_option_line("wall_distribution_count");
         optgroup->append_single_option_line("min_bead_width");
+        optgroup->append_single_option_line("max_bead_width");
         optgroup->append_single_option_line("min_feature_size");
 
     page = add_options_page(L("Output options"), "output+page_white");


### PR DESCRIPTION
closes #9150 

Nozzle 0.4, extrusion width 0.8

Current version:
![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/5dd2121d-9ff4-4153-81ad-bcd565d271b5)

With 0.8 mm (200% of 0.4) limitation:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/c775e2bf-da99-49fa-a5b7-35cb2d3a6740)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/9969e516-cb33-49ab-b93a-3655df068826)
