### PR TITLE
[docs] Update linux build instructions

### DIFF
--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -17,17 +17,18 @@ You need at least 8GB of RAM on your system. Linking on a 4GB RAM system will li
 
 GNU build tools, CMake, git and other libraries have to be installed on the build machine.
 Unless that's already the case, install them as usual from your distribution packages.
-E.g. on Ubuntu 20.10, run
-```shell
-sudo apt-get install  -y \
-git \
-build-essential \
-autoconf \
-cmake \
-libglu1-mesa-dev \
-libgtk-3-dev \
-libdbus-1-dev \
+E.g. on Ubuntu 23.10, run
 
+```shell
+sudo apt-get install \
+    git \
+    build-essential \
+    autoconf \
+    cmake \
+    libglu1-mesa-dev \
+    libgtk-3-dev \
+    libdbus-1-dev \
+    texinfo
 ```
 The names of the packages may be different on different distros.
 
@@ -66,6 +67,8 @@ Now when the dependencies are compiled, all that is needed is to tell CMake that
     cd build
     cmake .. -DSLIC3R_STATIC=1 -DSLIC3R_GTK=3 -DSLIC3R_PCH=OFF -DCMAKE_PREFIX_PATH=$(pwd)/../deps/build/destdir/usr/local
     make -j4
+
+(Note [issue 11794](https://github.com/prusa3d/PrusaSlicer/issues/11794) regarding `libtiff` errors).
 
 And that's it. It is now possible to run the freshly built PrusaSlicer binary:
 


### PR DESCRIPTION
 - Update Ubuntu version to latest stable (confirmed to work).
 - Add missing `texinfo` package requirement.
 - Improve formatting (added indentation, and no trailing `\`).
 - Remove `-y` for safety (verify isn't not about to nuke your system).
 - Reference issue 11794, build issue related to `libtiff`.