### PR TITLE
2.9.0 Wayland build

### DIFF
--- a/deps/+GLEW/GLEW.cmake
+++ b/deps/+GLEW/GLEW.cmake
@@ -5,4 +5,5 @@ add_cmake_project(
   SOURCE_SUBDIR build/cmake
   CMAKE_ARGS
     -DBUILD_UTILS=OFF
+    -DGLEW_EGL=ON
 )

--- a/deps/+wxWidgets/wxWidgets.cmake
+++ b/deps/+wxWidgets/wxWidgets.cmake
@@ -28,8 +28,8 @@ else ()
 endif ()
 
 add_cmake_project(wxWidgets
-    URL https://github.com/prusa3d/wxWidgets/archive/323a465e577e03f330e2e6a4c78e564d125340cb.zip
-    URL_HASH SHA256=B538E4AD3CC93117932F4DED70C476D6650F9C70A9D4055A08F3693864C47465
+    URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5.tar.bz2
+    URL_HASH SHA256=0AD86A3AD3E2E519B6A705248FC9226E3A09BBF069C6C692A02ACF7C2D1C6B51
     PATCH_COMMAND COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/webview.patch
     CMAKE_ARGS
         "-DCMAKE_DEBUG_POSTFIX:STRING="
@@ -51,7 +51,7 @@ add_cmake_project(wxWidgets
         -DwxUSE_EXPAT=sys
         -DwxUSE_LIBSDL=OFF
         -DwxUSE_XTEST=OFF
-        -DwxUSE_GLCANVAS_EGL=OFF
+        -DwxUSE_GLCANVAS_EGL=ON
         -DwxUSE_WEBREQUEST=OFF
         ${_wx_webview}
         ${_wx_secretstore}

--- a/src/PrusaSlicer.cpp
+++ b/src/PrusaSlicer.cpp
@@ -90,11 +90,6 @@ int CLI::run(int argc, char **argv)
     save_main_thread_id();
 
 #ifdef __WXGTK__
-    // On Linux, wxGTK has no support for Wayland, and the app crashes on
-    // startup if gtk3 is used. This env var has to be set explicitly to
-    // instruct the window manager to fall back to X server mode.
-    ::setenv("GDK_BACKEND", "x11", /* replace */ true);
-
     // https://github.com/prusa3d/PrusaSlicer/issues/12969
     ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
     ::setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1", /* replace */ false);
@@ -802,9 +797,8 @@ int CLI::run(int argc, char **argv)
     #if !defined(_WIN32) && !defined(__APPLE__)
         // likely some linux / unix system
         const char *display = boost::nowide::getenv("DISPLAY");
-        // const char *wayland_display = boost::nowide::getenv("WAYLAND_DISPLAY");
-        //if (! ((display && *display) || (wayland_display && *wayland_display))) {
-        if (! (display && *display)) {
+        const char *wayland_display = boost::nowide::getenv("WAYLAND_DISPLAY");
+        if (! ((display && *display) || (wayland_display && *wayland_display))) {
             // DISPLAY not set.
             boost::nowide::cerr << "DISPLAY not set, GUI mode not available." << std::endl << std::endl;
             this->print_help(false);

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -607,7 +607,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     // Always fill in the "printhost_port" combo box from the config and select it.
     {
         Choice* choice = dynamic_cast<Choice*>(m_optgroup->get_field("printhost_port"));
-        choice->set_values({ m_config->opt_string("printhost_port") });
+        choice->set_values(std::vector<std::string>({ m_config->opt_string("printhost_port") }));
         choice->set_selection();
     }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4420,7 +4420,7 @@ void Plater::load_project(const wxString& filename)
     s_multiple_beds.set_loading_project_flag(true);
     ScopeGuard guard([](){ s_multiple_beds.set_loading_project_flag(false);});
 
-    if (! load_files({ into_path(filename) }).empty()) {
+    if (! load_files(std::vector<boost::filesystem::path>({ into_path(filename) })).empty()) {
         // At least one file was loaded.
         p->set_project_filename(filename);
         // Save the names of active presets and project specific config into ProjectDirtyStateManager.


### PR DESCRIPTION
Rebased #13307 and applied a gentoo patch to fix initializers when using the newer wxwidgets. 
Only issue I've encountered so far is that when returning to the plater view, the top menu bar disappears until an input is detected. I don't know if this is an issue of my device or the wayland patch, I don't have an X11 environment to test right now.