### PR TITLE
fix for tooltips in gizmos for macos

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -26,6 +26,13 @@
 
 namespace Slic3r::GUI {
 
+static const std::string CTRL_STR =
+#ifdef __APPLE__
+"⌘ + "
+#else
+"Ctrl + "
+#endif //__APPLE__
+;
 
 
 void GLGizmoFdmSupports::on_shutdown()
@@ -324,7 +331,7 @@ void GLGizmoFdmSupports::on_render_input_window(float x, float y, float bottom_l
     auto clp_dist = float(m_c->object_clipper()->get_position());
     ImGui::SameLine(sliders_left_width);
     ImGui::PushItemWidth(window_width - sliders_left_width - slider_icon_width);
-    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L("Ctrl + Mouse wheel")))
+    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L(CTRL_STR + "Mouse wheel")))
         m_c->object_clipper()->set_position_by_ratio(clp_dist, true);
 
     ImGui::Separator();

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -23,6 +23,13 @@
 #include <GL/glew.h>
 
 namespace Slic3r::GUI {
+istatic const std::string CTRL_STR =
+#ifdef __APPLE__
+"⌘ + "
+#else
+"Ctrl + "
+#endif //__APPLE__
+;
 
 static inline void show_notification_extruders_limit_exceeded()
 {
@@ -477,7 +484,7 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
     auto clp_dist = float(m_c->object_clipper()->get_position());
     ImGui::SameLine(sliders_left_width);
     ImGui::PushItemWidth(window_width - sliders_left_width - slider_icon_width);
-    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L("Ctrl + Mouse wheel")))
+    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L(CTRL_STR+"Mouse wheel")))
         m_c->object_clipper()->set_position_by_ratio(clp_dist, true);
 
     ImGui::Separator();

--- a/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSeam.cpp
@@ -20,6 +20,13 @@
 namespace Slic3r::GUI {
 
 
+istatic const std::string CTRL_STR =
+#ifdef __APPLE__
+"⌘ + "
+#else
+"Ctrl + "
+#endif //__APPLE__
+;
 
 void GLGizmoSeam::on_shutdown()
 {
@@ -168,7 +175,7 @@ void GLGizmoSeam::on_render_input_window(float x, float y, float bottom_limit)
     auto clp_dist = float(m_c->object_clipper()->get_position());
     ImGui::SameLine(sliders_left_width);
     ImGui::PushItemWidth(window_width - sliders_left_width - slider_icon_width);
-    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L("Ctrl + Mouse wheel")))
+    if (m_imgui->slider_float("##clp_dist", &clp_dist, 0.f, 1.f, "%.2f", 1.0f, true, _L(CTRL_STR+"Mouse wheel")))
         m_c->object_clipper()->set_position_by_ratio(clp_dist, true);
 
     ImGui::Separator();


### PR DESCRIPTION
![image](https://github.com/prusa3d/PrusaSlicer/assets/1230966/1e58a11a-30d6-4a26-a4bf-22ffb3092d40)

It is not correct on the Mac os 

closes #12898 