### PR TITLE
bugfix: sets -Dlerc:BOOL=OFF

### DIFF
--- a/deps/+TIFF/TIFF.cmake
+++ b/deps/+TIFF/TIFF.cmake
@@ -10,6 +10,7 @@ add_cmake_project(TIFF
         -Dzstd:BOOL=OFF
         -Dpixarlog:BOOL=OFF
         -Dlibdeflate:BOOL=OFF
+        -Dlerc:BOOL=OFF
 )
 
 set(DEP_TIFF_DEPENDS ZLIB PNG JPEG OpenGL)


### PR DESCRIPTION
When linking the PrusaSlcier on Debian12 Linux the following error occurs (undefined reference to lerc_decode):

![lerc_decode](https://github.com/prusa3d/PrusaSlicer/assets/25696872/a269340e-e794-4494-80e5-934e1e09e15c)

This can be fixed by setting -Dlerc:BOOL=OFF in deps/+TIFF/TIFF.cmake