### PR TITLE
Show name of file being reloaded on all platforms, not just MacOS

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3844,10 +3844,7 @@ void Plater::priv::reload_from_disk()
         // ask user to select the missing file
         fs::path search = missing_input_paths.back();
         wxString title = _L("Please select the file to reload");
-#if defined(__APPLE__)
-        title += " (" + from_u8(search.filename().string()) + ")";
-#endif // __APPLE__
-        title += ":";
+        title += " (" + from_u8(search.filename().string()) + "):";
         wxFileDialog dialog(q, title, "", from_u8(search.filename().string()), file_wildcards(FT_MODEL), wxFD_OPEN | wxFD_FILE_MUST_EXIST);
         if (dialog.ShowModal() != wxID_OK)
             return;


### PR DESCRIPTION
I filed a feature request for this a while ago, #12146, but just now made the change. I have no idea why this was limited to only MacOS, but it works fine on Linux with GTK3. I don't have a Windows system to build and test this on so if it breaks something there it can be disabled specifically for Windows.