### PR TITLE
don't call show_downloader_registration_dialog() if  SLIC3R_DESKTOP_INTEGRATION = 0

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3329,12 +3329,12 @@ bool GUI_App::config_wizard_startup()
         run_wizard(ConfigWizard::RR_DATA_LEGACY);
         return true;
     } 
-#ifndef __APPLE__    
+#if !defined(__APPLE__) && ((defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)) || !defined(__linux__))
     else if (is_editor() && m_last_app_conf_lower_version && app_config->get_bool("downloader_url_registered")) {
         show_downloader_registration_dialog();
         return true;
     }
-#endif
+#endif //!defined(__APPLE__) && ((defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)) || !defined(__linux__))
     return false;
 }
 


### PR DESCRIPTION
This complete https://github.com/prusa3d/PrusaSlicer/pull/12252 and makes linux builds with SLIC3R_DESKTOP_INTEGRATION = 0 to behave exactly like MacOS builds