### PR TITLE
fix wrong type (int instead of coord_t)

### DIFF
--- a/src/slic3r/GUI/Jobs/EmbossJob.cpp
+++ b/src/slic3r/GUI/Jobs/EmbossJob.cpp
@@ -322,9 +322,9 @@ void CreateObjectJob::process(Ctl &ctl)
     Points bed_shape_;
     bed_shape_.reserve(m_input.bed_shape.size());
     for (const Vec2d &p : m_input.bed_shape)
-        bed_shape_.emplace_back(p.cast<int>());
+        bed_shape_.emplace_back(p.cast<coord_t>());
     Slic3r::Polygon bed(bed_shape_);
-    if (!bed.contains(bed_coor.cast<int>()))
+    if (!bed.contains(bed_coor.cast<coord_t>()))
         // mouse pose is out of build plate so create object in center of plate
         bed_coor = bed.centroid().cast<double>();
 

--- a/src/slic3r/GUI/SurfaceDrag.cpp
+++ b/src/slic3r/GUI/SurfaceDrag.cpp
@@ -542,7 +542,7 @@ bool start_dragging(const Vec2d                &mouse_pos,
     // zero point of volume in world coordinate system
     Vec3d volume_center = to_world.translation();
     // screen coordinate of volume center
-    Vec2i coor                           = CameraUtils::project(camera, volume_center);
+    Point coor                           = CameraUtils::project(camera, volume_center);
     Vec2d mouse_offset                   = coor.cast<double>() - mouse_pos;
     Vec2d mouse_offset_without_sla_shift = mouse_offset;
     if (double sla_shift = gl_volume.get_sla_shift_z(); !is_approx(sla_shift, 0.)) {


### PR DESCRIPTION
CameraUtils::project return a Point.

bed_shape_ & bed are Points and Polygon, and Point contains coord_t values.
(and I wonder if there's not a missing scale and unscale, or if the truncation of the 'p' variable is intended)