### PR TITLE
Add Boost to VoronoiUtils.cpp

### DIFF
--- a/src/libslic3r/Geometry/VoronoiUtils.cpp
+++ b/src/libslic3r/Geometry/VoronoiUtils.cpp
@@ -1,6 +1,6 @@
 #include <Arachne/utils/PolygonsSegmentIndex.hpp>
 #include <MultiMaterialSegmentation.hpp>
-
+#include <boost/log/trivial.hpp>
 #include "VoronoiUtils.hpp"
 
 namespace Slic3r::Geometry {


### PR DESCRIPTION
Previously, I cloned the main branch into my Ubuntu 22 to use CLI. However, when I built the project, I encountered this issue:

```
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp: In static member function ‘static typename boost::polygon::enable_if<typename boost::polygon::gtl_if<typename boost::polygon::is_segment_concept<typename boost::polygon::geometry_concept<GeometryType>::type>::type>::type, std::vector<Slic3r::Point, tbb::detail::d1::scalable_allocator<Slic3r::Point> > >::type Slic3r::Geometry::VoronoiUtils::discretize_parabola(const Slic3r::Point&, const Segment&, const Slic3r::Point&, const Slic3r::Point&, coord_t, float)’:
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp:157:27: error: ‘warning’ was not declared in this scope
  157 |         BOOST_LOG_TRIVIAL(warning) << "Failing to discretize parabola! Must add an apex or one of the endpoints.";
      |                           ^~~~~~~
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp:157:9: error: there are no arguments to ‘BOOST_LOG_TRIVIAL’ that depend on a template parameter, so a declaration of ‘BOOST_LOG_TRIVIAL’ must be available [-fpermissive]
  157 |         BOOST_LOG_TRIVIAL(warning) << "Failing to discretize parabola! Must add an apex or one of the endpoints.";
      |         ^~~~~~~~~~~~~~~~~
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp:157:9: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp: In instantiation of ‘static typename boost::polygon::enable_if<typename boost::polygon::gtl_if<typename boost::polygon::is_segment_concept<typename boost::polygon::geometry_concept<GeometryType>::type>::type>::type, std::vector<Slic3r::Point, tbb::detail::d1::scalable_allocator<Slic3r::Point> > >::type Slic3r::Geometry::VoronoiUtils::discretize_parabola(const Slic3r::Point&, const Segment&, const Slic3r::Point&, const Slic3r::Point&, coord_t, float) [with Segment = Slic3r::Arachne::PolygonsSegmentIndex; typename boost::polygon::enable_if<typename boost::polygon::gtl_if<typename boost::polygon::is_segment_concept<typename boost::polygon::geometry_concept<GeometryType>::type>::type>::type, std::vector<Slic3r::Point, tbb::detail::d1::scalable_allocator<Slic3r::Point> > >::type = std::vector<Slic3r::Point, tbb::detail::d1::scalable_allocator<Slic3r::Point> >; typename boost::polygon::gtl_if<typename boost::polygon::is_segment_concept<typename boost::polygon::geometry_concept<GeometryType>::type>::type>::type = boost::polygon::gtl_yes; typename boost::polygon::is_segment_concept<typename boost::polygon::geometry_concept<GeometryType>::type>::type = boost::polygon::gtl_yes; typename boost::polygon::geometry_concept<GeometryType>::type = boost::polygon::segment_concept; coord_t = int]’:
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp:28:149:   required from here
/home/diego/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp:157:34: error: ‘BOOST_LOG_TRIVIAL’ was not declared in this scope
  157 |         BOOST_LOG_TRIVIAL(warning) << "Failing to discretize parabola! Must add an apex or one of the endpoints.";
      |                                  ^
make[2]: *** [src/libslic3r/CMakeFiles/libslic3r.dir/build.make:1224: src/libslic3r/CMakeFiles/libslic3r.dir/Geometry/VoronoiUtils.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1103: src/libslic3r/CMakeFiles/libslic3r.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
Thanks to the contribution of @SachCZ, I could finally build and run PrusaSlicer using CLI.

The main change was only this:
Added "#include <boost/log/trivial.hpp>" to "/home/your_user/PrusaSlicer/src/libslic3r/Geometry/VoronoiUtils.cpp"."