### PR TITLE
Fix bug ShortestPath.cpp

### DIFF
--- a/src/libslic3r/ShortestPath.cpp
+++ b/src/libslic3r/ShortestPath.cpp
@@ -1951,14 +1951,15 @@ static inline void improve_ordering_by_two_exchanges_with_segment_flipping(Polyl
 	for (const FlipEdge &edge : edges) {
 		Polyline &pl = polylines[edge.source_index];
 		out.emplace_back(std::move(pl));
-		if (edge.p2 == pl.first_point().cast<double>()) {
+		if (edge.p2 == out.back().first_point().cast<double>()) {
 			// Polyline is flipped.
 			out.back().reverse();
 		} else {
 			// Polyline is not flipped.
-			assert(edge.p1 == pl.first_point().cast<double>());
+			assert(edge.p1 == out.back().first_point().cast<double>());
 		}
 	}
+	polylines = out;
 
 #ifndef NDEBUG
 	double cost_final = cost();


### PR DESCRIPTION
Accessing a moved object.
Also this method create an unused "out" variable by removing from the parameter. I guess It should update the parameter object?
Anyway, seems very wrong