### PR TITLE
Add displacement map feature applied during slicing (resolves #8649)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build-linux/*
 deps/build-linux/*
 **/.DS_Store
 **/.idea/
+/deps/

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -29,6 +29,9 @@
 
 namespace Slic3r {
 
+std::map<std::string, png::BackendPng> config_images;
+png::BackendPng no_image; // A non-loaded image (IsOK() should always be false) for avoiding returning nullptr.
+
 // Escape \n, \r and backslash
 std::string escape_string_cstyle(const std::string &str)
 {
@@ -460,6 +463,22 @@ void ConfigBase::apply_only(const ConfigBase &other, const t_config_option_keys 
 		} else
             my_opt->set(other_opt);
     }
+    // ConfigOption *path_opt = this->option("fuzzy_skin_displacement_map", false); // tries to use deleted = operator?
+    // std::string path_opt = "/home/owner/Maps/wall/Bricks076A_1K-JPG/Bricks076A_1K_Displacement-512-RGBA.png"; // this->option("fuzzy_skin_displacement_map", false)->value;
+    // dynamic_cast<std::string>(*this->option("fuzzy_skin_displacement_map"))->value;
+    /*
+    if (path_opt != nullptr) {
+        std::string this_displacement_map_path = path_opt;
+        if (this_displacement_map_path != displacement_img.GetPath()) {
+            if (this_displacement_map_path != "") {
+                this->m_displacement_img.LoadFile(this_displacement_map_path);
+            }
+            else {
+                m_displacement_img.Destroy();
+            }
+        }
+    }
+    */
 }
 
 // Are the two configs equal? Ignoring options not present in both configs.

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -176,7 +176,8 @@ void Layer::make_perimeters()
 		                && config.infill_overlap              == other_config.infill_overlap
                         && config.fuzzy_skin                  == other_config.fuzzy_skin
                         && config.fuzzy_skin_thickness        == other_config.fuzzy_skin_thickness
-                        && config.fuzzy_skin_point_dist       == other_config.fuzzy_skin_point_dist)
+                        && config.fuzzy_skin_point_dist       == other_config.fuzzy_skin_point_dist
+                        && config.fuzzy_skin_displacement_map == other_config.fuzzy_skin_displacement_map)
 		            {
 			 			other_layerm->perimeters.clear();
 			 			other_layerm->fills.clear();

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -89,7 +89,8 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, SurfaceCollec
         // output:
         &this->perimeters,
         &this->thin_fills,
-        fill_surfaces
+        fill_surfaces,
+        this->layer()->print_z
     );
     
     if (this->layer()->lower_layer != nullptr)

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -81,16 +81,17 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, SurfaceCollec
         &slices,
         this->layer()->height,
         this->flow(frPerimeter),
-        &region_config,
-        &this->layer()->object()->config(),
+        &region_config, // PrintRegionConfig*
+        // &this->layer()->object()->config(), // PrintObjectConfig*
+        this->layer()->object(), // PrintObject*
         &print_config,
         spiral_vase,
+        this->layer()->print_z,
         
         // output:
         &this->perimeters,
         &this->thin_fills,
-        fill_surfaces,
-        this->layer()->print_z
+        fill_surfaces
     );
     
     if (this->layer()->lower_layer != nullptr)

--- a/src/libslic3r/PNGReadWrite.cpp
+++ b/src/libslic3r/PNGReadWrite.cpp
@@ -1,12 +1,27 @@
 #include "PNGReadWrite.hpp"
+#include "Config.hpp" // for ConfigurationError
 
 #include <memory>
 
+// Get the correct sleep function:
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+#include <cstdlib>
+
 #include <cstdio>
+#include <iostream>
 #include <png.h>
+#include <fstream>
+#include <vector>
+
+
 
 #include <boost/log/trivial.hpp>
 #include <boost/nowide/cstdio.hpp>
+
 
 namespace Slic3r { namespace png {
 
@@ -57,6 +72,400 @@ static void png_read_callback(png_struct *png_ptr,
 
     reader->read(static_cast<std::uint8_t *>(outBytes), byteCountToRead);
 }
+
+
+bool BackendPng::IsOk() {
+    //if (this->image_path == "") {
+    if (this->m_pixel_size < 1) {
+        return false;
+    }
+    if (this->cols < 1) {
+        return false;
+    }
+    if (this->rows < 1) {
+        return false;
+    }
+    return true;
+}
+
+bool BackendPng::dump() {
+    std::cerr<<"[BackendImage] \"" << this->GetPath() << "\" (OK:" << (this->IsOk()?"true":"false") << ") dump:" <<std::endl;
+    if (!this->IsOk()) return false;
+    for (size_t y=0; y<this->GetHeight(); y++) {
+        for (size_t x=0; x<this->GetWidth(); x++) {
+            if (this->m_color) {
+                std::cout << (x==0?"":", ")
+                    << std::to_string(this->GetRed(x, y)) << ","
+                    << std::to_string(this->GetGreen(x, y)) << ","
+                    << std::to_string(this->GetBlue(x, y));
+                ;
+            }
+            else {
+                std::cout << (x==0?"":",") << std::to_string(this->GetLuma(x, y));
+            }
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+    return true;
+}
+
+std::string BackendPng::GetPath()
+{
+    return this->image_path;
+}
+
+bool BackendPng::reinitialize(bool force) {
+    if (this->busy) {
+        if (!force) {
+            std::cerr << "[BackendPng::reinitialize] cannot run while busy loading." << std::endl;
+            return false;
+        }
+        // else do not show an error. Assume busy was set by the caller.
+    }
+    // Swap each buf with a new a tmp vector to reduce the buffer capacity (memory usage):
+    // std::vector<uint8_t>().swap(this->png->buf);
+    if (png && info) {
+        png_destroy_info_struct(png, &info);
+        this->png = nullptr;
+        this->info = nullptr;
+    }
+    if (png) {
+        png_destroy_read_struct(&png, nullptr, nullptr);
+        this->png = nullptr;
+    }
+    if (info) {
+        std::cerr << "[reinitialize] Error: Unexpected png info will be deleted." << std::endl;
+        delete this->info;
+        this->info = nullptr;
+    }
+    this->image_path = "";
+    this->m_pixel_size = 0; // cause IsOk() to return false.
+    this->error_shown = false;
+    this->m_color = false;
+    return true;
+}
+
+void BackendPng::Destroy()
+{
+    this->reinitialize(true);
+}
+
+bool BackendPng::load_png_file(std::string path) {
+    bool was_busy = this->busy;
+    if (this->image_path == path) {
+        // another thread must have already loaded it.
+        return true;
+    }
+    if (was_busy) {
+        // It is already loading.
+        return false;
+    }
+    this->busy = true; // Set to false before *every* return (or throw, which also requires first setting this->error_shown = true).
+    
+    if (path == "") {
+        this->busy = false;
+        this->error_shown = true;
+        throw ConfigurationError(
+            "The fuzzy_skin_displacement_map is blank but load_png_file was called."
+            " This is a programming error, not a configuration error."
+        );
+    }
+    else if ((this->GetPath() != "")) {
+        // Only reinitialize if the old path isn't "".
+        this->reinitialize(true);
+    }
+    // Private since format-specific
+    // Load data using STL: See <https://stackoverflow.com/a/21802936/4541104>
+    std::vector <uint8_t> vec; // since ImageGreyscale uses template class Image with uint8_t for PxT (pixel type)
+    std::ifstream file(path, std::ios::binary);
+    if (file.fail()) {
+        this->image_path = "";
+        this->busy = false;
+        this->error_shown = true;
+        throw ConfigurationError(
+            std::string("The fuzzy_skin_displacement_map \"")
+            + path + std::string("\" does not exist. Change the path and re-slice to clear the invalid state.")
+        );
+        // return false;
+    }
+    file.unsetf(std::ios::skipws); // Do not skip \n
+    std::streampos fileSize;
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+    vec.reserve(fileSize);
+    vec.insert(vec.begin(),
+               std::istream_iterator<uint8_t>(file),
+               std::istream_iterator<uint8_t>());
+    // Now translate the bytes to a png structure if that is proper:
+    png::ReadBuf        rb{static_cast<void*>(vec.data()), static_cast<size_t>(fileSize)}; // pre-C++11: (void*)&pixels_[0]
+    // Note: There is no real problem since fileSize is positive but
+    //   Having no cast results in the compiler warning: "narrowing conversion of
+    //   ‘fileSize.std::fpos<__mbstate_t>::operator std::streamoff()’
+    //   from ‘std::streamoff’ {aka ‘long int’} to ‘size_t’ {aka ‘long unsigned int’} [-Wnarrowing]"
+    if (load_png_stream(rb, path, true)) {
+        // ^ true to keep it busy (Prevent potential multithreading-related crash where busy is false but path is not set.
+        this->image_path = path;
+        this->busy = false;
+        return true;
+    }
+    this->busy = false;
+    return false;
+}
+bool BackendPng::load_png_stream(IStream &in_buf, std::string optional_stated_path, bool next_busy) {
+    // optional_stated_path is only for error messages.
+    this->busy = true; // also set to true by load_png, the usual caller
+    this->reinitialize(next_busy);
+    // based on the decode_png from this file
+    static const constexpr int PNG_SIG_BYTES = 8;
+
+    std::vector<png_byte> sig(PNG_SIG_BYTES, 0);
+    in_buf.read(sig.data(), PNG_SIG_BYTES);
+    std::string path_msg = "";
+    if (optional_stated_path != "")
+        path_msg = " \"" + optional_stated_path + "\"";
+    if (!png_check_sig(sig.data(), PNG_SIG_BYTES)) {
+        this->error_shown = true;
+        this->busy = next_busy;
+        throw ConfigurationError(
+            std::string("The fuzzy_skin_displacement_map")
+            + path_msg + std::string(" is not a PNG file. Change the path and re-slice to clear the invalid state.")
+        );
+        // return false;
+    }
+    this->png = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!this->png) {
+        this->error_shown = true;
+        this->busy = next_busy;
+        throw ConfigurationError(
+            std::string("The fuzzy_skin_displacement_map")
+            + path_msg + std::string(" is not a readable PNG file. Change the path and re-slice to clear the invalid state.")
+        );
+        // return false;
+    }
+    this->info = png_create_info_struct(this->png);
+    if(!this->info) {
+        this->error_shown = true;
+        this->busy = next_busy;
+        throw ConfigurationError(
+            std::string("The fuzzy_skin_displacement_map")
+            + path_msg + std::string(" is not a valid PNG file. Change the path and re-slice to clear the invalid state.")
+        );
+        // return false;
+    }
+
+    png_set_read_fn(this->png, static_cast<void *>(&in_buf), png_read_callback);
+
+    // Tell that we have already read the first bytes to check the signature
+    png_set_sig_bytes(this->png, PNG_SIG_BYTES);
+
+    png_read_info(this->png, this->info);
+
+    this->cols = png_get_image_width(this->png, this->info);
+    this->rows = png_get_image_height(this->png, this->info);
+    png_byte color_type = png_get_color_type(this->png, this->info);
+    png_byte bit_depth  = png_get_bit_depth(this->png, this->info);
+    // ^ png_byte is typedef unsigned char usually, so displaying it
+    //   as a string should use std::to_string.
+    // ^ png_get_bit_depth gets bits *per channel*!
+    //   Therefore derive m_pixel_size from color_type also:
+    if (color_type == PNG_COLOR_TYPE_RGBA && bit_depth == 8) {
+        this->m_pixel_size = 4;
+        this->m_color = true;
+    } else if (color_type == PNG_COLOR_TYPE_RGB && bit_depth == 8) {
+        this->m_pixel_size = 3;
+        this->m_color = true;
+    } else if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth == 8) {
+        this->m_pixel_size = 1;
+        this->m_color = false;
+    }
+    /*else if (color_type == PNG_COLOR_TYPE_GRAY_ALPHA && bit_depth == 8) {
+        this->m_pixel_size = 2;
+        this->m_color = false;
+    }
+    */
+    // ^ TODO: Allow GRAY_ALPHA somehow (causes sequential buffer overflow
+    //   or "libpng error: IDAT: invalid window size (libpng)" to be thrown by libpng on load.
+
+    if (this->m_pixel_size == 0) {
+        this->error_shown = true;
+        std::string type_msg = get_type_message(color_type);
+        
+        this->busy = next_busy;
+        throw ConfigurationError(
+            std::string("The fuzzy_skin_displacement_map")
+            + path_msg + std::string(" is not a grayscale/truecolor PNG file.")
+            + std::string(" The image is ") + std::to_string(static_cast<unsigned char>(bit_depth))
+            + std::string("bpc") + type_msg
+            + std::string(". Change the path and re-slice to clear the invalid state.")
+        );
+        // return false;
+    }
+
+    this->m_stride = m_pixel_size * this->cols;
+
+    this->buf.resize(this->rows * this->cols * this->m_pixel_size);
+
+    auto readbuf = static_cast<png_bytep>(this->buf.data());
+    for (size_t r = 0; r < this->rows; ++r)
+        png_read_row(this->png, readbuf + r * this->m_stride, nullptr);
+    if (this->GetWidth() * this->GetHeight() <= 16) this->dump(); // for debug only
+    this->busy = false;
+    return true;
+}
+
+bool BackendPng::load_png_stream(const ReadBuf &in_buf, std::string optional_stated_path, bool next_busy) {
+    // based on template<class Img> bool decode_png(const ReadBuf &in_buf, Img &out_img) from PNGReadWrite.hpp
+    struct ReadBufStream: public IStream {
+        const ReadBuf &rbuf_ref; size_t pos = 0;
+
+        explicit ReadBufStream(const ReadBuf &buf): rbuf_ref{buf} {}
+
+        size_t read(std::uint8_t *outp, size_t amount) override
+        {
+            if (amount > rbuf_ref.sz - pos) return 0;
+
+            auto buf = static_cast<const std::uint8_t *>(rbuf_ref.buf);
+            std::copy(buf + pos, buf + (pos + amount), outp);
+            pos += amount;
+
+            return amount;
+        }
+
+        bool is_ok() const override { return pos < rbuf_ref.sz; }
+    } stream{in_buf};
+    return this->load_png_stream(stream, optional_stated_path, next_busy);
+}
+
+bool BackendPng::LoadFile(std::string path)
+{
+    if (this->image_path == path) {
+        // another thread must have already loaded it.
+        return true;
+    }
+    double delay = .25;
+    double total_delay = 0.0;
+
+    double delay_timeout = 120;
+    // ^ How many seconds to wait for other thread(s)...OR milliseconds depending on sleep function used??
+    //   - Values below 60 cause fuzz in images >= 1024x1024 due to not loaded yet on i7-12000F on WD SSD.
+    // TODO: Adjust if milliseconds not seconds (See comment above)?
+    
+    while (this->busy) {
+        // wait for the other thread.
+        if (this->error_shown) {
+            return false; // Another thread already failed to load the image.
+        }
+        if (total_delay >= delay_timeout) {
+            std::cerr << "[BackendImage::LoadFile] waiting for other thread(s) timed out." << std::endl;
+            // FIXME: Find a way to avoid IsOK() is false after this if the image was still loading in another thread and will have succeeded.
+            break;
+        }
+        sleep(delay);
+        total_delay += delay;
+    }
+    if (total_delay > 0.0) {
+        if (this->GetPath() == path) {
+            // Another thread already loaded the correct image.
+            return true;
+        }
+        else if (this->IsOk()) {
+            // Another thread probably already loaded the correct image.
+            return true;
+        }
+        else if (this->error_shown) {
+            // Assume another thread already failed,
+            //   otherwise a load_ method may throw more than once
+            //   (display more than one error dialog) when the path is
+            //   not blank but this->GetPath() is blank (this->IsOk() is false)
+            //   and there is more than one thread that may call load on the
+            //   same BackendPng.
+            return false;
+        }
+        std::cerr << "[BackendPng::LoadFile] The thread is in an unknown state." << std::endl;
+        // return true;
+    }
+    // TODO: Support other formats if another headless (non-wx) image loader besides libpng is in the project.
+    return this->load_png_file(path);
+}
+
+
+size_t BackendPng::GetWidth()
+{
+    return this->cols;
+}
+
+size_t BackendPng::GetHeight()
+{
+    return this->rows;
+}
+
+bool BackendPng::clamp(size_t& x, size_t& y) {
+    bool was_in_bounds = true;
+    if (x >= this->GetWidth()) {
+        was_in_bounds = false;
+        x %= this->GetWidth();
+    }
+    if (y >= this->GetHeight()) {
+        was_in_bounds = false;
+        y %= this->GetHeight();
+    }
+    return was_in_bounds;
+}
+
+std::string BackendPng::get_type_message(png_byte color_type) {
+    std::string type_msg = "";
+    if (color_type == PNG_COLOR_TYPE_PALETTE) {
+        type_msg = " with indexed color";
+    } else if (color_type == PNG_COLOR_TYPE_GRAY) {
+        type_msg = " greyscale";
+    } else if (color_type == PNG_COLOR_TYPE_RGB) {
+        type_msg = " RGB";
+    } else if (color_type == PNG_COLOR_TYPE_RGBA) {
+        type_msg = " RGBA";
+    } else if (color_type == PNG_COLOR_TYPE_GA) {
+        type_msg = " greyscale+alpha";
+    } else {
+        type_msg = "type " + std::to_string(static_cast<unsigned char>(color_type));
+    }
+    return type_msg;
+}
+
+uint8_t BackendPng::GetRed(size_t x, size_t y) {
+    // PNG stores each pixel in RGBA order unless png_set_bgr is called,
+    //   or png_set_swap_alpha is called to move A to beginning
+    //   (See <http://www.libpng.org/pub/png/libpng-1.2.5-manual.html>).
+    this->clamp(x, y);
+    return buf[y * this->m_stride + x * this->m_pixel_size];
+}
+
+uint8_t BackendPng::GetGreen(size_t x, size_t y) {
+    this->clamp(x, y);
+    return buf[y * this->m_stride + x * this->m_pixel_size + 1];
+}
+
+uint8_t BackendPng::GetBlue(size_t x, size_t y) {
+    this->clamp(x, y);
+    return buf[y * this->m_stride + x * this->m_pixel_size + 2];
+}
+
+uint8_t BackendPng::GetLuma(size_t x, size_t y) {
+    this->clamp(x, y);
+    if (this->m_pixel_size < 3) { // GRAY or GRAY_ALPHA
+        return buf[y * this->m_stride + x * this->m_pixel_size];
+    }
+    size_t start = y * this->m_stride + x * this->m_pixel_size;
+    // To get something close to perceptible luminance, use the multipliers from
+    //   Rec. 709 such as used in HDTV. The multipliers total 1.0, so no additional
+    //   math is necessary to convert back to a byte range.
+    return static_cast<uint8_t>(
+        static_cast<float>(buf[start]) * .2126f // R
+        + static_cast<float>(buf[start+1]) * .7152f // G
+        + static_cast<float>(buf[start+2]) * .0722f // B
+    );
+}
+
 
 bool decode_png(IStream &in_buf, ImageGreyscale &out_img)
 {

--- a/src/libslic3r/PNGReadWrite.hpp
+++ b/src/libslic3r/PNGReadWrite.hpp
@@ -40,8 +40,12 @@ struct ReadBuf { const void *buf = nullptr; const size_t sz = 0; };
 
 bool is_png(const ReadBuf &pngbuf);
 
-/// Implement a drop-in replacement, in most or all use cases, for wxImage but for backend use.
-/// This class is based on the decode_png and elements from Image implementations, both from PNGReadWrite.*.
+/*!
+Implement a drop-in replacement, in most or all use cases, for wxImage but for backend use.
+This class is based on the decode_png and elements from Image implementations, both from PNGReadWrite.*.
+If this class is extended, it should imitate wxImage as much as possible for consistency between GUI and
+CLI code. Otherwise an interface should be created and this would be the backend implementation of that.
+*/
 class BackendPng {
 private:
     png_struct *png = nullptr;
@@ -59,29 +63,29 @@ private:
     bool load_png_file(std::string path);
     bool load_png_stream(IStream &in_buf, std::string optional_stated_path, bool next_busy);
     bool load_png_stream(const ReadBuf& in_buff, std::string optional_stated_path, bool next_busy);
-    bool clamp(size_t& x, size_t& y);
-    std::string get_type_message(png_byte color_type);
-    bool dump();
+    bool clamp(size_t& x, size_t& y) const;
+    std::string get_type_message(png_byte color_type) const;
+    bool dump() const;
 public:
     BackendPng() = default;
     BackendPng(const BackendPng&) = delete;
-    BackendPng(BackendPng&&) = delete;
-    BackendPng& operator=(const BackendPng&) = delete;
-    BackendPng& operator=(BackendPng&&) = delete;
+    // (BackendPng&&) = delete;
+    // BackendPng& operator=(const BackendPng&) = delete;
+    // BackendPng& operator=(BackendPng&&) = delete;
     void Destroy();
     ~BackendPng()
     {
         this->Destroy();
     }
-    bool IsOk();
-    std::string GetPath();
+    bool IsOk() const;
+    std::string GetPath() const;
     bool LoadFile(std::string path);
-    size_t GetWidth();
-    size_t GetHeight();
-    uint8_t GetRed(size_t x, size_t y);
-    uint8_t GetGreen(size_t x, size_t y);
-    uint8_t GetBlue(size_t x, size_t y);
-    uint8_t GetLuma(size_t x, size_t y);
+    size_t GetWidth() const;
+    size_t GetHeight() const;
+    uint8_t GetRed(size_t x, size_t y) const;
+    uint8_t GetGreen(size_t x, size_t y) const;
+    uint8_t GetBlue(size_t x, size_t y) const;
+    uint8_t GetLuma(size_t x, size_t y) const;
 };
 
 template<class Img> bool decode_png(const ReadBuf &in_buf, Img &out_img)

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -154,7 +154,8 @@ bool BackendImage::LoadGreyscalePng(std::string path) {
         this->image_path = "";
         this->busy = false;
         throw ConfigurationError(
-            "The fuzzy_skin_displacement_map \""+path+"\" does not exist. Change the path and re-slice to clear the invalid data."
+            "The fuzzy_skin_displacement_map \""
+            + path + "\" does not exist. Change the path and re-slice to clear the invalid state."
         );        
         // return false;
     }
@@ -175,7 +176,7 @@ bool BackendImage::LoadGreyscalePng(std::string path) {
         this->error_shown = true;
         throw ConfigurationError(
             std::string("Error: fuzzy_skin_displacement_map=\"")
-            + path + "\" wasn't recognized as an 8-bit Greyscale PNG file. Change the path and re-slice to clear the invalid data."
+            + path + "\" wasn't recognized as an 8-bit Greyscale PNG file. Change the path and re-slice to clear the invalid state."
         );
         // return false;
     }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -6,8 +6,6 @@
 
 #include <cmath>
 #include <cassert>
-#include <fstream>
-#include <vector>
 // typedef unsigned char Byte;
 
 // Get the correct sleep function:
@@ -143,149 +141,7 @@ public:
     bool is_internal_contour() const;
 };
 
-bool BackendImage::LoadGreyscalePng(std::string path) {
-    this->busy = true; // every return (and throw) statement must set this to false.
-    this->error_shown = false;
-    // Private since format-specific
-    // Load data using STL: See <https://stackoverflow.com/a/21802936/4541104>
-    std::vector <uint8_t> vec; // since ImageGreyscale uses template class Image with uint8_t for PxT (pixel type)
-    std::ifstream file(path, std::ios::binary);
-    if (file.fail()) {
-        this->image_path = "";
-        this->busy = false;
-        throw ConfigurationError(
-            "The fuzzy_skin_displacement_map \""
-            + path + "\" does not exist. Change the path and re-slice to clear the invalid state."
-        );        
-        // return false;
-    }
-    file.unsetf(std::ios::skipws); // Do not skip \n
-    std::streampos fileSize;
-    file.seekg(0, std::ios::end);
-    fileSize = file.tellg();
-    file.seekg(0, std::ios::beg);
-    vec.reserve(fileSize);
-    vec.insert(vec.begin(),
-               std::istream_iterator<uint8_t>(file),
-               std::istream_iterator<uint8_t>());
-    // Now translate the bytes to a png structure if that is proper:
-    png::ReadBuf        rb{static_cast<void*>(vec.data()), fileSize}; // pre-C++11: (void*)&pixels_[0]
-    if (!png::decode_png(rb, this->image)) {
-        this->image_path = "";
-        this->busy = false;
-        this->error_shown = true;
-        throw ConfigurationError(
-            std::string("Error: fuzzy_skin_displacement_map=\"")
-            + path + "\" wasn't recognized as an 8-bit Greyscale PNG file. Change the path and re-slice to clear the invalid state."
-        );
-        // return false;
-    }
-    this->image_path = path;
-    // this->dump(); // for debug only
-    this->busy = false;
-    return true;    
-}
-
-bool BackendImage::LoadFile(std::string path)
-{
-    double delay = .1;
-    double total_delay = 0.0;
-    double delay_timeout = 100; // how many seconds to wait for other thread(s)
-    while (this->busy) {
-        // wait for the other thread.
-        if (total_delay >= delay_timeout) {
-            std::cerr << "[BackendImage::LoadFile] waiting for other thread(s) timed out." << std::endl;
-            // FIXME: Find a way to avoid IsOK() is false after this if the image was still loading in another thread and will have succeeded.
-            break;
-        }
-        sleep(delay);
-        total_delay += delay;
-    }
-    if (total_delay > 0.0) {
-        if (this->path() == path) {
-            // Another thread already loaded the correct image.
-            return true;
-        }
-        else if (this->IsOk()) {
-            // Another thread probably already loaded the correct image.
-            return true;
-        }
-        else if (this->error_shown) {
-            // Assume another thread already failed,
-            //   otherwise the caller may throw more than once
-            //   (display more than one error dialog) when the path is
-            //   not blank but this->path() is blank (this->IsOk() is false).
-            return false;
-        }
-    }
-    // TODO: Support other formats if another headless (non-wx) image loader besides libpng is in the project.
-    return this->LoadGreyscalePng(path);
-}
-bool BackendImage::dump() {
-    std::cerr<<"[BackendImage] \"" << this->path() << "\" (OK:" << (this->IsOk()?"true":"false") << ") dump:" <<std::endl;
-    if (!this->IsOk()) return false;
-    for (size_t y=0; y<this->GetHeight(); y++) {
-        for (size_t x=0; x<this->GetWidth(); x++) {
-            std::cout << (x==0?"":",") << std::to_string(this->GetRed(x, y));
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl;
-    return true;
-}
-std::string BackendImage::path()
-{
-    return this->image_path;
-}
-size_t BackendImage::GetWidth()
-{
-    return this->image.cols;
-}
-size_t BackendImage::GetHeight()
-{
-    return this->image.rows;
-}
-bool BackendImage::Clamp(size_t& x, size_t& y) {
-    bool was_in_bounds = true;
-    if (x >= this->GetWidth()) {
-        was_in_bounds = false;
-        x %= this->GetWidth();
-    }
-    if (y >= this->GetHeight()) {
-        was_in_bounds = false;
-        y %= this->GetHeight();
-    }
-    return was_in_bounds;
-}
-uint8_t BackendImage::GetRed(size_t x, size_t y)
-{
-    this->Clamp(x, y);
-    return this->image.get(y, x);
-}
-uint8_t BackendImage::GetGreen(size_t x, size_t y)
-{
-    this->Clamp(x, y);
-    return this->image.get(y, x);
-}
-uint8_t BackendImage::GetBlue(size_t x, size_t y)
-{
-    this->Clamp(x, y);
-    return this->image.get(y, x);
-}
-bool BackendImage::IsOk()
-{
-    if (this->image_path == "") {
-        return false;
-    }
-    return true;
-}
-void BackendImage::Destroy()
-{
-    std::vector<uint8_t>().swap(this->image.buf);  // Swap buf with a new a tmp vector to reduce the buffer capacity (memory usage).
-    this->image_path = "";
-}
-
-BackendImage displacement_img;
+png::BackendPng displacement_img;
 
 // Thanks Cura developers for this function. PrusaSlicer community member Poikilos implemented displacement_img.
 static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuzzy_skin_point_dist, const double z)
@@ -312,12 +168,12 @@ static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuz
     if (mapped) {
         resolution = fuzzy_skin_point_dist; // A lower value can sharpen edges, but if a 1024x1024 image uses too high of a divisor (like 32 for a 200mm high model using 16MB RAM) the program will have increased slicing time by 32x (and likely have an OOM crash)!
         pixel_y = pixel_v;
-        // pixel_y = (double)(((int)(pixel_v+.5)) % displacement_img.GetHeight()); // +.5 to round; "Clamp" the texture using the "repeat" method (in graphics terms).
-        // pixel_y = displacement_img.GetHeight() - pixel_y; // Flip it so the bottom pixel (GetHeight()-1) is at the first layer(s) (z=~0) of the print.
+        pixel_y = static_cast<double>((static_cast<int>(pixel_v+.5)) % displacement_img.GetHeight()); // +.5 to round; "Clamp" the texture using the "repeat" method (in graphics terms).
+        pixel_y = displacement_img.GetHeight() - pixel_y; // Flip it so the bottom pixel (GetHeight()-1) is at the first layer(s) (z=~0) of the print.
         // std::cerr << "z=" << z << " / fuzzy_skin_point_dist=" << fuzzy_skin_point_dist << " and mapped becomes " << pixel_y << "" << std::endl; // debug only (and messy since multithreaded)
     }
     else {
-        dist_left_over = double(rand()) * (min_dist_between_points / 2) / double(RAND_MAX); // the distance to be traversed on the line before making the first new point
+        dist_left_over = double(rand()) * (min_dist_between_points / 2.) / double(RAND_MAX); // the distance to be traversed on the line before making the first new point
     }
     double total_dist = 0.0; // Keep track of total travel for displacement_img mapping.
     for (Point &p1 : poly.points)
@@ -331,7 +187,7 @@ static void fuzzy_polygon(Polygon &poly, double fuzzy_skin_thickness, double fuz
                 p0pa_dist += resolution)
             {
                 pixel_x = (double)((int)(pixel_u+.5) % displacement_img.GetWidth()); // +.5 to round; "Clamp" the texture using the "repeat" method (in graphics terms).
-                double value = double(displacement_img.GetBlue((int)(pixel_x+.5), (int)(pixel_y+.5))) / 255.0;
+                double value = double(displacement_img.GetLuma((int)(pixel_x+.5), (int)(pixel_y+.5))) / 255.0;
                 double r = (1.0 - value) * (fuzzy_skin_thickness * 2.) - fuzzy_skin_thickness;
                 // Adding +.5 before casting to int is effectively the same as rounding.
                 // Using GetBlue, GetRed or GetGreen doesn't matter since the image should have been loaded as gray.
@@ -371,7 +227,7 @@ using PerimeterGeneratorLoops = std::vector<PerimeterGeneratorLoop>;
 static ExtrusionEntityCollection traverse_loops(const PerimeterGenerator &perimeter_generator, const PerimeterGeneratorLoops &loops, ThickPolylines &thin_walls)
 {
     std::string this_displacement_map_path = perimeter_generator.config->fuzzy_skin_displacement_map.value;
-    if (this_displacement_map_path != displacement_img.path()) {
+    if (this_displacement_map_path != displacement_img.GetPath()) {
         if (this_displacement_map_path != "") {
             displacement_img.LoadFile(this_displacement_map_path);
             /*

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -7,8 +7,46 @@
 #include "Polygon.hpp"
 #include "PrintConfig.hpp"
 #include "SurfaceCollection.hpp"
+#include "PNGReadWrite.hpp"
 
 namespace Slic3r {
+
+class BackendImage
+{
+  private:
+    // PNGDescr* descr;
+    png::ImageGreyscale image;
+    std::string image_path;
+    bool LoadPng(std::string path);
+    bool Clamp(size_t& x, size_t& y);
+    bool busy;
+    bool error_shown; // Another thread already has shown an error so don't try load again (prevent multiple error dialogs).
+    bool dump(); // dump rgb values as CSV for debugging (HUGE stdout dump)
+  public:
+    BackendImage() :
+        // descr(nullptr),
+        error_shown(false),
+        busy(false)
+    {}
+    ~BackendImage() {
+        /*
+        if (descr != nullptr) {
+            delete descr;
+        }
+        */
+    }
+    bool LoadGreyscalePng(std::string path);
+    bool LoadFile(std::string path);
+    std::string path();
+    size_t GetWidth();
+    size_t GetHeight();
+     
+    uint8_t GetRed(size_t x, size_t y);
+    uint8_t GetGreen(size_t x, size_t y);
+    uint8_t GetBlue(size_t x, size_t y);
+    bool IsOk();
+    void Destroy();
+};
 
 class PerimeterGenerator {
 public:
@@ -28,10 +66,11 @@ public:
     ExtrusionEntityCollection   *loops;
     ExtrusionEntityCollection   *gap_fill;
     SurfaceCollection           *fill_surfaces;
+    const double                 z_of_current_layer;
     
     PerimeterGenerator(
         // Input:
-        const SurfaceCollection*    slices, 
+        const SurfaceCollection*    slices,
         double                      layer_height,
         Flow                        flow,
         const PrintRegionConfig*    config,
@@ -44,7 +83,9 @@ public:
         // Gaps without the thin walls
         ExtrusionEntityCollection*  gap_fill,
         // Infills without the gap fills
-        SurfaceCollection*          fill_surfaces)
+        SurfaceCollection*          fill_surfaces,
+        double                      z
+        )
         : slices(slices), lower_slices(nullptr), layer_height(layer_height),
             layer_id(-1), perimeter_flow(flow), ext_perimeter_flow(flow),
             overhang_flow(flow), solid_infill_flow(flow),
@@ -52,7 +93,8 @@ public:
             m_spiral_vase(spiral_vase),
             m_scaled_resolution(scaled<double>(print_config->gcode_resolution.value)),
             loops(loops), gap_fill(gap_fill), fill_surfaces(fill_surfaces),
-            m_ext_mm3_per_mm(-1), m_mm3_per_mm(-1), m_mm3_per_mm_overhang(-1)
+            m_ext_mm3_per_mm(-1), m_mm3_per_mm(-1), m_mm3_per_mm_overhang(-1),
+            z_of_current_layer(z)
         {}
 
     void        process();

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -8,6 +8,7 @@
 #include "PrintConfig.hpp"
 #include "SurfaceCollection.hpp"
 #include "PNGReadWrite.hpp"
+#include "Print.hpp" // PrintObject declaration etc
 
 namespace Slic3r {
 
@@ -23,7 +24,8 @@ public:
     Flow                         overhang_flow;
     Flow                         solid_infill_flow;
     const PrintRegionConfig     *config;
-    const PrintObjectConfig     *object_config;
+    const PrintObjectConfig     *object_config; // Deprecate since object is here now (Would require refactoring in several files)?
+    const PrintObject           *object;
     const PrintConfig           *print_config;
     // Outputs:
     ExtrusionEntityCollection   *loops;
@@ -31,28 +33,32 @@ public:
     SurfaceCollection           *fill_surfaces;
     const double                 z_of_current_layer;
     
-    PerimeterGenerator(
+    PerimeterGenerator( // also used in test_perimeters
         // Input:
         const SurfaceCollection*    slices,
         double                      layer_height,
         Flow                        flow,
         const PrintRegionConfig*    config,
-        const PrintObjectConfig*    object_config,
+        // const PrintObjectConfig*    object_config,
+        const PrintObject*          object, // must not be null if map such as fuzzy_skin_displacement_map is used
         const PrintConfig*          print_config,
         const bool                  spiral_vase,
+        double                      z,
+
         // Output:
         // Loops with the external thin walls
         ExtrusionEntityCollection*  loops,
         // Gaps without the thin walls
         ExtrusionEntityCollection*  gap_fill,
         // Infills without the gap fills
-        SurfaceCollection*          fill_surfaces,
-        double                      z
+        SurfaceCollection*          fill_surfaces
         )
         : slices(slices), lower_slices(nullptr), layer_height(layer_height),
             layer_id(-1), perimeter_flow(flow), ext_perimeter_flow(flow),
             overhang_flow(flow), solid_infill_flow(flow),
-            config(config), object_config(object_config), print_config(print_config),
+            config(config), print_config(print_config),
+            object_config(&object->config()),
+            object(object),
             m_spiral_vase(spiral_vase),
             m_scaled_resolution(scaled<double>(print_config->gcode_resolution.value)),
             loops(loops), gap_fill(gap_fill), fill_surfaces(fill_surfaces),

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -11,43 +11,6 @@
 
 namespace Slic3r {
 
-class BackendImage
-{
-  private:
-    // PNGDescr* descr;
-    png::ImageGreyscale image;
-    std::string image_path;
-    bool LoadPng(std::string path);
-    bool Clamp(size_t& x, size_t& y);
-    bool busy;
-    bool error_shown; // Another thread already has shown an error so don't try load again (prevent multiple error dialogs).
-    bool dump(); // dump rgb values as CSV for debugging (HUGE stdout dump)
-  public:
-    BackendImage() :
-        // descr(nullptr),
-        error_shown(false),
-        busy(false)
-    {}
-    ~BackendImage() {
-        /*
-        if (descr != nullptr) {
-            delete descr;
-        }
-        */
-    }
-    bool LoadGreyscalePng(std::string path);
-    bool LoadFile(std::string path);
-    std::string path();
-    size_t GetWidth();
-    size_t GetHeight();
-     
-    uint8_t GetRed(size_t x, size_t y);
-    uint8_t GetGreen(size_t x, size_t y);
-    uint8_t GetBlue(size_t x, size_t y);
-    bool IsOk();
-    void Destroy();
-};
-
 class PerimeterGenerator {
 public:
     // Inputs:

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -426,7 +426,7 @@ static std::vector<std::string> s_Preset_print_options {
     "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first",
     "ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
     "max_print_speed", "max_volumetric_speed", "avoid_crossing_perimeters_max_detour",
-    "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_dist",
+    "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_dist", "fuzzy_skin_displacement_map",
 #ifdef HAS_PRESSURE_EQUALIZER
     "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative",
 #endif /* HAS_PRESSURE_EQUALIZER */

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1302,6 +1302,17 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.8));
 
+    def = this->add("fuzzy_skin_displacement_map", coString);
+    def->label = L("Fuzzy skin displacement map");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("The fuzzy skin value will be from the mapped pixel brightness rather than random. "
+                     "The mapping is similar to cylindrical mapping within the scope of each perimeter, "
+                     "but the pixel offset is constant (based on fuzzy_skin_point_dist) "
+                     "to avoid changes in image scale along the Z axis.");
+    def->sidetext = L("Greyscale PNG file path (if used, point distance is mm per pixel)");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionString());
+
     def = this->add("gap_fill_enabled", coBool);
     def->label = L("Fill gaps");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1309,7 +1309,7 @@ void PrintConfigDef::init_fff_params()
                      "The mapping is similar to cylindrical mapping within the scope of each perimeter, "
                      "but the pixel offset is constant (based on fuzzy_skin_point_dist) "
                      "to avoid changes in image scale along the Z axis.");
-    def->sidetext = L("Greyscale PNG file path (if used, point distance is mm per pixel)");
+    def->sidetext = L("PNG file path (If used, point distance is mm per pixel where small decimals on big models may use more than 16G RAM).");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString());
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -557,6 +557,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<FuzzySkinType>,  fuzzy_skin))
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_dist))
+    ((ConfigOptionString,               fuzzy_skin_displacement_map))
     ((ConfigOptionBool,                 gap_fill_enabled))
     ((ConfigOptionFloat,                gap_fill_speed))
     ((ConfigOptionFloatOrPercent,       infill_anchor))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -147,6 +147,8 @@ void PrintObject::make_perimeters()
         if (! region.config().extra_perimeters || region.config().perimeters == 0 || region.config().fill_density == 0 || this->layer_count() < 2)
             continue;
 
+        //const png::BackendPng* tmp =
+        region.config().opt_image("fuzzy_skin_displacement_map", true);  // Preload the image in each region before threading (opt_image caches 1 per path).
         BOOST_LOG_TRIVIAL(debug) << "Generating extra perimeters for region " << region_id << " in parallel - start";
         tbb::parallel_for(
             tbb::blocked_range<size_t>(0, m_layers.size() - 1),

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -648,6 +648,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "fuzzy_skin"
             || opt_key == "fuzzy_skin_thickness"
             || opt_key == "fuzzy_skin_point_dist"
+            || opt_key == "fuzzy_skin_displacement_map"
             || opt_key == "overhangs"
             || opt_key == "thin_walls"
             || opt_key == "thick_bridges") {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1456,6 +1456,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("fuzzy_skin", category_path + "fuzzy-skin-type");
         optgroup->append_single_option_line("fuzzy_skin_thickness", category_path + "fuzzy-skin-thickness");
         optgroup->append_single_option_line("fuzzy_skin_point_dist", category_path + "fuzzy-skin-point-distance");
+        optgroup->append_single_option_line("fuzzy_skin_displacement_map", category_path + "fuzzy-skin-displacement-map");
 
     page = add_options_page(L("Infill"), "infill");
         category_path = "infill_42#";

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -37,6 +37,7 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
     };
 
     FullPrintConfig config;
+    // PrintObject* object_ptr = new PrintObject(...);
 
     auto test = [&config](const TestData &data) {
         SurfaceCollection slices;
@@ -51,11 +52,13 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
             1., // layer height
             Flow(1., 1., 1.),
             static_cast<const PrintRegionConfig*>(&config),
-            static_cast<const PrintObjectConfig*>(&config),
+            // static_cast<const PrintObjectConfig*>(&config),
+            nullptr, // object_ptr, // PrintObject*; nullptr is ok only if no map (such as fuzzy_skin_displacement_map) since maps require bounding_box for mapping.
             static_cast<const PrintConfig*>(&config),
             false, // spiral_vase
+            z,
             // output:
-            &loops, &gap_fill, &fill_surfaces, z);
+            &loops, &gap_fill, &fill_surfaces);
         perimeter_generator.process();
 
         THEN("expected number of collections") {

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -45,6 +45,7 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
         ExtrusionEntityCollection loops;
         ExtrusionEntityCollection gap_fill;
         SurfaceCollection         fill_surfaces;
+        double z = 0.0;
         PerimeterGenerator        perimeter_generator(
             &slices, 
             1., // layer height
@@ -54,7 +55,7 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
             static_cast<const PrintConfig*>(&config),
             false, // spiral_vase
             // output:
-            &loops, &gap_fill, &fill_surfaces);
+            &loops, &gap_fill, &fill_surfaces, z);
         perimeter_generator.process();
 
         THEN("expected number of collections") {


### PR DESCRIPTION
I would like to help PrusaSlicer start an industry trend of allowing a displacement map to be applied during the slicing stage similar to the vb_fuzzy_skin branch. It is good for many simple tasks like brick walls, which are popularly uploaded to model sites with displacement maps applied. For example, https://www.thingiverse.com/thing:5190970 makes Blender run at 1 frame per 30+ sec on an old i7 while doing any editing.