### PR TITLE
Improve STEP file import on Linux

### DIFF
--- a/src/libslic3r/Format/STEP.cpp
+++ b/src/libslic3r/Format/STEP.cpp
@@ -39,8 +39,8 @@ LoadStepFn get_load_step_fn()
 #endif
 
     if (!load_step_fn) {
-        auto libpath = boost::dll::program_location().parent_path();
 #ifdef _WIN32
+        auto libpath = boost::dll::program_location().parent_path();
         libpath /= "OCCTWrapper.dll";
         HMODULE module = LoadLibraryW(libpath.wstring().c_str());
         if (module == NULL)
@@ -61,8 +61,8 @@ LoadStepFn get_load_step_fn()
 #elif __APPLE__
         load_step_fn = &load_step_internal;
 #else
-        libpath /= "OCCTWrapper.so";
-        void *plugin_ptr = dlopen(libpath.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        // This is installed into /usr/lib(64)/ and dlopen will search there.
+        void *plugin_ptr = dlopen("OCCTWrapper.so", RTLD_NOW | RTLD_GLOBAL);
 
         if (plugin_ptr) {
             load_step_fn = reinterpret_cast<LoadStepFn>(dlsym(plugin_ptr, fn_name));

--- a/src/occt_wrapper/CMakeLists.txt
+++ b/src/occt_wrapper/CMakeLists.txt
@@ -59,5 +59,8 @@ target_link_libraries(OCCTWrapper libslic3r admesh)
 
 include(GNUInstallDirs)
 
-install(TARGETS OCCTWrapper DESTINATION "${CMAKE_INSTALL_BINDIR}")
-
+if (WIN32 OR APPLE)
+    install(TARGETS OCCTWrapper DESTINATION "${CMAKE_INSTALL_BINDIR}")
+else()
+    install(TARGETS OCCTWrapper DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+endif()

--- a/src/occt_wrapper/CMakeLists.txt
+++ b/src/occt_wrapper/CMakeLists.txt
@@ -19,35 +19,23 @@ include(GenerateExportHeader)
 
 generate_export_header(OCCTWrapper)
 
-find_package(OpenCASCADE 7.6.1 REQUIRED)
+find_package(OpenCASCADE REQUIRED)
+# OpenCASCADE has an exact version match even if you don't specify the EXACT
+# keyword in the find_package(). So lets implement it on our own.
+set(OPENCASCADE_MODULE_VERSION
+    "${OpenCASCADE_MAJOR_VERSION}.${OpenCASCADE_MINOR_VERSION}.${OpenCASCADE_MAINTENANCE_VERSION}")
+set(OPENCASCADE_REQUIRED_VERSION "7.8.0")
+if (${OPENCASCADE_MODULE_VERSION} VERSION_LESS ${OPENCASCADE_REQUIRED_VERSION})
+    message(
+        FATAL_ERROR
+        "Coun't find a compatible OpenCASCADE version - "
+        "required: ${OPENCASCADE_REQUIRED_VERSION}, found: "
+        "${OPENCASCADE_MODULE_VERSION}"
+    )
+endif()
 
 set(OCCT_LIBS
-    TKXDESTEP
-    TKSTEP
-    TKSTEP209
-    TKSTEPAttr
-    TKSTEPBase
-    TKXCAF
-    TKXSBase
-    TKVCAF
-    TKCAF
-    TKLCAF
-    TKCDF
-    TKV3d
-    TKService
-    TKMesh
-    TKBO
-    TKPrim
-    TKHLR
-    TKShHealing
-    TKTopAlgo
-    TKGeomAlgo
-    TKBRep
-    TKGeomBase
-    TKG3d
-    TKG2d
-    TKMath
-    TKernel
+    TKDESTEP
 )
 
 slic3r_remap_configs("${OCCT_LIBS}" RelWithDebInfo Release)


### PR DESCRIPTION
Hi,

my name is Andreas Schneider, I'm a FOSS Hacker and new to 3D Printing.

I recognized that opening STEP files in Fedora and OpenSUSE isn't working. I've changed the installation of OCCTWrapper.so so it is installed in the right place on Linux and loaded correctly. I also move the version check of OC to Prusa as they only do exact checks even for minor version bumps. There is also no need to list all the targets to link, we only need TKDESTEP. The cmake config sets all the required dependent libraries.