### PR TITLE
add missing includes of boost/nowide/fstream.hpp

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoSVG.cpp
@@ -27,6 +27,7 @@
 
 #include <wx/display.h> // detection of change DPI
 #include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include <GL/glew.h>
 #include <chrono> // measure enumeration of fonts

--- a/src/slic3r/GUI/PresetArchiveDatabase.cpp
+++ b/src/slic3r/GUI/PresetArchiveDatabase.cpp
@@ -16,6 +16,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/nowide/fstream.hpp>
 #include <cctype>
 #include <curl/curl.h>
 #include <iostream>

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -18,6 +18,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include <curl/curl.h>
 


### PR DESCRIPTION
Some files use fstream classes from boost::nowide but lack an include of the corresponding header file.