### PR TITLE
Remove unused variables and typedefs

### DIFF
--- a/src/admesh/connect.cpp
+++ b/src/admesh/connect.cpp
@@ -216,9 +216,7 @@ private:
 					// This is a match.  Record result in neighbors list.
 					match_neighbors(edge, *link->next);
 					// Delete the matched edge from the list.
-					HashEdge *temp = link->next;
 					link->next = link->next->next;
-					// pool.destroy(temp);
 #ifndef NDEBUG
 					++ this->freed;
 #endif /* NDEBUG */

--- a/src/admesh/normals.cpp
+++ b/src/admesh/normals.cpp
@@ -193,9 +193,7 @@ void stl_fix_normal_directions(stl_file *stl)
         		norm_sw[facet_num] = 1; // Record this one as being fixed.
         		++ checked;
       		}
-      		stl_normal *temp = head->next;	// Delete this facet from the list.
-      		head->next = head->next->next;
-      		// pool.destroy(temp);
+      		head->next = head->next->next; // Delete this facet from the list
     	} else { // If we ran out of facets to fix: All of the facets in this part have been fixed.
       		++ stl->stats.number_of_parts;
       		if (checked >= int(stl->stats.number_of_facets))

--- a/src/libigl/igl/connect_boundary_to_infinity.cpp
+++ b/src/libigl/igl/connect_boundary_to_infinity.cpp
@@ -25,7 +25,6 @@ IGL_INLINE void igl::connect_boundary_to_infinity(
   Eigen::Matrix<typename DerivedFO::Scalar,Eigen::Dynamic,Eigen::Dynamic> O;
   boundary_facets(F,O);
   FO.resize(F.rows()+O.rows(),F.cols());
-  typedef Eigen::Matrix<typename DerivedFO::Scalar,Eigen::Dynamic,1> VectorXI;
   FO.topLeftCorner(F.rows(),F.cols()) = F;
   FO.bottomLeftCorner(O.rows(),O.cols()) = O.rowwise().reverse();
   FO.bottomRightCorner(O.rows(),1).setConstant(inf_index);

--- a/src/libigl/igl/qslim_optimal_collapse_edge_callbacks.cpp
+++ b/src/libigl/igl/qslim_optimal_collapse_edge_callbacks.cpp
@@ -56,7 +56,7 @@ IGL_INLINE void igl::qslim_optimal_collapse_edge_callbacks(
     )> & post_collapse)
 {
   typedef std::tuple<Eigen::MatrixXd,Eigen::RowVectorXd,double> Quadric;
-  cost_and_placement = [&quadrics,&v1,&v2](
+  cost_and_placement = [&quadrics](
     const int e,
     const Eigen::MatrixXd & V,
     const Eigen::MatrixXi & /*F*/,

--- a/src/libslic3r/Algorithm/RegionExpansion.cpp
+++ b/src/libslic3r/Algorithm/RegionExpansion.cpp
@@ -259,7 +259,6 @@ std::vector<WaveSeed> wave_seeds(
     // Multiple pieces of a single src may intersect the same boundary.
     WaveSeeds out;
     out.reserve(segments.size());
-    int iseed = 0;
     for (const ClipperLib_Z::Path &path : segments) {
         assert(path.size() >= 2);
         const ClipperLib_Z::IntPoint &front = path.front();
@@ -267,7 +266,6 @@ std::vector<WaveSeed> wave_seeds(
         // Both ends of a seed segment are supposed to be inside a single boundary expolygon.
         // Thus as long as the seed contour is not closed, it should be open at a boundary point.
         assert((front == back && front.z() >= idx_boundary_end && front.z() < idx_src_end) || 
-            //(front.z() < 0 && back.z() < 0));
             // Hope that at least one end of an open polyline is clipped by the boundary, thus an intersection point is created.
             (front.z() < 0 || back.z() < 0));
         const Intersection *intersection = nullptr;
@@ -302,7 +300,6 @@ std::vector<WaveSeed> wave_seeds(
             if (boundary_id >= 0)
                 out.push_back({ uint32_t(front.z() - idx_boundary_end), uint32_t(boundary_id), ClipperZUtils::from_zpath(path) });
         }
-        ++ iseed;
     }
 
     if (sorted)

--- a/src/libslic3r/Fill/FillPlanePath.cpp
+++ b/src/libslic3r/Fill/FillPlanePath.cpp
@@ -153,7 +153,6 @@ static void generate_archimedean_chords(coord_t min_x, coord_t min_y, coord_t ma
     coordf_t b = 1./(2.*M_PI);
     coordf_t theta = 0.;
     coordf_t r = 1;
-    Pointfs out;
     //FIXME Vojtech: If used as a solid infill, there is a gap left at the center.
     output.add_point({ 0, 0 });
     output.add_point({ 1, 0 });
@@ -223,12 +222,10 @@ static void generate_hilbert_curve(coord_t min_x, coord_t min_y, coord_t max_x, 
 {
     // Minimum power of two square to fit the domain.
     size_t sz = 2;
-    size_t pw = 1;
     {
         size_t sz0 = std::max(max_x + 1 - min_x, max_y + 1 - min_y);
         while (sz < sz0) {
             sz = sz << 1;
-            ++ pw;
         }
     }
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -243,12 +243,10 @@ VendorProfile VendorProfile::from_ini(const ptree &tree, const boost::filesystem
 std::vector<std::string> VendorProfile::families() const
 {
     std::vector<std::string> res;
-    unsigned num_familiies = 0;
 
     for (auto &model : models) {
         if (std::find(res.begin(), res.end(), model.family) == res.end()) {
             res.push_back(model.family);
-            num_familiies++;
         }
     }
 

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -924,13 +924,11 @@ void LoopInterfaceProcessor::generate(SupportGeneratorLayerExtruded &top_contact
 
     // Grid size and bit shifts for quick and exact to/from grid coordinates manipulation.
     coord_t circle_grid_resolution = 1;
-    coord_t circle_grid_powerof2 = 0;
     {
         // epsilon to account for rounding errors
         coord_t circle_grid_resolution_non_powerof2 = coord_t(2. * circle_distance + 3.);
         while (circle_grid_resolution < circle_grid_resolution_non_powerof2) {
             circle_grid_resolution <<= 1;
-            ++ circle_grid_powerof2;
         }
     }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -477,12 +477,9 @@ void GLGizmoFdmSupports::update_from_model_object()
     const ModelObject* mo = m_c->selection_info()->model_object();
     m_triangle_selectors.clear();
 
-    int volume_id = -1;
     for (const ModelVolume* mv : mo->volumes) {
         if (! mv->is_model_part())
             continue;
-
-        ++volume_id;
 
         // This mesh does not account for the possible Z up SLA offset.
         const TriangleMesh* mesh = &mv->mesh();

--- a/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
@@ -221,12 +221,9 @@ void GLGizmoSeam::update_from_model_object()
     const ModelObject* mo = m_c->selection_info()->model_object();
     m_triangle_selectors.clear();
 
-    int volume_id = -1;
     for (const ModelVolume* mv : mo->volumes) {
         if (! mv->is_model_part())
             continue;
-
-        ++volume_id;
 
         // This mesh does not account for the possible Z up SLA offset.
         const TriangleMesh* mesh = &mv->mesh();

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -333,7 +333,7 @@ SCENARIO("Perimeters", "[Perimeters]")
             const double nozzle_dmr                 = config.opt<ConfigOptionFloats>("nozzle_diameter")->get_at(0);
             const double filament_dmr               = config.opt<ConfigOptionFloats>("filament_diameter")->get_at(0);
             const double bridge_mm_per_mm           = sqr(nozzle_dmr / filament_dmr) * config.opt_float("bridge_flow_ratio");
-            parser.parse_buffer(gcode, [&layer_speeds, &fan_speed, perimeter_speed, external_perimeter_speed, bridge_speed, nozzle_dmr, filament_dmr, bridge_mm_per_mm]
+            parser.parse_buffer(gcode, [&layer_speeds, &fan_speed, perimeter_speed, external_perimeter_speed, bridge_speed, bridge_mm_per_mm]
                 (Slic3r::GCodeReader &self, const Slic3r::GCodeReader::GCodeLine &line)
             {
                 if (line.cmd_is("M107"))


### PR DESCRIPTION
This removes a couple of variables, local typedefs and commented out code that the compiler was warning about.

This is conservative and does not remove e.g. unused functions, large commented out blocks, etc.