### PR TITLE
Boost: Add necessary changes for Windows on ARM64

### DIFF
--- a/deps/+Boost/Boost.cmake
+++ b/deps/+Boost/Boost.cmake
@@ -1,6 +1,7 @@
 
 set(_context_abi_line "")
 set(_context_arch_line "")
+set(_context_implementation_line "-DBOOST_CONTEXT_IMPLEMENTATION:STRING=fcontext")
 if (APPLE AND CMAKE_OSX_ARCHITECTURES)
     if (CMAKE_OSX_ARCHITECTURES MATCHES "x86")
         set(_context_abi_line "-DBOOST_CONTEXT_ABI:STRING=sysv")
@@ -9,6 +10,10 @@ if (APPLE AND CMAKE_OSX_ARCHITECTURES)
     endif ()
     set(_context_arch_line "-DBOOST_CONTEXT_ARCHITECTURE:STRING=${CMAKE_OSX_ARCHITECTURES}")
 endif ()
+
+if (MSVC AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$")
+    set(_context_implementation_line "-DBOOST_CONTEXT_IMPLEMENTATION=winfib")
+endif()
 
 add_cmake_project(Boost
     URL "https://github.com/boostorg/boost/releases/download/boost-1.83.0/boost-1.83.0.zip"
@@ -20,6 +25,7 @@ add_cmake_project(Boost
         -DBUILD_TESTING:BOOL=OFF
         "${_context_abi_line}"
         "${_context_arch_line}"
+        "${_context_implementation_line}"
 )
 
 set(DEP_Boost_DEPENDS ZLIB)

--- a/deps/+Boost/Boost.cmake
+++ b/deps/+Boost/Boost.cmake
@@ -19,8 +19,9 @@ add_cmake_project(Boost
     URL "https://github.com/boostorg/boost/releases/download/boost-1.83.0/boost-1.83.0.zip"
     URL_HASH SHA256=9effa3d7f9d92b8e33e2b41d82f4358f97ff7c588d5918720339f2b254d914c6
     LIST_SEPARATOR |
+    PATCH_COMMAND COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/Boost.patch
     CMAKE_ARGS
-        -DBOOST_EXCLUDE_LIBRARIES:STRING=contract|fiber|numpy|stacktrace|wave|test
+        -DBOOST_EXCLUDE_LIBRARIES:STRING=contract|fiber|numpy|stacktrace|wave|test|accumulators
         -DBOOST_LOCALE_ENABLE_ICU:BOOL=OFF # do not link to libicu, breaks compatibility between distros
         -DBUILD_TESTING:BOOL=OFF
         "${_context_abi_line}"

--- a/deps/+Boost/Boost.patch
+++ b/deps/+Boost/Boost.patch
@@ -1,0 +1,29 @@
+--- ./libs/json/include/boost/json/detail/charconv/detail/emulated128-orig.hpp	2024-07-16 21:55:14.679931600 -0600
++++ ./libs/json/include/boost/json/detail/charconv/detail/emulated128.hpp	2024-07-16 21:56:13.328860900 -0600
+@@ -58,7 +58,7 @@
+ 
+ static inline std::uint64_t umul64(std::uint32_t x, std::uint32_t y) noexcept
+ {
+-#if defined(BOOST_JSON_HAS_MSVC_32BIT_INTRINSICS)
++#if defined(BOOST_JSON_HAS_MSVC_32BIT_INTRINSICS) && !defined(_M_ARM64)
+     return __emulu(x, y);
+ #else
+     return x * static_cast<std::uint64_t>(y);
+@@ -73,7 +73,7 @@
+     auto result = static_cast<boost::uint128_type>(x) * static_cast<boost::uint128_type>(y);
+     return {static_cast<std::uint64_t>(result >> 64), static_cast<std::uint64_t>(result)};
+ 
+-    #elif defined(BOOST_JSON_HAS_MSVC_64BIT_INTRINSICS)
++    #elif defined(BOOST_JSON_HAS_MSVC_64BIT_INTRINSICS) && !defined(_M_ARM64)
+ 
+     std::uint64_t high;
+     std::uint64_t low = _umul128(x, y, &high);
+@@ -113,7 +113,7 @@
+     auto result = static_cast<boost::uint128_type>(x) * static_cast<boost::uint128_type>(y);
+     return static_cast<std::uint64_t>(result >> 64);
+ 
+-    #elif defined(BOOST_JSON_HAS_MSVC_64BIT_INTRINSICS)
++    #elif defined(BOOST_JSON_HAS_MSVC_64BIT_INTRINSICS) && !defined(_M_ARM64)
+ 
+     return __umulh(x, y);
+ 


### PR DESCRIPTION
Boost.Context does not have the ARM64 implementation in Assembly for Windows Portable Executables.

Use the Windows Fibers implementation instead (only for ARM64)

Part of fix for https://github.com/prusa3d/PrusaSlicer/issues/13107