### PR TITLE
Fix skirt separation math.

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1159,7 +1159,7 @@ void Print::_make_skirt()
 
     // Initial offset of the brim inner edge from the object (possible with a support & raft).
     // The skirt will touch the brim if the brim is extruded.
-    auto   distance = float(scale_(m_config.skirt_distance.value) - spacing/2.);
+    auto   distance = float(scale_(m_config.skirt_distance.value - spacing/2.));
     // Draw outlines from outside to inside.
     // Loop while we have less skirts than required or any extruder hasn't reached the min length if any.
     std::vector<coordf_t> extruded_length(extruders.size(), 0.);


### PR DESCRIPTION
In the code as-is, the half-width of the skirt extrusion is added to the user-specified distance.  However, the user-specified distance is scaled to internal units while the half-width is not, resulting in math like "250000 + 0.125" for a skirt extrusion of 0.25mm

The fix is to include the half-width inside the scaling function so that it is also scaled, resulting in math like "250000 + 125000".

The user-visible result is that if you have no brim and set the skirt spacing to zero, the skirt will actually touch the model and not be offset by half an extrusion width.