### PR TITLE
Reverse extrusion directions

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -278,7 +278,7 @@ private:
         bool vase_mode
     );
     std::string     extrude_entity(const ExtrusionEntityReference &entity, const GCode::SmoothPathCache &smooth_path_cache, const std::string_view description, double speed = -1.);
-    std::string     extrude_loop(const ExtrusionLoop &loop, const GCode::SmoothPathCache &smooth_path_cache, const std::string_view description, double speed = -1.);
+    std::string     extrude_loop(const ExtrusionLoop &loop, bool reverse, const GCode::SmoothPathCache &smooth_path_cache, const std::string_view description, double speed = -1.);
     std::string     extrude_skirt(const ExtrusionLoop &loop_src, const ExtrusionFlow &extrusion_flow_override,
         const GCode::SmoothPathCache &smooth_path_cache, const std::string_view description, double speed);
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -473,6 +473,7 @@ static std::vector<std::string> s_Preset_print_options {
     "mmu_segmented_region_interlocking_depth", "wipe_tower_extruder", "wipe_tower_no_sparse_layers", "wipe_tower_extra_flow", "wipe_tower_extra_spacing", "compatible_printers", "compatible_printers_condition", "inherits",
     "perimeter_generator", "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
     "wall_distribution_count", "min_feature_size", "min_bead_width"
+    "reverse_overhangs", "reverse_perimeters_even", "reverse_infill_even"
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2494,6 +2494,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def->sidetext = L("%");
 #if 0
     def = this->add("seam_preferred_direction", coFloat);
 //    def->gui_type = ConfigOptionDef::GUIType::slider;
@@ -3534,6 +3535,27 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->min = 0;
     def->set_default_value(new ConfigOptionFloatOrPercent(85, true));
+
+    def = this->add("reverse_overhangs", coBool);
+    def->label = L("Reverse external perimeters with overhang direction every layer");
+    def->category = L("Advanced");
+    def->tooltip = L("Extrude each layer overhang perimeters in opposite direction, improving quality.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("reverse_perimeters_even", coBool);
+    def->label = L("Reverse perimeters directions on even layers");
+    def->category = L("Advanced");
+    def->tooltip = L("Extrude each layer perimeters in opposite direction, reduce internal stress and warping.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("reverse_infill_even", coBool);
+    def->label = L("Reverse infill direction every layer");
+    def->category = L("Advanced");
+    def->tooltip = L("Extrude each layer infill in opposite direction, reduce internal stress and warping.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
 
     // Declare retract values for filament profile, overriding the printer's extruder profile.
     for (const char *opt_key : {

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -649,6 +649,10 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                perimeter_speed))
     // Total number of perimeters.
     ((ConfigOptionInt,                  perimeters))
+    //Perimeters reverse
+    ((ConfigOptionBool,                 reverse_overhangs))
+    ((ConfigOptionBool,                 reverse_perimeters_even))
+    ((ConfigOptionBool,                 reverse_infill_even))
     ((ConfigOptionFloatOrPercent,       small_perimeter_speed))
     ((ConfigOptionFloat,                solid_infill_below_area))
     ((ConfigOptionInt,                  solid_infill_extruder))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -715,7 +715,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "perimeter_extrusion_width"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first"
-            || opt_key == "arc_fitting") {
+            || opt_key == "arc_fitting"
+            || opt_key == "reverse_overhangs"
+            || opt_key == "reverse_perimeters_even") {
             steps.emplace_back(posPerimeters);
         } else if (
                opt_key == "gap_fill_enabled"

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1691,6 +1691,11 @@ void TabPrint::build()
         optgroup->append_single_option_line("xy_size_compensation");
         optgroup->append_single_option_line("elefant_foot_compensation", "elephant-foot-compensation_114487");
 
+        optgroup = page->new_optgroup(L("Extrusion direction reverse"));
+        optgroup->append_single_option_line("reverse_overhangs");
+        optgroup->append_single_option_line("reverse_perimeters_even");
+        optgroup->append_single_option_line("reverse_infill_even");
+
         optgroup = page->new_optgroup(L("Arachne perimeter generator"));
         optgroup->append_single_option_line("wall_transition_angle");
         optgroup->append_single_option_line("wall_transition_filter_deviation");


### PR DESCRIPTION
Resolves  #12003 **Alternate overhang perimeters extruding directions**

This PR add option to reverse extruding direction every second layer. First, reversing overhang perimeters drastically improves their quality. See SoftFever/OrcaSlicer/pull/2413 and my own trial:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/c8ad4950-9ac7-4189-b872-416594f7a25f)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/06fea972-0f82-4a32-a674-00e1aa0505da)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/18e2fe7f-e1a8-43f3-bc64-5da5d2b14b2a)

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/efb6389c-566a-4721-b1b4-8655f4a70850)

Second, according to discussions reversing internal perimeters/infill significantly reduces thermal stress and thus wrapping of materials like ABS, PC, etc.

See for example **Add option to "Reverse only internal perimeters" under the reverse on odd feature to reduce part warping** SoftFever/OrcaSlicer/pull/2722 I decided not to reverse external perimeter as it reduce surface quality.

Draft shield and support are always reversed to reduce their wrapping too.


