### PR TITLE
[FEATURE] Add bed (plate) number placeholder

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1220,6 +1220,9 @@ void GCodeGenerator::_do_export(Print& print, GCodeOutputStream &file, Thumbnail
     this->placeholder_parser().set("has_wipe_tower", has_wipe_tower);
     this->placeholder_parser().set("has_single_extruder_multi_material_priming", has_wipe_tower && print.config().single_extruder_multi_material_priming);
     this->placeholder_parser().set("total_toolchanges", tool_ordering.toolchanges_count());
+
+    this->placeholder_parser().set("bed_number", new ConfigOptionString(print.get_bed_number_formatted()));
+
     {
         BoundingBoxf bbox(print.config().bed_shape.values);
         assert(bbox.defined);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -36,6 +36,7 @@
 #include "libslic3r/GCode/ConflictChecker.hpp"
 #include "Utils.hpp"
 #include "BuildVolume.hpp"
+#include "MultipleBeds.hpp"
 #include "format.hpp"
 #include "ArrangeHelper.hpp"
 #include "CustomParametersHandling.hpp"
@@ -1581,6 +1582,7 @@ std::string Print::output_filename(const std::string &filename_base) const
     DynamicConfig config = this->finished() ? this->print_statistics().config() : this->print_statistics().placeholders();
     config.set_key_value("num_extruders", new ConfigOptionInt((int)m_config.nozzle_diameter.size()));
     config.set_key_value("default_output_extension", new ConfigOptionString(".gcode"));
+    config.set_key_value("bed_number", new ConfigOptionString(get_bed_number_formatted()));
 
     // Handle output_filename_format. There is a hack related to binary G-codes: gcode / bgcode substitution.
     std::string output_filename_format = m_config.output_filename_format.value;
@@ -1590,6 +1592,14 @@ std::string Print::output_filename(const std::string &filename_base) const
         output_filename_format.erase(output_filename_format.end()-6);
 
     return this->PrintBase::output_filename(output_filename_format, ".gcode", filename_base, &config);
+}
+
+std::string Print::get_bed_number_formatted() const
+{
+    std::string bed_number = std::to_string(s_multiple_beds.get_active_bed() + 1);
+    static const size_t n_zero = 2;
+
+    return std::string(n_zero - std::min(n_zero, bed_number.length()), '0') + bed_number;
 }
 
 // Returns if all used filaments have same shrinkage compensations.

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -734,6 +734,8 @@ public:
 
 	std::string                 output_filename(const std::string &filename_base = std::string()) const override;
 
+	std::string                 get_bed_number_formatted() const;
+
     size_t                      num_print_regions() const throw() { return m_print_regions.size(); }
     const PrintRegion&          get_print_region(size_t idx) const  { return *m_print_regions[idx]; }
     const ToolOrdering&         get_tool_ordering() const { return m_wipe_tower_data.tool_ordering; }


### PR DESCRIPTION
Make the bed/plate number available as a output filaname placeholder, using `[bed_number]`
