### PR TITLE
Don't perform downloader desktop integration if builded with SLIC3R_DESKTOP_INTEGRATION = 0

### DIFF
--- a/src/libslic3r/Geometry/VoronoiUtils.cpp
+++ b/src/libslic3r/Geometry/VoronoiUtils.cpp
@@ -1,5 +1,6 @@
 #include <Arachne/utils/PolygonsSegmentIndex.hpp>
 #include <MultiMaterialSegmentation.hpp>
+#include <boost/log/trivial.hpp>
 
 #include "VoronoiUtils.hpp"
 

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1518,11 +1518,11 @@ PageDownloader::PageDownloader(ConfigWizard* parent)
         ));
     }
 
-#ifdef __linux__
+#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
     append_text(wxString::Format(_L(
         "On Linux systems the process of registration also creates desktop integration files for this version of application."
     )));
-#endif
+#endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
 
     box_allow_downloads->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent& event) { this->m_downloader->allow(event.IsChecked()); });
 
@@ -1582,7 +1582,7 @@ bool DownloaderUtils::Worker::perform_register(const std::string& path_override/
 #elif __APPLE__
     // Apple registers for custom url in info.plist thus it has to be already registered since build.
     // The url will always trigger opening of prusaslicer and we have to check that user has allowed it. (GUI_App::MacOpenURL is the triggered method)
-#else 
+#elif defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
     // the performation should be called later during desktop integration
     perform_registration_linux = true;
 #endif
@@ -1600,7 +1600,7 @@ void DownloaderUtils::Worker::deregister()
     key_full = key_string;
 #elif __APPLE__
     // TODO
-#else 
+#elif defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
     BOOST_LOG_TRIVIAL(debug) << "DesktopIntegrationDialog::undo_downloader_registration";
     DesktopIntegrationDialog::undo_downloader_registration();
     perform_registration_linux = false;
@@ -3063,14 +3063,14 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
         if ((check_unsaved_preset_changes = install_bundles.size() > 0))
             header = _L_PLURAL("A new vendor was installed and one of its printers will be activated", "New vendors were installed and one of theirs printers will be activated", install_bundles.size());
 
-#ifdef __linux__
+#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
     // Desktop integration on Linux
     BOOST_LOG_TRIVIAL(debug) << "ConfigWizard::priv::apply_config integrate_desktop" << page_welcome->integrate_desktop()  << " perform_registration_linux " << page_downloader->m_downloader->get_perform_registration_linux();
     if (page_welcome->integrate_desktop())
         DesktopIntegrationDialog::perform_desktop_integration();
     if (page_downloader->m_downloader->get_perform_registration_linux())
         DesktopIntegrationDialog::perform_downloader_desktop_integration();
-#endif
+#endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
 
     // Decide whether to create snapshot based on run_reason and the reset profile checkbox
     bool snapshot = true;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3175,10 +3175,10 @@ void GUI_App::show_downloader_registration_dialog()
     if (msg.ShowModal() == wxID_YES) {
         auto downloader_worker = new DownloaderUtils::Worker(nullptr);
         downloader_worker->perform_register(app_config->get("url_downloader_dest"));
-#ifdef __linux__
+#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
         if (downloader_worker->get_perform_registration_linux())
             DesktopIntegrationDialog::perform_downloader_desktop_integration();
-#endif // __linux__
+#endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
     } else {
         app_config->set("downloader_url_registered", "0");
     }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2987,12 +2987,6 @@ void GUI_App::MacOpenFiles(const wxArrayString &fileNames)
 
 void GUI_App::MacOpenURL(const wxString& url)
 {
-    if (app_config && !app_config->get_bool("downloader_url_registered"))
-    {
-        notification_manager()->push_notification(NotificationType::URLNotRegistered);
-        BOOST_LOG_TRIVIAL(error) << "Recieved command to open URL, but it is not allowed in app configuration. URL: " << url;
-        return;
-    }
     start_download(boost::nowide::narrow(url));
 }
 
@@ -3558,14 +3552,24 @@ void GUI_App::start_download(std::string url)
         BOOST_LOG_TRIVIAL(error) << "Could not start URL download: plater is nullptr.";
         return; 
     }
+
+    #if defined(__APPLE__) || (defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
+    if (app_config && !app_config->get_bool("downloader_url_registered"))
+    {
+        notification_manager()->push_notification(NotificationType::URLNotRegistered);
+        BOOST_LOG_TRIVIAL(error) << "Recieved command to open URL, but it is not allowed in app configuration. URL: " << url;
+        return;
+    }
+    #endif //defined(__APPLE__) || (defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
+
     //lets always init so if the download dest folder was changed, new dest is used 
-        boost::filesystem::path dest_folder(app_config->get("url_downloader_dest"));
-        if (dest_folder.empty() || !boost::filesystem::is_directory(dest_folder)) {
-            std::string msg = _u8L("Could not start URL download. Destination folder is not set. Please choose destination folder in Configuration Wizard.");
-            BOOST_LOG_TRIVIAL(error) << msg;
-            show_error(nullptr, msg);
-            return;
-        } 
+    boost::filesystem::path dest_folder(app_config->get("url_downloader_dest"));
+    if (dest_folder.empty() || !boost::filesystem::is_directory(dest_folder)) {
+        std::string msg = _u8L("Could not start URL download. Destination folder is not set. Please choose destination folder in Configuration Wizard.");
+        BOOST_LOG_TRIVIAL(error) << msg;
+        show_error(nullptr, msg);
+        return;
+    }
     m_downloader->init(dest_folder);
     m_downloader->start_download(url);
 }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -28,9 +28,9 @@
 #ifdef WIN32
 #include <wx/msw/registry.h>
 #endif // WIN32
-#ifdef __linux__
+#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
 #include "DesktopIntegrationDialog.hpp"
-#endif //__linux__
+#endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
 
 namespace Slic3r {
 
@@ -758,10 +758,10 @@ void PreferencesDialog::accept(wxEvent&)
 			downloader->allow(it->second == "1");
 		if (!downloader->on_finish())
 			return;
-#ifdef __linux__
+#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
 		if( downloader->get_perform_registration_linux()) 
 			DesktopIntegrationDialog::perform_downloader_desktop_integration();
-#endif // __linux__
+#endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
 	}
 
 	std::vector<std::string> options_to_recreate_GUI = { "no_defaults", "tabs_as_menu", "sys_menu_enabled", "font_pt_size", "suppress_round_corners" };


### PR DESCRIPTION
This pull request replace my previous (https://github.com/prusa3d/PrusaSlicer/pull/11229).

This PR prevent the call of perform_downloader_desktop_integration() and undo_downloader_registration() when PrusaSlicer is builded with  SLIC3R_DESKTOP_INTEGRATION = 0.

In this way we can ship the desktop integration directly inside the flatpak desktop file respecting the sandbox rules.