### PR TITLE
Lifts tool before tool change to avoid material contamination. Fixes #12694

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -453,6 +453,8 @@ private:
     bool                                m_second_layer_things_done;
     // G-code that is due to be written before the next extrusion
     std::string                         m_pending_pre_extrusion_gcode;
+    // Tool should be lowered before the next extrusion
+    std::optional<float>                m_pending_pre_extrusion_lower;
     // Pointer to currently exporting PrintObject and instance index.
     GCode::PrintObjectInstance          m_current_instance;
 


### PR DESCRIPTION
When using my XL 5H, I've been having a hard time getting good wipe-tower free prints.

When changing a tool without a wipe tower, the printer currently just stops while touching the print and does the tool change. The tool change then returns to where it was but that causes colors to be contaminated.

It then rapids to the next location without a lift dragging the nozzle across the last layer.

This change lifts the tool right before the change and returns it down before the next extrude.