### PR TITLE
fix Ultimaker compatible_printers_condition

### DIFF
--- a/resources/profiles/Ultimaker.ini
+++ b/resources/profiles/Ultimaker.ini
@@ -211,22 +211,22 @@ top_solid_layers = 4
 
 [print:0.10mm FINE @ULTIMAKER]
 inherits = *0.10mm*
-compatible_printers_condition = printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline" and nozzle_diameter[0]==0.4
+compatible_printers_condition = (printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline") and nozzle_diameter[0]==0.4
 
 [print:0.12mm DETAIL @ULTIMAKER]
 inherits = *0.12mm*
 support_material_extrusion_width = 0.38
-compatible_printers_condition = printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline" and nozzle_diameter[0]==0.4
+compatible_printers_condition = (printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline") and nozzle_diameter[0]==0.4
 
 [print:0.20mm NORMAL @ULTIMAKER]
 inherits = *0.20mm*
 support_material_extrusion_width = 0.38
-compatible_printers_condition = printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline" and nozzle_diameter[0]==0.4
+compatible_printers_condition = (printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline") and nozzle_diameter[0]==0.4
 
 [print:0.25mm DRAFT @ULTIMAKER]
 inherits = *0.25mm*
 support_material_extrusion_width = 0.38
-compatible_printers_condition = printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline" and nozzle_diameter[0]==0.4
+compatible_printers_condition = (printer_model=="ULTIMAKER2" or printer_model=="ULTIMAKERSline") and nozzle_diameter[0]==0.4
 
 # Common filament preset
 [filament:*common*]


### PR DESCRIPTION
Logical `and` has higher associativity than logical `or`, therefore the previous conditions were equivalent to having parentheses like this:

```ini
compatible_printers_condition = printer_model=="ULTIMAKER2" or (printer_model=="ULTIMAKERSline" and nozzle_diameter[0]==0.4)
```

which ignores nozzle_diameter on Ultimaker 2.