### PR TITLE
Improve overhang perimeter printability with large extrusion widths

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -466,7 +466,7 @@ static std::vector<std::string> s_Preset_print_options {
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",
     "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width",
     "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width",
-    "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "infill_anchor", "infill_anchor_max", "bridge_flow_ratio",
+    "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "infill_anchor", "infill_anchor_max", "bridge_flow_ratio", "max_overhang_perimeter_length_before_enforcing_nozzle_extrusion_width",
     "elefant_foot_compensation", "xy_size_compensation", "resolution", "gcode_resolution", "arc_fitting",
     "wipe_tower", "wipe_tower_x", "wipe_tower_y",
     "wipe_tower_width", "wipe_tower_cone_angle", "wipe_tower_rotation_angle", "wipe_tower_brim_width", "wipe_tower_bridging", "single_extruder_multi_material_priming", "mmu_segmented_region_max_width",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -566,6 +566,21 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+    def = this->add("max_overhang_perimeter_length_before_enforcing_nozzle_extrusion_width", coFloat);
+    def->label = L("Reduce overhang perimeter extrusion width after");
+    def->category = L("Advanced");
+    def->tooltip = L("Reduces the overhang perimeter width after this length. "
+                   "When using large default extrusion widths, the risk of sagging is high, "
+                   "when the overhang section exceeds this length, the extrusion width for"
+                   "the layer region will be reduced to the nozzle diameter value. This causes "
+                   "that the separation between overhang perimeters is reduced and the amount of "
+                   "perimeters increased. If solid infil is also large, consider reducing the "
+                   "bridge flow ratio accordingly to also fill the gap between perimeters.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(30));
+
     def = this->add("bridge_speed", coFloat);
     def->label = L("Bridges");
     def->category = L("Speed");
@@ -4724,6 +4739,9 @@ std::string validate(const FullPrintConfig &cfg)
     // --bridge-flow-ratio
     if (cfg.bridge_flow_ratio <= 0)
         return "Invalid value for --bridge-flow-ratio";
+
+    if (cfg.max_overhang_perimeter_length_before_enforcing_nozzle_extrusion_width < 0)
+        return "Invalid value for --max-overhang-perimeter-length-before-enforcing-nozzle-extrusion-width";
 
     // extruder clearance
     if (cfg.extruder_clearance_radius <= 0)

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -608,6 +608,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  bottom_solid_layers))
     ((ConfigOptionFloat,                bottom_solid_min_thickness))
     ((ConfigOptionFloat,                bridge_flow_ratio))
+    ((ConfigOptionFloat,                max_overhang_perimeter_length_before_enforcing_nozzle_extrusion_width))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionEnum<InfillPattern>,  top_fill_pattern))
     ((ConfigOptionEnum<InfillPattern>,  bottom_fill_pattern))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1679,6 +1679,7 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Flow"));
         optgroup->append_single_option_line("bridge_flow_ratio");
+        optgroup->append_single_option_line("max_overhang_perimeter_length_before_enforcing_nozzle_extrusion_width");
 
         optgroup = page->new_optgroup(L("Slicing"));
         optgroup->append_single_option_line("slice_closing_radius");


### PR DESCRIPTION

I am not sure if this may be useful for PrusaSlicer, Slicer or derivatives. 

I ran into important sagging problems when using large Extrusion Widths (around 200% of nozzle size). I use those values because with relatively thin walls (2mm) it reduces substantially my print-time (as walls are covered with 2 perimeters instead of 4 perimeters).

What for?

When printing with relatively slower printers, such as MK3 (no input shaper), no substantial time savings can be achieved by increasing the speed without substantial loss of quality.

Reduction of print times can come from the remaining parameters defining the flow rate within the volumetric extrusion rate of the extruder (mm^3/s), i.e. extrusion width and layer height.

When a part has a substantial amount of relatively thin walls, increasing the extrusion width may lead to reducing the number of perimeters (due to wider lesser amount of perimeters) while keeping the speed constant.

What is the problem when using larger extrusion widths?

A MK3 can make reasonably good parts even at 200% extrussion width and even beyond. For a 0.4mm nozzle, those are extrusion widths of 0.8-0.9mm.

However, problems arise with overhang perimeters (perimeters used for bridging), as wider perimeters weight more, are spouted out of the relatively small hole of the nozzle energetically and sag. These are also a very poor support for the next layers.

Does thick bridges affect the outcome?

This problem arises both, with the "Thick bridges" enabled and disabled.

With it enabled, the relatively thick perimeters (EW=0.9mm) are reduced to the nozzle width (0.4mm) over the overhang area (and are printed properly). However, the spacing between briding perimeters remains that corresponding to an EW of 0.9mm, this provides a very poor support of the next layers, with often the material of the next layer being forced through or over the holes between wires (to the broad spacing).

With it disabled, the overhang perimeters are too thick themselves and sag, making it a poor support for the next layer.

So what is the parameter that may be tweaked?

The separation between overhanging perimeters can be reduced, so that it corresponds to the spacing when the EW is 0.4mm. Then the EW of this wires need to be reduced accordingly.

How can this be achieved?

One could provide more wires just over the overhang area. This would lead to a solution where the number of "perimeters" is different over the overhang area and the non-overhang are, within a single layer region. This appears to drive Slic3r crazy, as it wants full loops over a single layer region.

So what is the solution you propose?

The solution is to reduce the extrusion width of the whole region comprising the overhang area, so that the perimeter generator generates more lighter fine spaced perimeters, which are a better support for the next layers.

There appears to be no way to know whether a layer will have overhangs before creating the extrusions for a given layer. The solution, which is here only implemented for Arachne, is essentially to run Arachne and if there are overhangs, Arachne is interrupted and re-run with a reduced extrusion width. This mechanism is only enabled if the EW is higher than 1.2*the_nozzle_diameter, so not to interfere with traditional ways of slicing (where it would not have any effect anyway, as EW are relatively speaking not "large").

Example 1:
1. With MK3 default 0.2mm Quality profile:
![Bridge_test_default_0 2mm_quality](https://github.com/prusa3d/PrusaSlicer/assets/5249162/7dd81b15-b001-41af-b8c9-db674683c00f)
2. Default PrusaSlicer with parameters:
![SettingsLargeEW](https://github.com/prusa3d/PrusaSlicer/assets/5249162/86254bed-7b81-450b-a3f9-2d0c1a784c99)
![bridge_test_settingsLargeEW](https://github.com/prusa3d/PrusaSlicer/assets/5249162/5b086f02-f952-47b0-87e3-32473e9cd0fc)
3. New Mode in PrusaSlicer (h=0.3mm) w/o changes to "Bridge flow ratio":
![bridge_test_settingsLargeEW_newMode](https://github.com/prusa3d/PrusaSlicer/assets/5249162/a4ef99ba-bdbe-4619-8cd9-aeb4cfe0dda7)
4. New Mode in PrusaSlicer with "Bridge flow ratio" at 0.35%:
![bridge_test_settingsLargeEW_newMode_bride_flow_rate_0 35](https://github.com/prusa3d/PrusaSlicer/assets/5249162/6c54e874-7331-4b25-b07e-7b67a3135d5b)

Print time: 2h 29min vs 1h 17min

Volumetric flow rate:
![bridge_test_newMode_volumetric_flow_rate](https://github.com/prusa3d/PrusaSlicer/assets/5249162/af260a71-7050-4118-933b-e8b454600efe)

Example 2:
![image](https://github.com/prusa3d/PrusaSlicer/assets/5249162/b894bfdc-c908-4694-85b9-ef7bfb65ff0e)


