### PR TITLE
Fix unit test fff_print_tests

### DIFF
--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -73,8 +73,27 @@ And that's it. It is now possible to run the freshly built PrusaSlicer binary:
     cd src
     ./prusa-slicer
 
+#### 4. Running Unit Tests
 
+For the most complete unit testing, use the Debug build option `-DCMAKE_BUILD_TYPE=Debug` when running cmake.
+Without the Debug build, internal assert statements are not tested.
 
+To run the unit tests:
+
+    cd build
+    make test
+
+To run a specific unit test:
+
+    cd build/tests/
+
+The unit tests can be found by
+
+    `ls */*_tests`
+
+Any of these unit tests can be run directly e.g.
+
+    `./fff_print/fff_print_tests`
 
 ## Useful CMake flags when building dependencies
 

--- a/doc/How to build - Mac OS.md
+++ b/doc/How to build - Mac OS.md
@@ -63,6 +63,28 @@ Alternatively, if you would like to use XCode GUI, modify the `cmake` command to
 and then open the `PrusaSlicer.xcodeproj` file.
 This should open up XCode where you can perform build using the GUI or perform other tasks.
 
+### Running Unit Tests
+
+For the most complete unit testing, use the Debug build option `-DCMAKE_BUILD_TYPE=Debug` when running cmake.
+Without the Debug build, internal assert statements are not tested.
+
+To run all the unit tests:
+
+    cd build
+    make test
+
+To run a specific unit test:
+
+    cd build/tests/
+
+The unit tests can be found by
+
+    `ls */*_tests`
+
+Any of these unit tests can be run directly e.g.
+
+    `./fff_print/fff_print_tests`
+
 ### Note on Mac OS X SDKs
 
 By default PrusaSlicer builds against whichever SDK is the default on the current system.

--- a/doc/How to build - Windows.md
+++ b/doc/How to build - Windows.md
@@ -58,8 +58,28 @@ Debug->Start Debugging or press F5
 
 PrusaSlicer should start. You're up and running!
 
+### Running Unit Tests
+
+For the most complete unit testing, use the Debug build option `-DCMAKE_BUILD_TYPE=Debug` when running cmake.
+Without the Debug build, internal assert statements are not tested.
+
+To run the unit tests:
+
+    cd build
+    make test
 
 
+To run a specific unit test:
+
+    cd build\tests
+
+The unit tests can be found by
+
+    `dir *\*_tests`
+
+Any of these unit tests can be run directly e.g.
+
+    `.\fff_print\fff_print_tests`
 
 ## 2.B Run the automatic build script
 

--- a/tests/fff_print/test_gcode.cpp
+++ b/tests/fff_print/test_gcode.cpp
@@ -119,12 +119,12 @@ std::optional<double> parse_axis(const std::string& line, const std::string& axi
 * - no travel moves go outside skirt
 * - temperatures are set correctly
 */
-TEST_CASE("Extrusion, travels, temeperatures", "[GCode]") {
+TEST_CASE("Extrusion, travels, temperatures", "[GCode]") {
     DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
     config.set_deserialize_strict({
         { "gcode_comments", 1 },
         { "complete_objects", 1 },
-        { "extrusion_axis", 'A' },
+        { "extrusion_axis", "A" },
         { "start_gcode", "" },  // prevent any default extra Z move
         { "layer_height", 0.4 },
         { "first_layer_height", 0.4 },
@@ -174,6 +174,11 @@ TEST_CASE("Extrusion, travels, temeperatures", "[GCode]") {
         }
     });
 
+    // Remove last travel_moves returning to origin
+    if (travel_moves.back().x() == 0 && travel_moves.back().y() == 0) {
+        travel_moves.pop_back();
+    }
+
     const unsigned layer_count = 20 / 0.4;
     INFO("Complete_objects generates the correct number of Z moves.");
     CHECK(z_moves.size() == layer_count * 2);
@@ -192,20 +197,30 @@ TEST_CASE("Extrusion, travels, temeperatures", "[GCode]") {
 
 
 TEST_CASE("Used filament", "[GCode]") {
-    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
-    config.set_deserialize_strict({
-        { "retract_length", "1000000" },
+    DynamicPrintConfig config1 = Slic3r::DynamicPrintConfig::full_print_config();
+    config1.set_deserialize_strict({
+        { "retract_length", "0" },
         { "use_relative_e_distances", 1 },
         { "layer_gcode", "G92 E0\n" },
     });
-	GCodeReader parser;
-    Print print;
-    Model model;
-    Test::init_print({TestMesh::cube_20x20x20}, print, model, config);
-    Test::gcode(print);
+    Print print1;
+    Model model1;
+    Test::init_print({TestMesh::cube_20x20x20}, print1, model1, config1);
+    Test::gcode(print1);
+
+    DynamicPrintConfig config2 = Slic3r::DynamicPrintConfig::full_print_config();
+    config2.set_deserialize_strict({
+        { "retract_length", "999" },
+        { "use_relative_e_distances", 1 },
+        { "layer_gcode", "G92 E0\n" },
+    });
+    Print print2;
+    Model model2;
+    Test::init_print({TestMesh::cube_20x20x20}, print2, model2, config2);
+    Test::gcode(print2);
 
     INFO("Final retraction is not considered in total used filament");
-    CHECK(print.print_statistics().total_used_filament > 0);
+    CHECK(print1.print_statistics().total_used_filament == print2.print_statistics().total_used_filament);
 }
 
 void check_m73s(Print& print){

--- a/tests/fff_print/test_retraction.cpp
+++ b/tests/fff_print/test_retraction.cpp
@@ -135,11 +135,6 @@ void test_slicing(std::initializer_list<TestMesh> meshes, DynamicPrintConfig& co
         check_gcode(meshes, config, duplicate);
     }
 
-    SECTION("Negative restart extra length") {
-        config.set_deserialize_strict({{ "retract_restart_extra", "-1" }});
-        check_gcode(meshes, config, duplicate);
-    }
-
     SECTION("Retract_lift") {
         config.set_deserialize_strict({{ "retract_lift", "1,2" }});
         check_gcode(meshes, config, duplicate);


### PR DESCRIPTION
fff_print_tests fail when run in Debug mode:
At commit 5c7888b11453eb96a95b49dfd4cbd3b56db64eb8

```bash
user@prusa:/home/user/PrusaSlicer/build-debug$ make test
Running tests...
Test project /home/user/PrusaSlicer/build-debug
    Start 1: arrange_tests
1/6 Test #1: arrange_tests ....................   Passed   34.79 sec
    Start 2: thumbnails_tests
2/6 Test #2: thumbnails_tests .................   Passed    0.39 sec
    Start 3: libslic3r_tests
3/6 Test #3: libslic3r_tests ..................Subprocess aborted***Exception: 100.95 sec
    Start 4: fff_print_tests
4/6 Test #4: fff_print_tests ..................Subprocess aborted***Exception: 376.86 sec
    Start 5: sla_print_tests
5/6 Test #5: sla_print_tests ..................   Passed  3161.06 sec
    Start 6: slic3rutils_tests
6/6 Test #6: slic3rutils_tests ................   Passed   16.77 sec

67% tests passed, 2 tests failed out of 6

Total Test time (real) = 3690.87 sec

The following tests FAILED:
	  3 - libslic3r_tests (Subprocess aborted)
	  4 - fff_print_tests (Subprocess aborted)
Errors while running CTest
Output from these tests are in: /home/user/PrusaSlicer/build-debug/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
user@prusa:/home/user/PrusaSlicer/build-debug$ 
```
This pull request addresses the failures in the fff_print_tests.

```bash
user@prusa:/home/user/PrusaSlicer/build-debug$ make test
Running tests...
Test project /home/user/PrusaSlicer/build-debug
    Start 1: arrange_tests
1/6 Test #1: arrange_tests ....................   Passed   31.95 sec
    Start 2: thumbnails_tests
2/6 Test #2: thumbnails_tests .................   Passed    0.03 sec
    Start 3: libslic3r_tests
3/6 Test #3: libslic3r_tests ..................Subprocess aborted***Exception:  94.54 sec
    Start 4: fff_print_tests
4/6 Test #4: fff_print_tests ..................   Passed  1178.31 sec
    Start 5: sla_print_tests
5/6 Test #5: sla_print_tests ..................   Passed  3006.60 sec
    Start 6: slic3rutils_tests
6/6 Test #6: slic3rutils_tests ................   Passed   16.55 sec

83% tests passed, 1 tests failed out of 6

Total Test time (real) = 4328.06 sec

The following tests FAILED:
	  3 - libslic3r_tests (Subprocess aborted)
Errors while running CTest
Output from these tests are in: /home/user/PrusaSlicer/build-debug/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8
user@prusa:/home/user/PrusaSlicer/build-debug$ 
```

Tested on Ubuntu 22.04 virtual machine.

The following changes were made:

* Fix fff_print_tests assertion failure axis.size() <= 1
PrusaSlicer/src/libslic3r/GCodeReader.cpp:24: char Slic3r::get_extrusion_axis_char(const Slic3r::GCodeConfig&): Assertion `axis.size() <= 1' failed.
The set_deserialise_strict() method converts 'A' to the string "65" (representing the ASCII numerical value) instead of the string "A". Perhaps this should be fixed more robustly.
* Fix fff_print_tests test name Temeperatures -> Temperatures
* Fix fff_print_tests All travel moves happen within skirt
Remove the last travel_moves point which returns to the origin (0,0) which is outside the convex hull. This point was causing CHECK(convex_hull.contains(travel_move)) to fail.
* Fix fff_print_tests "Used Filament" test Assertion `std::abs(length) < 1000.0' failed
The test configured a retract_length of 10000000 which is larger than the asserted maximum retraction length of 1000.
PrusaSlicer/src/libslic3r/GCode/GCodeWriter.cpp:473: std::string Slic3r::GCodeWriter::_retract(double, double, std::string_view): Assertion `std::abs(length) < 1000.0' failed.
Fixed by doing the print with two different (legal) retraction lengths and checking that the total_used_filament agrees in both cases.
* Fix fff_print_tests "Slicing with retraction and lifting" remove illegal negative restart_extra test case
Negative restart_extra is asserted against at PrusaSlicer/src/libslic3r/Extrucer.cpp:58
* How to build - add instructions on how to run the unit tests
