### PR TITLE
OpenEXR: Do no use x86 intrinsics in ARM64

### DIFF
--- a/deps/+OpenEXR/OpenEXR.patch
+++ b/deps/+OpenEXR/OpenEXR.patch
@@ -28,3 +28,15 @@
  #include <ImfMisc.h>
  #include <ImfHeader.h>
  #include <ImfAttribute.h>
+
+--- ../OpenEXR-orig/OpenEXR/IlmImf/ImfSimd.h	2021-02-12 17:56:19.000000000 +0100
++++ ./OpenEXR/IlmImf/ImfSimd.h	2023-06-01 13:22:15.777480000 +0200
+@@ -45,7 +45,7 @@
+ 
+ 
+ // GCC and Visual Studio SSE2 compiler flags
+-#if defined __SSE2__ || (_MSC_VER >= 1300 && !_M_CEE_PURE)
++#if defined __SSE2__ || (_MSC_VER >= 1300 && !_M_CEE_PURE) && !defined(_M_ARM64)
+     #define IMF_HAVE_SSE2 1
+ #endif
+ 


### PR DESCRIPTION
Part of fix for https://github.com/prusa3d/PrusaSlicer/issues/13107
