### PR TITLE
Avoid null pointer dereference for partial configuration settings

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5130,7 +5130,14 @@ void DynamicPrintConfig::normalize_fdm()
         }
     }
 
-    if (this->has("wipe_tower_extruder")) {
+    // This method is called repeatedly while building configuration.  We may
+    // not have enough info yet to determine whether the extruder is valid;
+    // wait until we do before checking.
+    //
+    // NOTE:  other extruder validation (e.g. perimeter_extruder, infill_extruder)
+    // happens elsewhere, as those settings can be modified for specific print
+    // objects or sometimes even regions of objects.
+    if (this->has("wipe_tower_extruder") && this->has("nozzle_diameter")) {
         // If invalid, replace with 0.
         int extruder = this->opt<ConfigOptionInt>("wipe_tower_extruder")->value;
         int num_extruders = this->opt<ConfigOptionFloats>("nozzle_diameter")->size();


### PR DESCRIPTION
Fixes https://github.com/prusa3d/PrusaSlicer/issues/13864.

I first looked at how other extruder configuration options were validated and/or normalized.  I found them at:

https://github.com/prusa3d/PrusaSlicer/blob/5c7888b11453eb96a95b49dfd4cbd3b56db64eb8/src/libslic3r/PrintObject.cpp#L2598-L2599
and:
https://github.com/prusa3d/PrusaSlicer/blob/5c7888b11453eb96a95b49dfd4cbd3b56db64eb8/src/libslic3r/PrintObject.cpp#L2650-L2652

Upon further analysis, I determined that ```wipe_tower_extruder``` validation does not really fit in either spot -- as far as I can tell, the ```wipe_tower_extruder``` can only be set at the print level, whereas the others can be set for individual objects (for supports) or even regions of an object (for the rest).

I considered adding another call of ```clamp_exturder_to_default``` [sic] in several other locations, such as within ```Print::validate(std::vector<std::string>*)``` or ```Print::apply(const Model &, DynamicPrintConfig)```.  Quite possibly one of these spots could have worked, however due to my unfamiliarity with the code base, I was concerned that I may accidentally introduce other bugs.  I also felt a large amount of testing would be required to validate such a change.  For instance, I was not sure at what point it is no longer safe to change configuration (i.e. updating ```wipe_tower_extruder``` to a valid value) due to other logic already relying on it.

After a lot of deliberation, it seemed to me that ```DynamicPrintConfig::normalize_fdm()``` could work after all (despite my initial concerns expressed in https://github.com/prusa3d/PrusaSlicer/issues/13864).  I examined where it is called, and I found it is used in several stages of processing configuration -- for example, for each file provided by a ```--load``` command line option, for presets, for default FFF or SLA print options, and so on.

Even though early calls to ```DynamicPrintConfig::normalize_fdm()``` do not necessarily have full configuration (i.e. the original bug), for sure later calls do.  And it seemed to me that someone had already tested ```wipe_tower_extruder``` validation at this location (just not without ```nozzle_diameter``` in the same file) to prove that this could work.

I did build this and do some very basic testing (a few command line calls, including what I was originally doing when I encountered the segmentation fault in the first place).