### PR TITLE
Stop displaying bed in thumbnails

### DIFF
--- a/src/libslic3r/GCode/Thumbnails.hpp
+++ b/src/libslic3r/GCode/Thumbnails.hpp
@@ -52,7 +52,7 @@ inline void export_thumbnails_to_file(ThumbnailsGeneratorCallback &thumbnail_cb,
     if (thumbnail_cb != nullptr) {
         for (const auto& [format, size] : thumbnails_list) {
             static constexpr const size_t max_row_length = 78;
-            ThumbnailsList thumbnails = thumbnail_cb(ThumbnailsParams{ {size}, true, true, true, true });
+            ThumbnailsList thumbnails = thumbnail_cb(ThumbnailsParams{ {size}, true, true, false, true });
             for (const ThumbnailData& data : thumbnails)
                 if (data.is_valid()) {
                     auto compressed = compress_thumbnail(data, format);
@@ -89,7 +89,7 @@ inline void generate_binary_thumbnails(ThumbnailsGeneratorCallback& thumbnail_cb
     assert(thumbnail_cb != nullptr);
     if (thumbnail_cb != nullptr) {
         for (const auto& [format, size] : thumbnails_list) {
-            ThumbnailsList thumbnails = thumbnail_cb(ThumbnailsParams{ {size}, true, true, true, true });
+            ThumbnailsList thumbnails = thumbnail_cb(ThumbnailsParams{ {size}, true, true, false, true });
             for (const ThumbnailData &data : thumbnails)
                 if (data.is_valid()) {
                     auto compressed = compress_thumbnail(data, format);


### PR DESCRIPTION
Thumbnails look nicer with transparent background

Fixes https://github.com/prusa3d/PrusaSlicer/issues/8038