### PR TITLE
[UI] [Doc Links] Fix links to Support Material docs

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1545,26 +1545,26 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_material_auto", category_path + "auto-generated-supports");
         optgroup->append_single_option_line("support_material_threshold", category_path + "overhang-threshold");
         optgroup->append_single_option_line("support_material_enforce_layers", category_path + "enforce-support-for-the-first");
-        optgroup->append_single_option_line("raft_first_layer_density", category_path + "raft-first-layer-density");
-        optgroup->append_single_option_line("raft_first_layer_expansion", category_path + "raft-first-layer-expansion");
+        optgroup->append_single_option_line("raft_first_layer_density");
+        optgroup->append_single_option_line("raft_first_layer_expansion");
 
         optgroup = page->new_optgroup(L("Raft"));
         optgroup->append_single_option_line("raft_layers", category_path + "raft-layers");
-        optgroup->append_single_option_line("raft_contact_distance", category_path + "raft-layers");
-        optgroup->append_single_option_line("raft_expansion");
+        optgroup->append_single_option_line("raft_contact_distance", category_path + "raft-contact-z-distance");
+        optgroup->append_single_option_line("raft_expansion", category_path + "raft-expansion");
 
         optgroup = page->new_optgroup(L("Options for support material and raft"));
         optgroup->append_single_option_line("support_material_style", category_path + "style");
-        optgroup->append_single_option_line("support_material_contact_distance", category_path + "contact-z-distance");
-        optgroup->append_single_option_line("support_material_bottom_contact_distance", category_path + "contact-z-distance");
+        optgroup->append_single_option_line("support_material_contact_distance", category_path + "top-contact-z-distance");
+        optgroup->append_single_option_line("support_material_bottom_contact_distance", category_path + "bottom-contact-z-distance");
         optgroup->append_single_option_line("support_material_pattern", category_path + "pattern");
         optgroup->append_single_option_line("support_material_with_sheath", category_path + "with-sheath-around-the-support");
-        optgroup->append_single_option_line("support_material_spacing", category_path + "pattern-spacing-0-inf");
+        optgroup->append_single_option_line("support_material_spacing", category_path + "pattern-spacing");
         optgroup->append_single_option_line("support_material_angle", category_path + "pattern-angle");
-        optgroup->append_single_option_line("support_material_closing_radius", category_path + "pattern-angle");
-        optgroup->append_single_option_line("support_material_interface_layers", category_path + "interface-layers");
-        optgroup->append_single_option_line("support_material_bottom_interface_layers", category_path + "interface-layers");
-        optgroup->append_single_option_line("support_material_interface_pattern", category_path + "interface-pattern");
+        optgroup->append_single_option_line("support_material_closing_radius", category_path + "closing-radius");
+        optgroup->append_single_option_line("support_material_interface_layers", category_path + "top-interface-layers");
+        optgroup->append_single_option_line("support_material_bottom_interface_layers", category_path + "bottom-interface-layers");
+        optgroup->append_single_option_line("support_material_interface_pattern");
         optgroup->append_single_option_line("support_material_interface_spacing", category_path + "interface-pattern-spacing");
         optgroup->append_single_option_line("support_material_interface_contact_loops", category_path + "interface-loops");
         optgroup->append_single_option_line("support_material_buildplate_only", category_path + "support-on-build-plate-only");


### PR DESCRIPTION
Many of the documentation links in the "Support Material" settings page were pointing to non-existent URLs.

This PR corrects the URLs for options which have documentation.

e.g. "Raft contact Z distance" now correctly takes you to https://help.prusa3d.com/article/support-material_1698#raft-contact-z-distance

It also removes 3 links to documentation that doesn't exist:

```
First Layer Density
First Layer Expansion
Material Interface Pattern
```
Tested by building and running the linux version of prusa slicer, and confirmed the correct documentation is opened.