### PR TITLE
Rewrite perimeter fuzzification functions

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -197,85 +197,182 @@ public:
     }
 };
 
-// Thanks Cura developers for this function.
-static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuzzy_skin_point_dist)
-{
-    const double min_dist_between_points = fuzzy_skin_point_dist * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
-    const double range_random_point_dist = fuzzy_skin_point_dist / 2.;
-    double dist_left_over = double(rand()) * (min_dist_between_points / 2) / double(RAND_MAX); // the distance to be traversed on the line before making the first new point
-    Point* p0 = &poly.points.back();
-    Points out;
-    out.reserve(poly.points.size());
-    for (Point &p1 : poly.points)
-    { // 'a' is the (next) new point between p0 and p1
-        Vec2d  p0p1      = (p1 - *p0).cast<double>();
-        double p0p1_size = p0p1.norm();
-        // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
-        double dist_last_point = dist_left_over + p0p1_size * 2.;
-        for (double p0pa_dist = dist_left_over; p0pa_dist < p0p1_size;
-            p0pa_dist += min_dist_between_points + double(rand()) * range_random_point_dist / double(RAND_MAX))
-        {
-            double r = double(rand()) * (fuzzy_skin_thickness * 2.) / double(RAND_MAX) - fuzzy_skin_thickness;
-            out.emplace_back(*p0 + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * r).cast<coord_t>());
-            dist_last_point = p0pa_dist;
-        }
-        dist_left_over = p0p1_size - dist_last_point;
-        p0 = &p1;
-    }
-    while (out.size() < 3) {
-        size_t point_idx = poly.size() - 2;
-        out.emplace_back(poly[point_idx]);
-        if (point_idx == 0)
-            break;
-        -- point_idx;
-    }
-    if (out.size() >= 3)
-        poly.points = std::move(out);
+static double lerp(double a, double b, double t) {
+    // Define a <double> lerp function equal in functionality to the lerp function defined in c++20.
+    return a + t * (b - a);
 }
 
-// Thanks Cura developers for this function.
+static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuzzy_skin_point_dist)
+{
+    /* Fuzzification configuration setup */
+    const bool closed = true; // Defined to maintain code parity / similarity with fuzzy_extrusion_line.
+    Points &points = poly.points;
+
+    Points out;
+
+    const double line_unit_length = 2./3. * fuzzy_skin_point_dist; // The unit lengths of line segments, equal to both the minimum length of the line, as well as the delta between minimum and maximum line length.
+    const double point_min_delta = 2e-1 * line_unit_length; // The radius in which reference points might get dropped if they are next to original corner points.
+    const int n_point = points.size();
+    int n_seg = points.size();
+    // Reduce the number of segments by 1 for open lines, or pre-closed loops since no segment exists between the first and last points in these cases.
+    if (!closed or (closed and (points[0] == points[n_seg - 1])))
+        --n_seg;
+
+    double total_length = 0;
+    for (int i = 0; i < n_seg; ++i) {
+        total_length += (points[(i + 1) % n_point] - points[i]).cast<double>().norm();
+    }
+
+    out.reserve(n_seg + std::ceil(total_length / line_unit_length));
+
+    /* Fuzzification loop variable initialisation */
+    Vec2d seg_dir;
+    Vec2d seg_perp = closed ?
+                     perp((points[0] - points[-1 % n_seg]).cast<double>().normalized()) :
+                     perp((points[1] - points[0]).cast<double>().normalized());
+    Point p_ref = points[0]; // The reference point for the current line segment (= the first corner)
+
+    double x_prev = 0;
+    double x_next = total_length < (2. * line_unit_length) ? total_length : line_unit_length + double(rand()) / double(RAND_MAX) * std::min(line_unit_length, total_length - 2 * line_unit_length);
+
+    double x_prev_corner = 0; // Will be properly set in the first corner point loop
+    double x_next_corner = 0;
+    int corner_idx = 0;
+
+    double y_0 = (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
+    double y_prev = y_0;
+    double y_next = (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
+
+    /* Fuzzification loop: */
+    while (x_prev < total_length) {
+        // Add any interim corner points from the original line
+        while (x_next_corner <= x_next) {
+            // Don't add the last point, since it has some special behaviour
+            if (corner_idx == n_seg)
+                break;
+            double y = lerp(y_prev, y_next, (x_next_corner - x_prev) / (x_next - x_prev));
+            Vec2d prev_perp = seg_perp;
+
+            p_ref = points[corner_idx];
+            Vec2d seg = (points[(corner_idx + 1) % n_point] - p_ref).cast<double>();
+            double seg_length = seg.norm();
+            seg_dir = seg.normalized();
+            seg_perp = perp(seg_dir);
+
+            Vec2d corner_perp = seg_perp.dot(prev_perp) > -0.99 ? Vec2d((seg_perp + prev_perp).normalized()) : seg_dir;
+            out.emplace_back(p_ref + (y * corner_perp).cast<coord_t>());
+
+            x_prev_corner = x_next_corner;
+            x_next_corner += seg_length;
+            ++corner_idx;
+        }
+        // Add the next mid-segment fuzzy point
+        // Only add the point if it is not too close to an existing interim corner point to prevent point spam
+        if (!((x_next - x_prev_corner) < point_min_delta or (x_next_corner - x_next) < point_min_delta))
+            out.emplace_back(p_ref + ((x_next - x_prev_corner) * seg_dir + y_next * seg_perp).cast<coord_t>());
+
+        x_prev = x_next;
+        x_next = x_prev > total_length - (2. * line_unit_length) ? total_length : x_prev + line_unit_length + double(rand()) / double(RAND_MAX) * std::min(line_unit_length, total_length - x_prev - 2. * line_unit_length);
+
+        y_prev = y_next;
+        y_next = (closed and x_next == total_length) ? y_0 : (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
+    }
+    // Add the closing corner
+    if (closed)
+        out.emplace_back(out[0]);
+    else
+        out.emplace_back(points[n_seg] + (y_next * seg_perp).cast<coord_t>());
+
+    out.shrink_to_fit();
+
+    poly.points = std::move(out);
+}
+
+
 static void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, double fuzzy_skin_thickness, double fuzzy_skin_point_dist)
 {
-    const double min_dist_between_points = fuzzy_skin_point_dist * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
-    const double range_random_point_dist = fuzzy_skin_point_dist / 2.;
-    double       dist_left_over          = double(rand()) * (min_dist_between_points / 2) / double(RAND_MAX); // the distance to be traversed on the line before making the first new point
+    // Fuzzification configuration setup
+    const bool closed = ext_lines.is_closed;
+    const std::vector<Arachne::ExtrusionJunction> &points = ext_lines.junctions;
 
-    auto                                   *p0 = &ext_lines.front();
     std::vector<Arachne::ExtrusionJunction> out;
-    out.reserve(ext_lines.size());
-    for (auto &p1 : ext_lines) {
-        if (p0->p == p1.p) { // Connect endpoints.
-            out.emplace_back(p1.p, p1.w, p1.perimeter_index);
-            continue;
-        }
 
-        // 'a' is the (next) new point between p0 and p1
-        Vec2d  p0p1      = (p1.p - p0->p).cast<double>();
-        double p0p1_size = p0p1.norm();
-        // so that p0p1_size - dist_last_point evaulates to dist_left_over - p0p1_size
-        double dist_last_point = dist_left_over + p0p1_size * 2.;
-        for (double p0pa_dist = dist_left_over; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + double(rand()) * range_random_point_dist / double(RAND_MAX)) {
-            double r = double(rand()) * (fuzzy_skin_thickness * 2.) / double(RAND_MAX) - fuzzy_skin_thickness;
-            out.emplace_back(p0->p + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * r).cast<coord_t>(), p1.w, p1.perimeter_index);
-            dist_last_point = p0pa_dist;
-        }
-        dist_left_over = p0p1_size - dist_last_point;
-        p0             = &p1;
+    const double line_unit_length = 2./3. * fuzzy_skin_point_dist; // The unit lengths of line segments, equal to both the minimum length of the line, as well as the delta between minimum and maximum line length.
+    const double point_min_delta = 2e-1 * line_unit_length; // The radius in which reference points might get dropped if they are next to original corner points
+    const int n_point = ext_lines.size();
+    int n_seg = n_point;
+    // Reduce the number of segments by 1 for open lines, or pre-closed loops since no segment exists between the first and last points in these cases.
+    if (!closed or (closed and (points[0].p == points[n_seg - 1].p)))
+        --n_seg;
+
+    double total_length = 0;
+    for (int i = 0; i < n_seg; ++i) {
+        total_length += (points[(i + 1) % n_point].p - points[i].p).cast<double>().norm();
     }
 
-    while (out.size() < 3) {
-        size_t point_idx = ext_lines.size() - 2;
-        out.emplace_back(ext_lines[point_idx].p, ext_lines[point_idx].w, ext_lines[point_idx].perimeter_index);
-        if (point_idx == 0)
-            break;
-        -- point_idx;
+    out.reserve(n_seg + std::ceil(total_length / line_unit_length));
+
+    // Fuzzification loop variable initialisation
+    Vec2d seg_dir;
+    Vec2d seg_perp = closed ?
+                     perp((points[0].p - points[-1 % n_seg].p).cast<double>().normalized()) :
+                     perp((points[1].p - points[0].p).cast<double>().normalized());
+    Arachne::ExtrusionJunction p_ref = points[0]; // The reference point for the current line segment (= the first corner)
+
+    double x_prev = 0;
+    double x_next = total_length < (2. * line_unit_length) ? total_length : line_unit_length + double(rand()) / double(RAND_MAX) * std::min(line_unit_length, total_length - 2 * line_unit_length);
+
+    double x_prev_corner = 0; // Will be properly set in the first corner point loop
+    double x_next_corner = 0;
+    int corner_idx = 0;
+
+    double y_0 = (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
+    double y_prev = y_0;
+    double y_next = (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
+
+    /* Fuzzification loop: */
+    while (x_prev < total_length) {
+        // Add any interim corner points from the original line
+        while (x_next_corner <= x_next) {
+            // Don't add the last point, since it has some special behaviour
+            if (corner_idx == n_seg)
+                break;
+            double y = lerp(y_prev, y_next, (x_next_corner - x_prev) / (x_next - x_prev));
+            Vec2d prev_perp = seg_perp;
+
+            p_ref = points[corner_idx];
+            Vec2d seg = (points[(corner_idx + 1) % n_point].p - p_ref.p).cast<double>();
+            double seg_length = seg.norm();
+            seg_dir = seg.normalized();
+            seg_perp = perp(seg_dir);
+
+            Vec2d corner_perp = seg_perp.dot(prev_perp) > -0.99 ? Vec2d((seg_perp + prev_perp).normalized()) : seg_dir;
+            out.emplace_back(p_ref.p + (y * corner_perp).cast<coord_t>(), p_ref.w, p_ref.perimeter_index);
+
+            x_prev_corner = x_next_corner;
+            x_next_corner += seg_length;
+            ++corner_idx;
+        }
+        // Add the next mid-segment fuzzy point
+        // Only add the point if it is not too close to an existing interim corner point to prevent point spam
+        if (!((x_next - x_prev_corner) < point_min_delta or (x_next_corner - x_next) < point_min_delta))
+            out.emplace_back(p_ref.p + ((x_next - x_prev_corner) * seg_dir + y_next * seg_perp).cast<coord_t>(), p_ref.w, p_ref.perimeter_index);
+
+        x_prev = x_next;
+        x_next = x_prev > total_length - (2. * line_unit_length) ? total_length : x_prev + line_unit_length + double(rand()) / double(RAND_MAX) * std::min(line_unit_length, total_length - x_prev - 2. * line_unit_length);
+
+        y_prev = y_next;
+        y_next = (closed and x_next == total_length) ? y_0 : (2. * double(rand()) / double(RAND_MAX) - 1.) * fuzzy_skin_thickness;
     }
+    // Add the closing corner
+    if (closed)
+        out.emplace_back(out[0]);
+    else
+        out.emplace_back(points[n_seg].p + (y_next * seg_perp).cast<coord_t>(), p_ref.w, p_ref.perimeter_index);
 
-    if (ext_lines.back().p == ext_lines.front().p) // Connect endpoints.
-        out.front().p = out.back().p;
+    out.shrink_to_fit();
 
-    if (out.size() >= 3)
-        ext_lines.junctions = std::move(out);
+    ext_lines.junctions = std::move(out);
 }
 
 using PerimeterGeneratorLoops = std::vector<PerimeterGeneratorLoop>;


### PR DESCRIPTION
The previous implementation of the fuzzy_polygon (classic perimeter generator) and fuzzy_extrusion_line (Arachne perimeter generator) did not work well at larger values for `Fuzzy skin point distance`. At higher values, the generator would start cutting corners, and overshooting at corners leading to incorrect overhangs being generated. The latter of these issues was reported in #7744.

This PR is a complete rewrite of the fuzzification algorithm to work well with both small and large values for `Fuzzy skin point distance`.  The table below shows a comparison between the old and new fuzzy skin generation algorithm between the old fuzzification algorithm (left), and the new fuzzification algorithm (right) at various `Fuzzy skin point distance` values. (Note: the top infill has been hidden to better show the difference between the algorithms.)

| Fuzzy skin point distance | Old fuzzification algorithm | New fuzzification algorithm |
| :--- | :---: | :---: |
| 0.8 mm | ![Old_0 8](https://github.com/user-attachments/assets/0d29e550-547a-4727-86c0-51932ff04ee1) | ![New_0 8](https://github.com/user-attachments/assets/d2b7bbb1-04ae-4ff7-baa0-21cefaa175cb) |
| 2.0 mm | ![Old_2 0](https://github.com/user-attachments/assets/65907073-c602-42c3-b49e-8be4dc09d09e) | ![New_2 0](https://github.com/user-attachments/assets/fb8e6831-f434-4b88-8a8d-25297f7dde26) |
| 5.0 mm | ![Old_5 0](https://github.com/user-attachments/assets/e2a9ba92-66ed-4c58-847e-d7052337813e) | ![New_5 0](https://github.com/user-attachments/assets/aadf3aaa-625b-44e9-9855-af540f26e9a0) |
| 50.0 mm | ![Old_50 0](https://github.com/user-attachments/assets/00295c04-173a-46bf-abb1-db1fe3960ec0) | ![New_50 0](https://github.com/user-attachments/assets/5372328f-e3c3-4f8d-94e0-e7bd18220eff) |
| 5.0 mm (Top down view) |![Old_5 0_top](https://github.com/user-attachments/assets/7baf108e-f2f0-4605-b292-ef693c45b0f9)  | ![New_5 0_top](https://github.com/user-attachments/assets/eb413dd2-964e-4d24-b0a7-676e1aae8de8) |

A brief summary of how the new algorithm works:
```
while not at the end:
    choose new segment length
    for each original corner point on this segment:
        place this corner point at the appropriate offset (magnitude determined using linear interpolation over current segment)
    place the end point of the segment
```
Since a new point is placed at x-locations where a corner point existed in the original line, the corner cutting that was visible in the original algorithm is avoided.
By cleverly picking the lengths of each of the segments (i.e. taking into account the remaining perimeter length), the outline can be closed with every segment length being in the acceptable range, thus not suffering from the overshoot present in the original algorithm