### PR TITLE
Added a docker build script to easily build Ubuntu 20.04 binaries using docker on any Linux distro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
+/prusa-slicer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+
+
+from   ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+run apt update -y
+run apt-get install  -y \
+	git \
+	build-essential \
+	autoconf \
+	cmake \
+	libglu1-mesa-dev \
+	libgtk-3-dev \
+	libdbus-1-dev
+
+ENV LANG=C.UTF-8

--- a/docker/build-for-ubuntu-20.04-using-docker.sh
+++ b/docker/build-for-ubuntu-20.04-using-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CD=$(dirname $(readlink -f $0))
+cd "$CD"
+
+docker build . -t prusa-slicer && \
+docker rm -f prusa-build 2>/dev/null && \
+docker run --rm -ti --name prusa-build \
+	-v "$CD/../":/data/ \
+	prusa-slicer \
+/bin/bash -c "	cd /data/deps && \
+		mkdir -p build && \
+		cd build && \
+		cmake .. -DDEP_WX_GTK3=ON && \
+		(make -j 8 || /bin/bash) && \
+		cd /data/ && \
+		mkdir -p build && \
+		cd build && \
+		cmake .. -DSLIC3R_STATIC=1 -DSLIC3R_GTK=3 -DSLIC3R_PCH=OFF -DCMAKE_PREFIX_PATH=/data/deps/build/destdir/usr/local -DSLIC3R_GUI=1 -DSLIC3R_STATIC=1  && \
+		make -j 8 && \
+		cp /data/build/src/prusa-slicer /data/ \
+"


### PR DESCRIPTION
just run the script with docker installed, and you should get a "prusa-slicer" executable file at the root of the git folder. Just execute it and prusa-slicer should run, as long as your linux distro is newer than Ubuntu 20.04. (it doesn't need to be Ubuntu... just newer than Ubuntu 20.04)

This should help anyone like me who wants to build and run it in linux.