### PR TITLE
Fix build errors reported by gcc 14

### DIFF
--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -751,7 +751,7 @@ bool PrusaLink::get_storage(wxArrayString& storage_path, wxArrayString& storage_
                 if (path && (!available || *available)) {
                     StorageInfo si;
                     si.path = boost::nowide::widen(*path);
-                    si.name = name ? boost::nowide::widen(*name) : wxString();
+                    si.name = name ? boost::nowide::widen(*name) : std::wstring();
                     // If read_only is missing, assume it is NOT read only.
                     // si.read_only = read_only ? *read_only : false; // version without "ro"
                     si.read_only = (read_only ? *read_only : (ro ? *ro : false));

--- a/src/slic3r/Utils/PrusaConnect.cpp
+++ b/src/slic3r/Utils/PrusaConnect.cpp
@@ -257,7 +257,7 @@ bool PrusaConnectNew::get_storage(wxArrayString& storage_path, wxArrayString& st
                     if (path && (!available || *available)) {
                         StorageInfo si;
                         si.path = boost::nowide::widen(*path);
-                        si.name = name ? boost::nowide::widen(*name) : wxString();
+                        si.name = name ? boost::nowide::widen(*name) : std::wstring();
                         // If read_only is missing, assume it is NOT read only.
                         // si.read_only = read_only ? *read_only : false; // version without "ro"
                         si.read_only = (read_only ? *read_only : (ro ? *ro : false));


### PR DESCRIPTION
gcc 14 reports ambiguous function calls and ternary type mismatches. The patches of this PR address those issues.