### PR TITLE
adds build scripts for macOS and Linux

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+#
+# This script can download and compile dependencies, compile PrusauSlicer
+# and optional build a .tgz and an appimage.
+#
+# Original script from SuperSclier by supermerill https://github.com/supermerill/SuperSlicer
+#
+# Change log:
+#
+# 20 Nov 2023, wschadow, branding and minor changes
+# 01 Jan 2024, wschadow, debranding for the Prusa version, added build options
+#
+
+export ROOT=`pwd`
+export NCORES=`nproc`
+
+OS_FOUND=$( command -v uname)
+
+case $( "${OS_FOUND}" | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    TARGET_OS="linux"
+   ;;
+  msys*|cygwin*|mingw*)
+    # or possible 'bash on windows'
+    TARGET_OS='windows'
+   ;;
+  nt|win*)
+    TARGET_OS='windows'
+    ;;
+  darwin)
+    TARGET_OS='macos'
+    ;;
+  *)
+    TARGET_OS='unknown'
+    ;;
+esac
+
+# check operating system
+echo
+if [ $TARGET_OS == "linux" ]; then
+    if [ $(uname -m) == "x86_64" ]; then
+        echo -e "$(tput setaf 2)Linux 64-bit found$(tput sgr0)\n"
+        Processor="64"
+    elif [[ $(uname -m) == "i386" || $(uname -m) == "i686" ]]; then
+        echo "$(tput setaf 2)Linux 32-bit found$(tput sgr0)\n"
+        Processor="32"
+    else
+        echo "$(tput setaf 1)Unsupported OS: Linux $(uname -m)"
+        exit -1
+    fi
+else
+    echo -e "$(tput setaf 1)This script doesn't support your Operating system!"
+    echo -e "Please use Linux 64-bit or Windows 10 64-bit with Linux subsystem / git-bash.$(tput sgr0)\n"
+    exit -1
+fi
+
+# Check if CMake is installed
+export CMAKE_INSTALLED=`which cmake`
+if [[ -z "$CMAKE_INSTALLED" ]]
+then
+    echo "Can't find CMake. Either is not installed or not in the PATH. Aborting!"
+    exit -1
+fi
+
+unset name
+while getopts ":hugbdsiw" opt; do
+  case ${opt} in
+    u )
+        UPDATE_LIB="1"
+        ;;
+    i )
+        BUILD_IMAGE="1"
+        ;;
+    d )
+        BUILD_DEPS="1"
+        ;;
+    s )
+        BUILD_PRUSASLICER="1"
+        ;;
+    b )
+        BUILD_DEBUG="1"
+        ;;
+    g )
+        FORCE_GTK2="-g"
+        ;;
+    w )
+	BUILD_WIPE="1"
+	;;
+    h ) echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-s][-i]"
+        echo "   -h: this message"
+	    echo "   -w: wipe build directories before building"
+        echo "   -u: only update dependency packets (optional and need sudo)"
+        echo "   -g: force gtk2 build"
+        echo "   -b: build in debug mode"
+        echo "   -d: build deps"
+        echo "   -s: build PrusaSlicer"
+        echo "   -i: Generate appimage (optional)"
+        echo -e "\n   For a first use, you want to 'sudo ./BuildLinux.sh -u'"
+        echo -e "   and then './BuildLinux.sh -dsi'\n"
+        exit 0
+        ;;
+  esac
+done
+
+if [ $OPTIND -eq 1 ]
+then
+    echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-s][-i]"
+    echo "   -h: this message"
+    echo "   -w: wipe build directories before building"
+    echo "   -u: only update dependency packets (optional and need sudo)"
+    echo "   -g: force gtk2 build"
+    echo "   -b: build in debug mode"
+    echo "   -d: build deps"
+    echo "   -s: build PrusaSlicer"
+    echo "   -i: generate appimage (optional)"
+    echo -e "\n   For a first use, you want to 'sudo ./BuildLinux.sh -u'"
+    echo -e "   and then './BuildLinux.sh -dsi'\n"
+    exit 0
+fi
+
+FOUND_GTK2=$(dpkg -l libgtk* | grep gtk2)
+FOUND_GTK3=$(dpkg -l libgtk* | grep gtk-3)
+FOUND_GTK2_DEV=$(dpkg -l libgtk* | grep gtk2.0-dev)
+FOUND_GTK3_DEV=$(dpkg -l libgtk* | grep gtk-3-dev)
+
+echo -e "FOUND_GTK2:\n$FOUND_GTK2\n"
+echo -e "FOUND_GTK3:\n$FOUND_GTK3)\n"
+
+if [[ -n "$FORCE_GTK2" ]]
+then
+   FOUND_GTK3=""
+   FOUND_GTK3_DEV=""
+fi
+
+if [[ -n "$UPDATE_LIB" ]]
+then
+    echo -n -e "Updating linux ...\n"
+    apt update
+    if [[ -z "$FOUND_GTK3" ]]
+    then
+        echo -e "\nInstalling: libgtk2.0-dev libglew-dev libudev-dev libdbus-1-dev cmake git\n"
+        apt install libgtk2.0-dev libglew-dev libudev-dev libdbus-1-dev cmake git
+    else
+        echo -e "\nFind libgtk-3, installing: libgtk-3-dev libglew-dev libudev-dev libdbus-1-dev cmake git\n"
+        apt install libgtk-3-dev libglew-dev libudev-dev libdbus-1-dev cmake git
+    fi
+
+    # for ubuntu 22.04:
+    ubu_version="$(cat /etc/issue)"
+    if [[ $ubu_version == "Ubuntu 22.04"* ]]
+    then
+        apt install curl libssl-dev libcurl4-openssl-dev m4
+    fi
+    if [[ -n "$BUILD_DEBUG" ]]
+    then
+        echo -e "\nInstalling: libssl-dev libcurl4-openssl-dev\n"
+        apt install libssl-dev libcurl4-openssl-dev
+    fi
+    echo -e "... done\n"
+    exit 0
+fi
+
+if [[ -z "$FOUND_GTK2_DEV" ]]
+then
+    if [[ -z "$FOUND_GTK3_DEV" ]]
+    then
+	echo -e "\nError, you must install the dependencies before."
+	echo -e "Use option -u with sudo\n"
+	exit 0
+    fi
+fi
+
+if [[ -n "$BUILD_DEPS" ]]
+then
+    if [[ -n $BUILD_WIPE ]]
+    then
+       rm -fr deps/build
+    fi
+    # mkdir build in deps
+    if [ ! -d "deps/build" ]
+    then
+	mkdir deps/build
+    fi
+    echo -e "[1/9] Configuring dependencies...\n"
+    BUILD_ARGS=""
+    if [[ -n "$FOUND_GTK3_DEV" ]]
+    then
+        BUILD_ARGS="-DDEP_WX_GTK3=ON"
+    else
+        BUILD_ARGS="-DDEP_WX_GTK3=OFF"
+    fi
+    if [[ -n "$BUILD_DEBUG" ]]
+    then
+        # have to build deps with debug & release or the cmake won't find evrything it needs
+	if [ ! -d "deps/build/release" ]
+	then
+	    mkdir deps/build/release
+	fi
+        pushd deps/build/release > /dev/null
+        cmake ../.. -DDESTDIR="../destdir" $BUILD_ARGS
+        popd > /dev/null
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
+    fi
+
+    pushd deps/build > /dev/null
+    cmake .. $BUILD_ARGS
+
+    echo -e "\n... done\n"
+
+    echo -e "\n[2/9] Building dependencies...\n"
+
+    # make deps
+    make -j$NCORES
+    echo -e "\n... done\n"
+
+    # rename wxscintilla
+    echo "[3/9] Renaming wxscintilla library..."
+    pushd destdir/usr/local/lib  > /dev/null
+    if [[ -z "$FOUND_GTK3_DEV" ]]
+    then
+        cp libwxscintilla-3.2.a libwx_gtk2u_scintilla-3.2.a
+    else
+        cp libwxscintilla-3.2.a libwx_gtk3u_scintilla-3.2.a
+    fi
+    popd > /dev/null
+    echo -e "\n... done\n"
+
+    # clean deps
+    echo "[4/9] Cleaning dependencies..."
+    rm -rf dep_*
+    popd  > /dev/null
+    echo -e "\n... done\n"
+fi
+
+if [[ -n "$BUILD_PRUSASLICER" ]]
+then
+    echo -e "[5/9] Configuring PrusaSlicer ...\n"
+    if [[ -n $BUILD_WIPE ]]
+    then
+       rm -fr build
+    fi
+    # mkdir build
+    if [ ! -d "build" ]
+    then
+	mkdir build
+    fi
+
+    BUILD_ARGS=""
+    if [[ -n "$FOUND_GTK3_DEV" ]]
+    then
+        BUILD_ARGS="-DSLIC3R_GTK=3"
+    fi
+    if [[ -n "$BUILD_DEBUG" ]]
+    then
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
+    fi
+
+    # cmake
+    pushd build > /dev/null
+    cmake .. -DCMAKE_PREFIX_PATH="$PWD/../deps/build/destdir/usr/local" -DSLIC3R_STATIC=1 ${BUILD_ARGS}
+    echo "... done"
+    # make PrusaSlicer
+    echo -e "\n[6/9] Building PrusaSlicer ...\n"
+    make -j$NCORES
+	echo -e "\n... done"
+
+    echo -e "\n[7/9] Generating language files ...\n"
+    #make .mo
+    make gettext_po_to_mo
+
+    popd  > /dev/null
+    echo -e "\n... done"
+
+    # Give proper permissions to script
+    chmod 755 $ROOT/build/src/BuildLinuxImage.sh
+
+    pushd build  > /dev/null
+    $ROOT/build/src/BuildLinuxImage.sh -a $FORCE_GTK2
+    popd  > /dev/null
+fi
+
+if [[ -n "$BUILD_IMAGE" ]]
+then
+    # Give proper permissions to script
+    chmod 755 $ROOT/build/src/BuildLinuxImage.sh
+    pushd build  > /dev/null
+    $ROOT/build/src/BuildLinuxImage.sh -i $FORCE_GTK2
+    popd  > /dev/null
+fi
+
+

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script can download and compile dependencies, compile PrusauSlicer
+# This script can download and compile dependencies, compile PrusaSlicer
 # and optional build a .tgz and an appimage.
 #
 # Original script from SuperSclier by supermerill https://github.com/supermerill/SuperSlicer
@@ -63,7 +63,7 @@ then
 fi
 
 unset name
-while getopts ":hugbdsiw" opt; do
+while getopts ":hugbdrstiw" opt; do
   case ${opt} in
     u )
         UPDATE_LIB="1"
@@ -77,23 +77,31 @@ while getopts ":hugbdsiw" opt; do
     s )
         BUILD_PRUSASLICER="1"
         ;;
+    t )
+        BUILD_TESTS="1"
+        ;;
     b )
         BUILD_DEBUG="1"
         ;;
     g )
         FORCE_GTK2="-g"
         ;;
+    r )
+        BUILD_CLEANDEPEND="1"
+	;;
     w )
 	BUILD_WIPE="1"
 	;;
-    h ) echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-s][-i]"
+    h ) echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-r][-s][-t][-i]"
         echo "   -h: this message"
 	    echo "   -w: wipe build directories before building"
         echo "   -u: only update dependency packets (optional and need sudo)"
         echo "   -g: force gtk2 build"
         echo "   -b: build in debug mode"
         echo "   -d: build deps"
+        echo "   -r: clean dependencies"
         echo "   -s: build PrusaSlicer"
+        echo "   -t: build tests (in combination with -s)"
         echo "   -i: Generate appimage (optional)"
         echo -e "\n   For a first use, you want to 'sudo ./BuildLinux.sh -u'"
         echo -e "   and then './BuildLinux.sh -dsi'\n"
@@ -104,14 +112,16 @@ done
 
 if [ $OPTIND -eq 1 ]
 then
-    echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-s][-i]"
+    echo "Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-r][-s][-t][-i]"
     echo "   -h: this message"
     echo "   -w: wipe build directories before building"
     echo "   -u: only update dependency packets (optional and need sudo)"
     echo "   -g: force gtk2 build"
     echo "   -b: build in debug mode"
     echo "   -d: build deps"
+    echo "   -r: clean dependencies"
     echo "   -s: build PrusaSlicer"
+    echo "   -t: build tests (in combination with -s)"
     echo "   -i: generate appimage (optional)"
     echo -e "\n   For a first use, you want to 'sudo ./BuildLinux.sh -u'"
     echo -e "   and then './BuildLinux.sh -dsi'\n"
@@ -174,14 +184,16 @@ if [[ -n "$BUILD_DEPS" ]]
 then
     if [[ -n $BUILD_WIPE ]]
     then
+       echo -e "\n wiping deps/build directory...\n"
        rm -fr deps/build
+       echo -e " ... done\n"
     fi
     # mkdir build in deps
     if [ ! -d "deps/build" ]
     then
 	mkdir deps/build
     fi
-    echo -e "[1/9] Configuring dependencies...\n"
+    echo -e "[1/9] Configuring dependencies ...\n"
     BUILD_ARGS=""
     if [[ -n "$FOUND_GTK3_DEV" ]]
     then
@@ -204,14 +216,12 @@ then
 
     pushd deps/build > /dev/null
     cmake .. $BUILD_ARGS
-
-    echo -e "\n... done\n"
+    echo -e "\n ... done\n"
 
     echo -e "\n[2/9] Building dependencies...\n"
-
     # make deps
     make -j$NCORES
-    echo -e "\n... done\n"
+    echo -e "\n ... done\n"
 
     # rename wxscintilla
     echo "[3/9] Renaming wxscintilla library..."
@@ -223,13 +233,17 @@ then
         cp libwxscintilla-3.2.a libwx_gtk3u_scintilla-3.2.a
     fi
     popd > /dev/null
-    echo -e "\n... done\n"
+    popd > /dev/null
+    echo -e "\n ... done\n"
+fi
 
-    # clean deps
-    echo "[4/9] Cleaning dependencies..."
-    rm -rf dep_*
-    popd  > /dev/null
-    echo -e "\n... done\n"
+if [[ -n "$BUILD_CLEANDEPEND" ]]
+then
+    echo -e "[4/9] Cleaning dependencies...\n"
+    pushd deps/build > /dev/null
+    rm -fr dep_*
+    popd > /dev/null
+    echo -e " ... done\n"
 fi
 
 if [[ -n "$BUILD_PRUSASLICER" ]]
@@ -237,7 +251,9 @@ then
     echo -e "[5/9] Configuring PrusaSlicer ...\n"
     if [[ -n $BUILD_WIPE ]]
     then
+       echo -e "\n wiping build directory ...\n"
        rm -fr build
+       echo -e "\n ... done"
     fi
     # mkdir build
     if [ ! -d "build" ]
@@ -255,21 +271,28 @@ then
         BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
     fi
 
+    if [[ -n "$BUILD_TESTS" ]]
+    then
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TESTS=1"
+    else
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TESTS=0"
+    fi
+
     # cmake
     pushd build > /dev/null
     cmake .. -DCMAKE_PREFIX_PATH="$PWD/../deps/build/destdir/usr/local" -DSLIC3R_STATIC=1 ${BUILD_ARGS}
-    echo "... done"
+    echo " ... done"
     # make PrusaSlicer
     echo -e "\n[6/9] Building PrusaSlicer ...\n"
     make -j$NCORES
-	echo -e "\n... done"
+    echo -e "\n ... done"
 
     echo -e "\n[7/9] Generating language files ...\n"
     #make .mo
     make gettext_po_to_mo
 
     popd  > /dev/null
-    echo -e "\n... done"
+    echo -e "\n ... done"
 
     # Give proper permissions to script
     chmod 755 $ROOT/build/src/BuildLinuxImage.sh
@@ -287,5 +310,3 @@ then
     $ROOT/build/src/BuildLinuxImage.sh -i $FORCE_GTK2
     popd  > /dev/null
 fi
-
-

--- a/BuildMacOS.sh
+++ b/BuildMacOS.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+#
+# This script can download and compile dependencies, compile PrusauSlicer
+# and optional build a .tgz and an appimage.
+#
+# Original script from SuperSclier by supermerill https://github.com/supermerill/SuperSlicer
+#
+# Change log:
+#
+# 20 Nov 2023, wschadow, branding and minor changes
+# 01 Jan 2024, wschadow, debranding for the Prusa version, added build options
+#
+
+export ROOT=`pwd`
+export NCORES=`sysctl -n hw.ncpu`
+
+
+OS_FOUND=$( command -v uname)
+
+case $( "${OS_FOUND}" | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    TARGET_OS="linux"
+   ;;
+  msys*|cygwin*|mingw*)
+    # or possible 'bash on windows'
+    TARGET_OS='windows'
+   ;;
+  nt|win*)
+    TARGET_OS='windows'
+    ;;
+  darwin)
+    TARGET_OS='macos'
+    ;;
+  *)
+    TARGET_OS='unknown'
+    ;;
+esac
+
+# check operating system
+echo
+if [ $TARGET_OS == "macos" ]; then
+    if [ $(uname -m) == "x86_64" ]; then
+        echo -e "$(tput setaf 2)macOS x86_64 found$(tput sgr0)\n"
+        Processor="64"
+    elif [[ $(uname -m) == "i386" || $(uname -m) == "i686" ]]; then
+        echo "$(tput setaf 2)macOS arm64 found$(tput sgr0)\n"
+        Processor="64"
+    else
+        echo "$(tput setaf 1)Unsupported OS: macOS $(uname -m)"
+        exit -1
+    fi
+else
+    echo -e "$(tput setaf 1)This script doesn't support your Operating system!"
+    echo -e "Please use Linux 64-bit or Windows 10 64-bit with Linux subsystem / git-bash.$(tput sgr0)\n"
+#    exit -1
+fi
+
+# Check if CMake is installed
+export CMAKE_INSTALLED=`which cmake`
+if [[ -z "$CMAKE_INSTALLED" ]]
+then
+    echo "Can't find CMake. Either is not installed or not in the PATH. Aborting!"
+    exit -1
+fi
+
+while getopts ":idaxbhcsw" opt; do
+  case ${opt} in
+    i )
+        BUILD_IMAGE="1"
+        ;;
+    d )
+        BUILD_DEPS="1"
+        ;;        
+    a )
+        export BUILD_ARCH="arm64"
+        ;;
+    x )
+        export BUILD_ARCH="x86_64"
+        ;;
+    b )
+        BUILD_DEBUG="1"
+        ;;
+    s )
+        BUILD_PRUSASLICER="1"
+        ;;
+    c)
+        BUILD_XCODE="1"
+        ;;
+    w )
+	    BUILD_WIPE="1"
+	;;        
+    h ) echo "Usage: ./BuildMacOS.sh  [-h][-w][-d][-a][-x][-b][-c][-s][-i]"
+        echo "   -h: this message"    
+	    echo "   -w: wipe build directories bfore building"        
+        echo "   -d: build dependencies"
+        echo "   -a: Build for arm64 (Apple Silicon)"
+        echo "   -x: Build for x86_64 (Intel)"
+        echo "   -b: Build with debug symbols"
+        echo "   -c: Build for XCode"
+        echo "   -s: build PrusaSlicer"        
+        echo "   -i: Generate DMG image (optional)\n"        
+        exit 0
+        ;;
+  esac
+done
+
+if [ $OPTIND -eq 1 ]
+then
+    echo "Usage: ./BuildLinux.sh [-h][-w][-d][-a][-x][-b][-c][-s][-i]"
+    echo "   -h: this message"   
+	echo "   -w: wipe build directories bfore building"         
+    echo "   -d: build dependencies"
+    echo "   -a: Build for arm64 (Apple Silicon)"
+    echo "   -x: Build for x86_64 (Intel)"
+    echo "   -b: Build with debug symbols"
+    echo "   -c: Build for XCode"
+    echo "   -s: build PrusaSlicer"    
+    echo -e "   -i: Generate DMG image (optional)\n"        
+    exit 0
+fi
+
+export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix zstd)/lib/
+
+if [[ -n "$BUILD_DEPS" ]]
+then
+    if [[ -n $BUILD_WIPE ]]
+    then
+       rm -fr deps/build
+    fi
+    # mkdir in deps
+    if [ ! -d "deps/build" ]
+    then
+    mkdir deps/build
+    fi
+    echo -e " \n[1/9] Configuring dependencies ... \n"
+    BUILD_ARGS=""
+    if [[ -n "$BUILD_ARCH" ]]
+    then
+        BUILD_ARGS="${BUILD_ARGS}  -DCMAKE_OSX_ARCHITECTURES:STRING=${BUILD_ARCH}"
+    fi
+    if [[ -n "$BUILD_DEBUG" ]]
+    then
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
+    fi
+    # cmake deps
+    echo "Cmake command: cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=\"10.14\" ${BUILD_ARCH} "
+    pushd deps/build > /dev/null
+    cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" $BUILD_ARGS 
+
+    echo -e "\n... done\n"
+
+    echo -e "[2/9] Building dependencies ...\n"
+
+    # make deps
+    make -j$NCORES
+
+    echo -e "\n... done\n"
+
+    echo -e "[3/9] Renaming wxscintilla library ...\n"
+
+    # rename wxscintilla
+    pushd destdir/usr/local/lib
+    cp libwxscintilla-3.2.a libwx_osx_cocoau_scintilla-3.2.a
+
+    popd > /dev/null
+    echo -e "\n... done\n"
+
+    echo -e "[4/9] Cleaning dependencies...\n"
+
+    # clean deps
+    rm -rf dep_*
+    popd > /dev/null
+
+    echo -e "\n... done\n"
+fi
+
+if [[ -n "$BUILD_PRUSASLICER" ]]
+then
+    echo -e "[5/9] Configuring PrusaSlicer ...\n"
+
+    if [[ -n $BUILD_WIPE ]]
+    then
+       rm -fr build
+    fi
+
+    # mkdir build
+    if [ ! -d "build" ]
+    then
+	mkdir build
+    fi
+
+    BUILD_ARGS=""
+    if [[ -n "$BUILD_ARCH" ]]
+    then
+        BUILD_ARGS="${BUILD_ARGS} -DCMAKE_OSX_ARCHITECTURES=${BUILD_ARCH}"
+    fi
+    if [[ -n "$BUILD_DEBUG" ]]
+    then
+        BUILD_ARGS="-DCMAKE_BUILD_TYPE=Debug ${BUILD_ARGS}"
+    fi
+    if [[ -n "$BUILD_XCODE" ]]
+    then
+        BUILD_ARGS="-GXcode ${BUILD_ARGS}"
+    fi
+    # cmake
+    pushd build > /dev/null
+    cmake .. -DCMAKE_PREFIX_PATH="$PWD/../deps/build/destdir/usr/local" -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" -DSLIC3R_STATIC=1 ${BUILD_ARGS}
+    echo -e "\n... done"
+
+    # make Slic3r
+    if [[ -z "$BUILD_XCODE" ]]
+    then
+        echo -e "\n[6/9] Building PrusaSlicer ...\n"
+        make -j$NCORES
+        echo -e "\n... done"
+    fi
+
+    echo -e "\n[7/9] Generating language files ...\n"
+    #make .mo
+    make gettext_po_to_mo
+    
+    popd  > /dev/null
+    echo -e "\n... done"
+
+    # Give proper permissions to script
+    chmod 755 $ROOT/build/src/BuildMacOSImage.sh
+
+    pushd build  > /dev/null
+    $ROOT/build/src/BuildMacOSImage.sh -a 
+    popd  > /dev/null  
+fi
+
+if [[ -n "$BUILD_IMAGE" ]]
+then
+    # Give proper permissions to script
+    chmod 755 $ROOT/build/src/BuildMacOSImage.sh
+    pushd build  > /dev/null
+    $ROOT/build/src/BuildMacOSImage.sh -i
+    popd  > /dev/null
+fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,3 +662,7 @@ else ()
 endif ()
 
 configure_file(${LIBDIR}/platform/unix/fhs.hpp.in ${LIBDIR_BIN}/platform/unix/fhs.hpp)
+
+if (NOT WIN32 AND NOT APPLE)
+   configure_file(${LIBDIR}/platform/unix/build_appimage.sh.in ${LIBDIR_BIN}/build_appimage.sh @ONLY)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,8 +126,16 @@ if (MINGW)
     set_target_properties(PrusaSlicer PROPERTIES PREFIX "")
 endif (MINGW)
 
+if (APPLE)
+    # Binary name on unix like systems (Linux, Unix)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/platform/osx/BuildMacOSImage.sh.in ${CMAKE_CURRENT_BINARY_DIR}/BuildMacOSImage.sh @ONLY)
+    set_target_properties(PrusaSlicer PROPERTIES OUTPUT_NAME "prusa-slicer")
+endif ()
+
+
 if (NOT WIN32 AND NOT APPLE)
     # Binary name on unix like systems (Linux, Unix)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/platform/unix/BuildLinuxImage.sh.in ${CMAKE_CURRENT_BINARY_DIR}/BuildLinuxImage.sh @ONLY)
     set_target_properties(PrusaSlicer PROPERTIES OUTPUT_NAME "prusa-slicer")
 endif ()
 

--- a/src/platform/osx/BuildMacOSImage.sh.in
+++ b/src/platform/osx/BuildMacOSImage.sh.in
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#
+# This script can download and compile dependencies, compile CaribouSlicer
+# and optional build a .tgz and an appimage.
+#
+# Original script from SuperSclier by supermerill https://github.com/supermerill/SuperSlicer
+#
+# Change log:
+#
+# 20 Nov 2023, wschadow, branding and minor changes
+# 01 Jan 2024, wschadow, debranding for the Prusa version, added build options
+#
+
+export ROOT=`pwd`
+export NCORES=`sysctl -n hw.ncpu`
+
+while getopts ":iha" opt; do
+  case ${opt} in
+    i )
+        export BUILD_IMAGE="1"
+        ;;
+    a )
+        export BUILD_APP="1"
+        ;;
+    h ) echo "Usage: ./BuildMacOSImage.sh [-i][-a][-h]"
+        echo "   -i: generate DMG image (optional)"
+    	echo "   -a: generate App (optional)"
+        echo "   -h: help"
+        exit 0
+        ;;
+  esac
+done
+
+if [[ -n "$BUILD_APP" ]]
+then
+    echo -e "\n[8/9] Generating macOS app ..."
+
+    # update Info.plist
+    pushd src > /dev/null
+    sed "s/+UNKNOWN/_$(date '+%F')/" Info.plist >Info.date.plist
+    popd > /dev/null
+
+    # create directory and copy into it
+    if [ -d "pack" ]
+    then
+        rm -rf pack
+    fi
+    mkdir pack
+    mkdir pack/@SLIC3R_APP_KEY@
+    mkdir pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app
+    mkdir pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents
+    mkdir pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/_CodeSignature
+    mkdir pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Frameworks
+    mkdir pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS
+
+    # copy Resources
+    cp -Rf ../resources pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Resources
+    cp pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Resources/icons/@SLIC3R_APP_KEY@.icns pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/resources/@SLIC3R_APP_KEY@.icns
+    cp src/Info.date.plist pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Info.plist
+    echo -n -e 'APPL????\x0a' > PkgInfo
+    cp PkgInfo pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/PkgInfo
+    # remove unneeded po from resources
+    find pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Resources/localization -name "*.po" -type f -delete
+
+    # copy bin and do not let it lower case
+    cp -f src/@SLIC3R_APP_NAME@ pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+    chmod u+x pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+    tar -czvf @SLIC3R_APP_KEY@-@SLIC3R_VERSION@-macOS.tgz pack/@SLIC3R_APP_KEY@ &>/dev/null
+
+    echo -e "\n... done\n"
+fi   
+
+if [[ -n "$BUILD_IMAGE" ]]
+then
+    echo -e "\n[9/9] Creating DMG Image for distribution ...\n"
+
+    # create dmg
+    hdiutil create -ov -fs HFS+ -volname "@SLIC3R_APP_KEY@" -srcfolder "pack/@SLIC3R_APP_KEY@" temp.dmg
+    hdiutil convert temp.dmg -format UDZO -o @SLIC3R_APP_KEY@-@SLIC3R_VERSION@.dmg
+    rm -f temp.dmg
+    echo -e "\n... done\n"
+fi

--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+#
+# This script can download and compile dependencies, compile CaribouSlicer
+# and optional build a .tgz and an appimage.
+#
+# Original script from SuperSclier by supermerill https://github.com/supermerill/SuperSlicer
+#
+# Change log:
+#
+# 20 Nov 2023, wschadow, branding and minor changes
+# 01 Jan 2024, wschadow, debranding for the Prusa version, added build options
+#
+
+# Our sysctl call may be run as normal user,
+# but /sbin is not always in normal users' PATH.
+if [[ -f /sbin/sysctl && -x /sbin/sysctl ]]; then sysctl_bin=/sbin/sysctl
+else sysctl_bin=sysctl  # If not found in sbin, hope
+fi
+
+export ROOT=`pwd`
+export NCORES=`nproc`
+
+while getopts ":ihag" opt; do
+  case ${opt} in
+    i )
+        export BUILD_IMAGE="1"
+        ;;
+    a )
+        export BUILD_APP="1"
+        ;;
+    g )
+        export FORCE_GTK2="1"
+        ;;
+    h ) echo "Usage: ./BuildLinuxImage.sh [-g][-i][-a][-h]"
+        echo "   -g: force gtk2 build"
+        echo "   -i: generate Appimage (optional)"
+	    echo "   -a: generate tgz (optional)"
+        echo "   -h: help"
+        exit 0
+        ;;
+  esac
+done
+
+if [[ -n "$BUILD_APP" ]]
+then
+    echo -e "\n[8/9] Generating Linux app ..."
+    # create directory and copy into it
+    if [ -d "package" ]
+    then
+        rm -rf package/*
+        rm -rf package/.* 2&>/dev/null
+    else
+        mkdir package
+    fi
+    mkdir package/bin
+
+    # copy Resources
+    cp -rf ../resources/ package/resources
+    cp -f src/prusa-slicer package/bin/@SLIC3R_APP_NAME@
+    ln -rs package/bin/@SLIC3R_APP_NAME@ package/bin/PrusaGcodeViewer
+    # remove unneeded po from resources
+    find package/resources/localization -name "*.po" -type f -delete
+    find package/resources/localization -name "P*.mo" -o -name "*.txt" -o -name "P*.pot" -type f -delete
+
+    # create bin
+    echo -e '#!/bin/bash\nDIR=$(readlink -f "$0" | xargs dirname)\nexport LD_LIBRARY_PATH="$DIR/bin"\nexec "$DIR/bin/@SLIC3R_APP_NAME@" "$@"' > package/@SLIC3R_APP_NAME@
+    chmod ug+x package/@SLIC3R_APP_NAME@
+    pushd package > /dev/null
+    if [[ -z "$FORCE_GTK2" ]]
+    then
+	tar -czvf ../@SLIC3R_APP_KEY@-@SLIC3R_VERSION@-GTK3-linux64.tgz .  &>/dev/null
+    else
+	tar -czvf ../@SLIC3R_APP_KEY@-@SLIC3R_VERSION@-GTK2-linux64.tgz .  &>/dev/null
+    fi
+
+    popd > /dev/null
+    echo -e "\n... done\n"
+fi
+
+if [[ -n "$BUILD_IMAGE" ]]
+then
+    echo -e "\n[9/9] Creating Appimage for distribution ...\n"
+    pushd package  > /dev/null
+    chmod +x ../src/build_appimage.sh
+    ../src/build_appimage.sh
+    popd  > /dev/null
+    if [[ -z "$FORCE_GTK2" ]]
+    then
+	mv package/"@SLIC3R_APP_KEY@_ubu64.AppImage" "@SLIC3R_APP_KEY@-@SLIC3R_VERSION@-GTK3-linux-x64.AppImage"
+    else
+	mv package/"@SLIC3R_APP_KEY@_ubu64.AppImage" "@SLIC3R_APP_KEY@-@SLIC3R_VERSION@-GTK2-linux-x64.AppImage"
+    fi
+
+    echo -e "\n... done\n"
+fi

--- a/src/platform/unix/build_appimage.sh.in
+++ b/src/platform/unix/build_appimage.sh.in
@@ -1,0 +1,30 @@
+#!/bin/sh
+APPIMAGETOOLURL="https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage"
+
+
+APP_IMAGE="@SLIC3R_APP_KEY@_ubu64.AppImage"
+
+wget ${APPIMAGETOOLURL} -O ../appimagetool.AppImage
+chmod +x ../appimagetool.AppImage
+
+sed -i -e 's#/usr#././#g' bin/@SLIC3R_APP_CMD@
+mv @SLIC3R_APP_CMD@ AppRun
+chmod +x AppRun
+
+cp resources/icons/@SLIC3R_APP_KEY@_192px.png @SLIC3R_APP_KEY@.png
+mkdir -p usr/share/icons/hicolor/192x192/apps
+cp resources/icons/@SLIC3R_APP_KEY@_192px.png usr/share/icons/hicolor/192x192/apps/@SLIC3R_APP_KEY@.png
+cat <<EOF > @SLIC3R_APP_KEY@.desktop
+[Desktop Entry]
+Name=@SLIC3R_APP_KEY@
+Exec=AppRun %F
+Icon=@SLIC3R_APP_KEY@
+Type=Application
+Categories=Utility;
+MimeType=model/stl;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;application/x-amf;
+EOF
+cp @SLIC3R_APP_NAME@ AppRun
+
+../appimagetool.AppImage .
+mv @SLIC3R_APP_KEY@-x86_64.AppImage ${APP_IMAGE}
+chmod +x ${APP_IMAGE}


### PR DESCRIPTION
This add build scripts for Linux and macOS. They are based on the scripts found in SuperSlicer and some options are added:

Usage: ./BuildLinux.sh [-h][-w][-u][-g][-b][-d][-s][-i]
   -h: this message
   -w: wipe build directories before building
   -u: only update dependency packets (optional and need sudo)
   -g: force gtk2 build
   -b: build in debug mode
   -d: build deps
   -s: build PrusaSlicer
   -i: generate appimage (optional)