### PR TITLE
GLEW: Set base address only in 32bit

### DIFF
--- a/deps/+GLEW/GLEW.cmake
+++ b/deps/+GLEW/GLEW.cmake
@@ -3,6 +3,7 @@ add_cmake_project(
   URL https://sourceforge.net/projects/glew/files/glew/2.2.0/glew-2.2.0.zip
   URL_HASH SHA256=a9046a913774395a095edcc0b0ac2d81c3aacca61787b39839b941e9be14e0d4
   SOURCE_SUBDIR build/cmake
+  PATCH_COMMAND COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/GLEW.patch
   CMAKE_ARGS
     -DBUILD_UTILS=OFF
 )

--- a/deps/+GLEW/GLEW.patch
+++ b/deps/+GLEW/GLEW.patch
@@ -1,0 +1,13 @@
+--- ./build/cmake/CMakeLists.txt	2024-07-16 21:32:44.530717300 -0600
++++ ./build/cmake/CMakeLists.txt	2024-07-16 21:32:14.245830500 -0600
+@@ -115,7 +115,9 @@
+   # add options from visual studio project
+   target_compile_definitions (glew PRIVATE "GLEW_BUILD;VC_EXTRALEAN")
+   target_compile_definitions (glew_s PRIVATE "GLEW_STATIC;VC_EXTRALEAN")
+-  target_link_libraries (glew LINK_PRIVATE -BASE:0x62AA0000)
++  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i?86|x86|x86_32)$")
++    target_link_libraries (glew LINK_PRIVATE -BASE:0x62AA0000)
++  endif()
+   # kill security checks which are dependent on stdlib
+   target_compile_options (glew PRIVATE -GS-)
+   target_compile_options (glew_s PRIVATE -GS-)


### PR DESCRIPTION
Part of fix for #13107

See https://github.com/nigels-com/glew/pull/384