### PR TITLE
Add minimum flow rates for spiral vase transitsions

### DIFF
--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -76,13 +76,16 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
     const bool transition_out = last_layer && m_config.use_relative_e_distances.value;
     const bool smooth_spiral  = m_smooth_spiral && m_config.use_relative_e_distances.value;
 
+    const float starting_flowrate  = float(m_config.spiral_vase_starting_flow_rate.value / 100);
+    const float finishing_flowrate = float(m_config.spiral_vase_finishing_flow_rate.value / 100);
+
     const AABBTreeLines::LinesDistancer previous_layer_distancer = get_layer_distancer(m_previous_layer);
     Vec2f                               last_point               = m_previous_layer.empty() ? Vec2f::Zero() : m_previous_layer.back();
     float                               len                      = 0.f;
 
     std::string        new_gcode, transition_gcode;
     std::vector<Vec2f> current_layer;
-    m_reader.parse_buffer(gcode, [z, total_layer_length, layer_height, transition_in, transition_out, smooth_spiral, max_xy_smoothing = m_max_xy_smoothing,
+    m_reader.parse_buffer(gcode, [z, total_layer_length, layer_height, transition_in, transition_out,starting_flowrate, finishing_flowrate, smooth_spiral, max_xy_smoothing = m_max_xy_smoothing,
                                   &len, &last_point, &new_gcode, &transition_gcode, &current_layer, &previous_layer_distancer]
         (GCodeReader &reader, GCodeReader::GCodeLine line) {
         if (line.cmd_is("G1")) {
@@ -96,15 +99,19 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
                 if (const float dist_XY = line.dist_XY(reader); dist_XY > 0 && line.extruding(reader)) { // Exclude wipe and retract
                     len += dist_XY;
                     const float factor = len / total_layer_length;
-                    if (transition_in)
-                        // Transition layer, interpolate the amount of extrusion from zero to the final value.
-                        line.set(reader, E, line.e() * factor, 5);
+                    if (transition_in) {
+                        // Transition layer, interpolate the amount of extrusion starting from spiral_vase_starting_flow_rate to 100%.
+                        float starting_e_factor = starting_flowrate + (factor * (1.f - starting_flowrate));
+                        line.set(reader, E, line.e() * starting_e_factor, 5);
+                    }
                     else if (transition_out) {
                         // We want the last layer to ramp down extrusion, but without changing z height!
                         // So clone the line before we mess with its Z and duplicate it into a new layer that ramps down E
                         // We add this new layer at the very end
+                        // As with transition_in, the amount is ramped down from 100% to spiral_vase_finishing_flow_rate
                         GCodeReader::GCodeLine transition_line(line);
-                        transition_line.set(reader, E, line.e() * (1.f - factor), 5);
+                        float finishing_e_factor = finishing_flowrate + ((1.f -factor) * (1.f - finishing_flowrate));
+                        transition_line.set(reader, E, line.e() * finishing_e_factor, 5);
                         transition_gcode += transition_line.raw() + '\n';
                     }
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -445,7 +445,7 @@ void Preset::set_visible_from_appconfig(const AppConfig &app_config)
 }
 
 static std::vector<std::string> s_Preset_print_options {
-    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "slice_closing_radius", "slicing_mode",
+    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "spiral_vase_starting_flow_rate","spiral_vase_finishing_flow_rate", "slice_closing_radius", "slicing_mode",
     "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
     "extra_perimeters", "extra_perimeters_on_overhangs", "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",
     "seam_position","staggered_inner_seams", "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2784,6 +2784,28 @@ void PrintConfigDef::init_fff_params()
                    "It won't work when printing more than one single object.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("spiral_vase_starting_flow_rate", coPercent);
+    def->label = "Spiral starting flow rate";
+    def->tooltip = L("Sets the starting flow rate while transitioning from the last bottom layer to the spiral. "
+                    "Normally the spiral transition scales the flow ratio from 0% to 100% during the first loop "
+                    "which can in some cases lead to under extrusion at the start of the spiral.");
+    def->sidetext = L("%");
+    def->min = 0;
+    def->max = 100;
+    def->set_default_value(new ConfigOptionPercent(0));
+    def->mode = comAdvanced;
+
+    def = this->add("spiral_vase_finishing_flow_rate", coPercent);
+    def->label = "Spiral finishing flow rate";
+    def->tooltip = L("Sets the finishing flow rate while ending the spiral. "
+                    "Normally the spiral transition scales the flow ratio from 100% to 0% during the last loop "
+                    "which can in some cases lead to under extrusion at the end of the spiral.");
+    def->sidetext = L("%");
+    def->min = 0;
+    def->max = 100;
+    def->set_default_value(new ConfigOptionPercent(0));
+    def->mode = comAdvanced;
+
     def = this->add("standby_temperature_delta", coInt);
     def->label = L("Temperature variation");
     // TRN PrintSettings : "Ooze prevention" > "Temperature variation"

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -834,6 +834,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
+    ((ConfigOptionPercent,             spiral_vase_finishing_flow_rate))
+    ((ConfigOptionPercent,             spiral_vase_starting_flow_rate))
 )
 
 static inline std::string get_extrusion_axis(const GCodeConfig &cfg)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -345,6 +345,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("min_feature_size", have_arachne);
     toggle_field("min_bead_width", have_arachne);
     toggle_field("thin_walls", !have_arachne);
+
+    toggle_field("spiral_vase_starting_flow_rate", has_spiral_vase);
+    toggle_field("spiral_vase_finishing_flow_rate", has_spiral_vase);
 }
 
 void ConfigManipulation::toggle_print_sla_options(DynamicPrintConfig* config)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1677,6 +1677,10 @@ void TabPrint::build()
         optgroup->append_single_option_line("min_bead_width");
         optgroup->append_single_option_line("min_feature_size");
 
+        optgroup = page->new_optgroup(L("Spiral vase"));
+        optgroup->append_single_option_line("spiral_vase_starting_flow_rate");
+        optgroup->append_single_option_line("spiral_vase_finishing_flow_rate");
+
     page = add_options_page(L("Output options"), "output+page_white");
         optgroup = page->new_optgroup(L("Sequential printing"));
         optgroup->append_single_option_line("complete_objects", "sequential-printing_124589");


### PR DESCRIPTION
Currently when starting the spiral vase the extrusion rate is ramped from 0 to 100% on the first layer and from 100% to 0% on the last layer. In some cases it can lead to underextrusion at the beginning and end of the spiral.

This change adds minimum flow rate options for the beginning and the end of the vase. This means that instead of ramping from 0% to 100% it instead ramps from for example 20% to 100%.

This issue has been reported in SuperSlicer but the same issue occurs in PrusaSlicer aswell.

https://github.com/supermerill/SuperSlicer/issues/4195

The behaviour of this feature can be tested by viewing the volumetric flow rate of a flow-rate limited slice. Here are two screenshots one with the existing 0% starting points and one with 70% and 40% starting points on the start and end of the spiral.

![0 %](https://github.com/user-attachments/assets/c2d73ea2-154a-429a-b81c-c676be298b18)
![7040 %](https://github.com/user-attachments/assets/1abf347a-04f2-4701-bdcf-87ad7ea1ba11)

