### PR TITLE
Variable layer height  - respect height range modifier.

### DIFF
--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -308,6 +308,13 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
         }
         */
         
+        for (auto const& [range,options] : object.layer_config_ranges){
+            if ( print_z >= range.first && print_z <= range.second) {
+                    height = options.opt_float("layer_height");
+                    break;
+            };
+        };
+
         layer_height_profile.push_back(print_z);
         layer_height_profile.push_back(height);
         print_z += height;


### PR DESCRIPTION
Keep manually set layer height while using adaptive layer height:

![image](https://github.com/prusa3d/PrusaSlicer/assets/8691781/105749d2-d4d8-42b8-b9d5-02bc1e863625)
