### PR TITLE
Build libslic3r-arrange/wrapper as static

### DIFF
--- a/src/slic3r-arrange-wrapper/CMakeLists.txt
+++ b/src/slic3r-arrange-wrapper/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(slic3r-arrange-wrapper)
 cmake_minimum_required(VERSION 3.13)
 
-add_library(slic3r-arrange-wrapper
+add_library(slic3r-arrange-wrapper STATIC
     include/arrange-wrapper/Arrange.hpp
     include/arrange-wrapper/ArrangeSettingsDb_AppCfg.hpp
     include/arrange-wrapper/ArrangeSettingsView.hpp

--- a/src/slic3r-arrange/CMakeLists.txt
+++ b/src/slic3r-arrange/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(slic3r-arrange)
 cmake_minimum_required(VERSION 3.13)
 
-add_library(slic3r-arrange
+add_library(slic3r-arrange STATIC
     include/arrange/Beds.hpp
     include/arrange/ArrangeItemTraits.hpp
     include/arrange/PackingContext.hpp


### PR DESCRIPTION
Fix build on linux without SLIC3R_STATIC (these are for internal use only).

- Avoids the need for installation (fixes https://github.com/prusa3d/PrusaSlicer/pull/13812)
- Fixes build without PIC (fixes https://github.com/prusa3d/PrusaSlicer/pull/13810, https://github.com/prusa3d/PrusaSlicer/issues/13694), which would still result in broken behavior (duplicate static initialization crashing on startup).