### PR TITLE
Fix mmu paint with "high" resolution

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -2021,6 +2021,10 @@ indexed_triangle_set FacetsAnnotation::get_facets(const ModelVolume& mv, Enforce
     selector.deserialize(m_data, false);
     return selector.get_facets(type);
 }
+void FacetsAnnotation::set_facets_selector(TriangleSelector& selector) const
+{
+    selector.deserialize(m_data, false);
+}
 
 indexed_triangle_set FacetsAnnotation::get_facets_strict(const ModelVolume& mv, EnforcerBlockerType type) const
 {

--- a/src/libslic3r/Model.hpp
+++ b/src/libslic3r/Model.hpp
@@ -692,6 +692,7 @@ public:
     const std::pair<std::vector<std::pair<int, int>>, std::vector<bool>>& get_data() const throw() { return m_data; }
     bool set(const TriangleSelector& selector);
     indexed_triangle_set get_facets(const ModelVolume& mv, EnforcerBlockerType type) const;
+    void set_facets_selector(TriangleSelector& selector) const;
     indexed_triangle_set get_facets_strict(const ModelVolume& mv, EnforcerBlockerType type) const;
     bool has_facets(const ModelVolume& mv, EnforcerBlockerType type) const;
     bool empty() const { return m_data.first.empty(); }


### PR DESCRIPTION
I test the project from `4101` and the artifacts are visible in PrusaSlicer 2.5 and 2.7
see
supermerill/SuperSlicer#2639
supermerill/SuperSlicer#4101

I passed the resolution field to let the mmuSegmentation use it instead of a fixed value. 
