### PR TITLE
Arrange: fix for new error in clang 19

### DIFF
--- a/src/slic3r-arrange/include/arrange/DataStoreTraits.hpp
+++ b/src/slic3r-arrange/include/arrange/DataStoreTraits.hpp
@@ -71,7 +71,7 @@ template<class T, class TT = T> using WritableDataStoreOnly = std::enable_if_t<I
 template<class T, class ArrItem>
 void set_data(ArrItem &itm, const std::string &key, T &&data)
 {
-    WritableDataStoreTraits<ArrItem>::template set(itm, key, std::forward<T>(data));
+    WritableDataStoreTraits<ArrItem>::set(itm, key, std::forward<T>(data));
 }
 
 template<class T> constexpr bool IsReadWritableDataStore = IsDataStore<T> && IsWritableDataStore<T>;


### PR DESCRIPTION
Using clang 19, the build otherwise fails with
```
In file included from /build/source/src/libslic3r/ModelArrange.cpp:8:
In file included from /build/source/src/libslic3r/Arrange/Items/ArrangeItem.hpp:19:
In file included from /build/source/src/libslic3r/Arrange/Items/MutableItemTraits.hpp:9:
/build/source/src/libslic3r/Arrange/Core/DataStoreTraits.hpp:74:48: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
   74 |     WritableDataStoreTraits<ArrItem>::template set(itm, key, std::forward<T>(data));
      |
```
Build is still running here, but I assume this will fix it.