### PR TITLE
Add explicit include for boost/filesystem/directory.hpp

### DIFF
--- a/src/slic3r/Config/Version.cpp
+++ b/src/slic3r/Config/Version.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/directory.hpp>
 #include <boost/nowide/fstream.hpp>
 
 #include "libslic3r/libslic3r.h"


### PR DESCRIPTION
This mends the build process on distros with a boost version of 1.85 and above.

Fixes #13795

Pinging @SachCZ as this is a bit of a followup to #13609, where you were involved. Thank you so much for your assistance with that one, by the way :grin: 