### PR TITLE
add missing includes

### DIFF
--- a/src/slic3r/GUI/UserAccountCommunication.cpp
+++ b/src/slic3r/GUI/UserAccountCommunication.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/log/trivial.hpp>
 #include <boost/beast/core/detail/base64.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <curl/curl.h>
 #include <string>
 

--- a/src/slic3r/GUI/UserAccountCommunication.hpp
+++ b/src/slic3r/GUI/UserAccountCommunication.hpp
@@ -12,6 +12,8 @@
 #include <mutex>
 #include <memory>
 
+#include <wx/timer.h>
+
 namespace Slic3r {
 namespace GUI {
 class CodeChalengeGenerator


### PR DESCRIPTION
Build fail without this includes (at least with gcc 13.2)