### PR TITLE
Fix GCodeReader::update_coordinates for G2 & G3

### DIFF
--- a/src/libslic3r/GCodeReader.cpp
+++ b/src/libslic3r/GCodeReader.cpp
@@ -117,7 +117,7 @@ void GCodeReader::update_coordinates(GCodeLine &gline, std::pair<const char*, co
 {
     if (*command.first == 'G') {
         int cmd_len = int(command.second - command.first);
-        if ((cmd_len == 2 && (command.first[1] == '0' || command.first[1] == '1')) ||
+        if ((cmd_len == 2 && (command.first[1] == '0' || command.first[1] == '1' || command.first[1] == '2' || command.first[1] == '3')) ||
             (cmd_len == 3 &&  command.first[1] == '9' && command.first[2] == '2')) {
             for (size_t i = 0; i < NUM_AXES; ++ i)
                 if (gline.has(Axis(i)))


### PR DESCRIPTION
Hi
I was using the gcode reader, and I found this issue:
The  reader hasn't its x,y and e coordinates updated, and so the distance & time computation is completely broken.
I don't really know where are the impacts in your codebase, maybe in CoolingBuffer. Still, it's better to have it fixed.