### PR TITLE
Remove boost/filesystem/convenience.hpp include

### DIFF
--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -35,7 +35,6 @@
 #include <pwd.h>
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/process.hpp>
 #endif
 


### PR DESCRIPTION
[Boost 1.85 removed filesystem/convenience.hpp](https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html)

Commit 611afd97895a092bc226c11b373b1451cf0f4171 already replaced the deprecated function `basename()` consumed from it, but the header include is still there and causes a build with boost 1.85 to fail.