### PR TITLE
[cosmetic] simplify macro to improve code readability

### DIFF
--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -2407,7 +2407,7 @@ void ConfigWizard::priv::load_pages()
     btn_finish->Enable(any_fff_selected || any_sla_selected || custom_printer_selected || custom_printer_in_bundle);
 
     index->add_page(page_update);
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
     index->add_page(page_downloader);
 #endif
     index->add_page(page_reload_from_disk);
@@ -2776,7 +2776,7 @@ void ConfigWizard::priv::on_3rdparty_install(const VendorProfile *vendor, bool i
 bool ConfigWizard::priv::on_bnt_finish()
 {
     wxBusyCursor wait;
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
     if (!page_downloader->on_finish_downloader()) {
         index->go_to(page_downloader);
         return false;
@@ -3405,7 +3405,7 @@ ConfigWizard::ConfigWizard(wxWindow *parent)
 
     
     p->add_page(p->page_update   = new PageUpdate(this));
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
     p->add_page(p->page_downloader = new PageDownloader(this));
 #endif
     p->add_page(p->page_reload_from_disk = new PageReloadFromDisk(this));

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -134,7 +134,7 @@ void PreferencesDialog::show(const std::string& highlight_opt_key /*= std::strin
 
 	if (wxGetApp().is_editor()) {
 		auto app_config = get_app_config();
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
 		downloader->set_path_name(app_config->get("url_downloader_dest"));
 		downloader->allow(!app_config->has("downloader_url_registered") || app_config->get_bool("downloader_url_registered"));
 #endif
@@ -644,7 +644,7 @@ void PreferencesDialog::build()
 			//L("If enabled, the descriptions of configuration parameters in settings tabs wouldn't work as hyperlinks. "
 			//  "If disabled, the descriptions of configuration parameters in settings tabs will work as hyperlinks."),
 			app_config->get_bool("suppress_hyperlinks"));
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
 		append_bool_option(m_optgroup_other, "downloader_url_registered",
 			L("Allow downloads from Printables.com"),
 			L("If enabled, PrusaSlicer will be allowed to download from Printables.com"),
@@ -652,7 +652,7 @@ void PreferencesDialog::build()
 #endif
 
 		activate_options_tab(m_optgroup_other);
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
 		create_downloader_path_sizer();
 #endif
 		create_settings_font_widget();
@@ -759,7 +759,7 @@ void PreferencesDialog::update_ctrls_alignment()
 
 void PreferencesDialog::accept(wxEvent&)
 {
-#if !defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
+#if !(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))
 	if(wxGetApp().is_editor()) {
 		if (const auto it = m_values.find("downloader_url_registered"); it != m_values.end())
 			downloader->allow(it->second == "1");


### PR DESCRIPTION
Slightly cosmetic change to reduce macro conditions to improve readability:
!A || (A & B) -> if !(A & !B) 
i.e.
!defined(__linux__) || (defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION))
-> 
!(defined(__linux__) && !defined(SLIC3R_DESKTOP_INTEGRATION))