### PR TITLE
Addressing widen is not a member of boost::nowide

### DIFF
--- a/src/slic3r/GUI/UserAccountCommunication.cpp
+++ b/src/slic3r/GUI/UserAccountCommunication.cpp
@@ -13,6 +13,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/nowide/cstdio.hpp>
 #include <boost/nowide/fstream.hpp>
+#include <boost/nowide/convert.hpp>
 #include <curl/curl.h>
 #include <string>
 


### PR DESCRIPTION
Addressing the `‘widen’ is not a member of ‘boost::nowide’` compile error.

```
/builddir/build/BUILD/PrusaSlicer-version_2.8.0/src/slic3r/GUI/UserAccountCommunication.cpp:97:46: error: ‘widen’ is not a member of ‘boost::nowide’
   97 |     const wxString username = boost::nowide::widen(usr);
      |                                              ^~~~~
/builddir/build/BUILD/PrusaSlicer-version_2.8.0/src/slic3r/GUI/UserAccountCommunication.cpp:98:49: error: ‘widen’ is not a member of ‘boost::nowide’
   98 |     const wxSecretValue password(boost::nowide::widen(psswd));
      |                                                 ^~~~~
```

Fixes https://github.com/prusa3d/PrusaSlicer/issues/13241.