### PR TITLE
Updated the copyright year to 2024

### DIFF
--- a/src/platform/msw/PrusaSlicer.rc.in
+++ b/src/platform/msw/PrusaSlicer.rc.in
@@ -12,7 +12,7 @@ PRODUCTVERSION @SLIC3R_RC_VERSION@
    VALUE "ProductName", "@SLIC3R_APP_NAME@"
    VALUE "ProductVersion", "@SLIC3R_BUILD_ID@"
    VALUE "InternalName", "@SLIC3R_APP_NAME@"
-   VALUE "LegalCopyright", "Copyright \251 2016-2023 Prusa Research, \251 2011-2018 Alessandro Ranellucci"
+   VALUE "LegalCopyright", "Copyright \251 2016-2024 Prusa Research, \251 2011-2018 Alessandro Ranellucci"
    VALUE "OriginalFilename", "prusa-slicer.exe"
   }
  }


### PR DESCRIPTION
Addresses issue [12399](https://github.com/prusa3d/PrusaSlicer/issues/12399)

Changed copyright year from 2023 to 2024.