### PR TITLE
[BUGFIX] Show active bed texture when bed model overlaps

### DIFF
--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -412,13 +412,17 @@ void Bed3D::render_axes()
 
 void Bed3D::render_system(GLCanvas3D& canvas, const Transform3d& view_matrix, const Transform3d& projection_matrix, bool bottom, bool show_texture, bool is_active)
 {
-    if (m_models_overlap && s_multiple_beds.get_number_of_beds() + int(s_multiple_beds.should_show_next_bed()) > 1) {
+    if (m_texture_filename.empty() && m_model_filename.empty()) {
         render_default(bottom, false, show_texture, view_matrix, projection_matrix);
         return;
     }
 
-    if (!bottom)
+    if (m_models_overlap && s_multiple_beds.get_number_of_beds() + int(s_multiple_beds.should_show_next_bed()) > 1) {
+        if (m_texture_filename.empty())
+            render_default(bottom, false, show_texture, view_matrix, projection_matrix);
+    } else if (!bottom) {
         render_model(view_matrix, projection_matrix);
+    }
 
     if (show_texture)
         render_texture(bottom, canvas, view_matrix, projection_matrix, is_active);
@@ -580,14 +584,17 @@ void Bed3D::render_model(const Transform3d& view_matrix, const Transform3d& proj
 
 void Bed3D::render_custom(GLCanvas3D& canvas, const Transform3d& view_matrix, const Transform3d& projection_matrix, bool bottom, bool show_texture, bool picking, bool is_active)
 {
-    if ((m_texture_filename.empty() && m_model_filename.empty())
-     || (m_models_overlap && s_multiple_beds.get_number_of_beds() + int(s_multiple_beds.should_show_next_bed()) > 1)) {
+    if (m_texture_filename.empty() && m_model_filename.empty()) {
         render_default(bottom, picking, show_texture, view_matrix, projection_matrix);
         return;
     }
 
-    if (!bottom)
+    if (m_models_overlap && s_multiple_beds.get_number_of_beds() + int(s_multiple_beds.should_show_next_bed()) > 1) {
+        if (m_texture_filename.empty())
+            render_default(bottom, false, show_texture, view_matrix, projection_matrix);
+    } else if (!bottom) {
         render_model(view_matrix, projection_matrix);
+    }
 
     if (show_texture)
         render_texture(bottom, canvas, view_matrix, projection_matrix, is_active);


### PR DESCRIPTION
When bed models are too large they are automatically hidden when another bed is added to avoid awkward spacing between beds/overlaps. This also results in the bed texture being hidden and falling back to the default "translucent" grid view.

This bug-fix changes the behavior to show the bed texture on the active bed even when the model is hidden which should be save as the texture is always scaled to the bed size.

Original bug report: #13791
