### PR TITLE
Touchpad friendly navigation

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -198,6 +198,9 @@ void AppConfig::set_defaults()
     if (get("reverse_mouse_wheel_zoom").empty())
         set("reverse_mouse_wheel_zoom", "0");
 
+    if (get("camera_navigation_style").empty())
+        set("camera_navigation_style", "default");          // allowed values - "default", "touchpad"
+
     if (get("show_splash_screen").empty())
         set("show_splash_screen", "1");
 

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -536,6 +536,7 @@ private:
     bool m_multisample_allowed;
     bool m_moving;
     bool m_tab_down;
+    bool m_camera_moving;
     ECursorType m_cursor_type;
     GLSelectionRectangle m_rectangle_selection;
     std::vector<int> m_hover_volume_idxs;
@@ -865,6 +866,10 @@ public:
     void on_mouse(wxMouseEvent& evt);
     void on_paint(wxPaintEvent& evt);
     void on_set_focus(wxFocusEvent& evt);
+
+    void on_camera_rotate(wxMouseEvent& evt, bool any_gizmo_active);
+    void on_camera_pan(wxMouseEvent& evt);
+    void start_camera_moving();
 
     Size get_canvas_size() const;
     Vec2d get_local_mouse_position() const;

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -867,9 +867,8 @@ public:
     void on_paint(wxPaintEvent& evt);
     void on_set_focus(wxFocusEvent& evt);
 
-    void on_camera_rotate(wxMouseEvent& evt, bool any_gizmo_active);
-    void on_camera_pan(wxMouseEvent& evt);
-    void start_camera_moving();
+    bool is_camera_rotate(const wxMouseEvent& evt) const;
+    bool is_camera_pan(const wxMouseEvent& evt) const;
 
     Size get_canvas_size() const;
     Vec2d get_local_mouse_position() const;

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -60,7 +60,13 @@ namespace Slic3r {
 		{"none",        NotifyReleaseNone},
 	};
 
+	static const t_config_enum_values s_keys_map_CameraNavStyle = {
+		{"default",     CameraNavDefault},
+		{"touchpad",    CameraNavTouchpad},
+	};
+
 	CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(NotifyReleaseMode)
+	CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(CameraNavStyle)
 
 namespace GUI {
 
@@ -457,6 +463,15 @@ void PreferencesDialog::build()
 	// Add "Camera" tab
 	m_optgroup_camera = create_options_tab(L("Camera"), tabs);
 	m_optgroup_camera->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+		if (opt_key == "camera_navigation_style") {
+			int val_int = boost::any_cast<int>(value);
+			for(const auto& item : s_keys_map_CameraNavStyle) {
+				if (item.second == val_int) {
+					m_values[opt_key] = item.first;
+					return;
+				}
+			}
+		}
 		if (auto it = m_values.find(opt_key);it != m_values.end()) {
 			m_values.erase(it); // we shouldn't change value, if some of those parameters were selected, and then deselected
 			return;
@@ -479,7 +494,21 @@ void PreferencesDialog::build()
 		L("If enabled, reverses the direction of zoom with mouse wheel"),
 		app_config->get_bool("reverse_mouse_wheel_zoom"));
 
+	append_enum_option<CameraNavStyle>(m_optgroup_camera, "camera_navigation_style",
+		L("Camera navigation style"),
+		L("Style of camera controls in 3D view: Default or Touchpad friendly"),
+		new ConfigOptionEnum<CameraNavStyle>(static_cast<CameraNavStyle>(s_keys_map_CameraNavStyle.at(app_config->get("camera_navigation_style")))),
+		{ { "default", L("Default") },
+		  { "touchpad", L("Touchpad") }
+		});
+
+
+
 	activate_options_tab(m_optgroup_camera);
+
+	// set Field for camera_navigation_style to its value to activate the object
+	boost::any val = s_keys_map_CameraNavStyle.at(app_config->get("camera_navigation_style"));
+	m_optgroup_camera->get_field("camera_navigation_style")->set_value(val, false);
 
 	// Add "GUI" tab
 	m_optgroup_gui = create_options_tab(L("GUI"), tabs);

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -32,6 +32,11 @@ namespace Slic3r {
 		NotifyReleaseNone
 	};
 
+	enum CameraNavStyle {
+		CameraNavDefault,
+		CameraNavTouchpad,
+	};
+
 namespace GUI {
 
 class ConfigOptionsGroup;


### PR DESCRIPTION
Implement touchpad friendly 3D scene navigation style inspired by FreeCAD.

This mode simplifies 3D scene rotation/panning on laptops allowing one-finger operation:

- Rotate: Alt+move
- Pan: Shift+Move