### PR TITLE
Add internal_infill_min_width setting

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -511,6 +511,7 @@ static std::vector<std::string> s_Preset_print_options {
     "wall_distribution_count", "min_feature_size", "min_bead_width",
     "top_one_perimeter_type", "only_one_perimeter_first_layer",
     "automatic_extrusion_widths", "automatic_infill_combination", "automatic_infill_combination_max_layer_height",
+    "internal_infill_min_width",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2876,6 +2876,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloat(70));
 
+    def = this->add("internal_infill_min_width", coFloat);
+    def->label = L("Internal infill minimum width");
+    def->category = L("Infill");
+    def->tooltip = L("Force solid infill for regions that would be internal infill but are surrounded by solid infill "
+                     "and are thinner than this. This can be used to avoid unneeded patches of internal infill which "
+                     "can slow the print down due to excessive direction changes, or to get a cleaner top surface for "
+                     "e.g. signs with raised text.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionFloat(0));
+
     def = this->add("solid_infill_extruder", coInt);
     def->label = L("Solid infill extruder");
     def->category = L("Extruders");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -720,6 +720,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                  infill_every_layers))
     ((ConfigOptionFloatOrPercent,       infill_overlap))
     ((ConfigOptionFloat,                infill_speed))
+    ((ConfigOptionFloat,                internal_infill_min_width))
     // Ironing options
     ((ConfigOptionBool,                 ironing))
     ((ConfigOptionEnum<IroningType>,    ironing_type))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1511,6 +1511,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("solid_infill_every_layers", category_path + "solid-infill-every-x-layers");
         optgroup->append_single_option_line("fill_angle", category_path + "fill-angle");
         optgroup->append_single_option_line("solid_infill_below_area", category_path + "solid-infill-threshold-area");
+        optgroup->append_single_option_line("internal_infill_min_width", category_path + "internal-infill-min-width");
         optgroup->append_single_option_line("bridge_angle");
         optgroup->append_single_option_line("only_retract_when_crossing_perimeters");
         optgroup->append_single_option_line("infill_first");


### PR DESCRIPTION
Added a setting to remedy situations where this:

![test_sign](https://github.com/user-attachments/assets/6e67d8ea-07b4-4a59-9f98-bd6d59ee9503)

Has layers like this:

![test_pointless_infill](https://github.com/user-attachments/assets/13c2db15-dbde-418a-beb5-befc1122c07f)

The thin patches of internal infill only slow the print down as the printer has to make a lot of unnecessary direction changes and moves. For thin sections like this, it's faster to just replace the sections with solid infill.

It can also make for a cleaner base plate surface for "logo or sign" like prints like the one in the example picture. If needed, it can be used as a height range modifier to apply the logic to only the backing part, and then have all the raised bits use internal infill to save plastic.

In addition to the "infill area width" check there is also logic to allow small patches of internal infill if there isn't enough surrounding solid area. This allows the sign in the example to be printed so that the base plate it entirely solid, but the letters themselves have internal infill because there is no surrounding solid infill to blend into. The check is somewhat of a heuristic, so somebody might have a better idea for it, but it worked well enough with my test objects.

Attached is a more complicated test object if somebody feels like playing with the setting and seeing how it affects different kinds of shapes.

[sign_slice.zip](https://github.com/user-attachments/files/18151880/sign_slice.zip) (STL file)
