### PR TITLE
build: disable lerc for libtiff

### DIFF
--- a/deps/+TIFF/TIFF.cmake
+++ b/deps/+TIFF/TIFF.cmake
@@ -10,6 +10,7 @@ add_cmake_project(TIFF
         -Dzstd:BOOL=OFF
         -Dpixarlog:BOOL=OFF
         -Dlibdeflate:BOOL=OFF
+        -Dlerc:BOOL=OFF
 )
 
 set(DEP_TIFF_DEPENDS ZLIB PNG JPEG OpenGL)


### PR DESCRIPTION
Final link failed due to missing Lerc library on hosts with lerc dev package installed.

Explicitly disable lerc for libtiff to avoid use of host libraries