### PR TITLE
Fix typo in layer region test

### DIFF
--- a/tests/libslic3r/test_layer_region.cpp
+++ b/tests/libslic3r/test_layer_region.cpp
@@ -131,7 +131,7 @@ TEST_CASE_METHOD(LayerRegionFixture, "test the bridge expansion with the bridge 
     }
 
     REQUIRE(result.size() == 2);
-    CHECK(std::fmod(result.at(1).bridge_angle, M_PI) == Approx(0.0));
+    CHECK(std::fmod(result.at(0).bridge_angle, M_PI) == Approx(0.0));
     CHECK(std::fmod(result.at(1).bridge_angle, M_PI) == Approx(0.0));
     CHECK(result.at(0).expolygon.contour.size() == 22);
     CHECK(result.at(1).expolygon.contour.size() == 14);


### PR DESCRIPTION
This fixes the result index in the check. The same result was checked twice in the test case. While adjusting the syntax of the first check in a91a7d6b0e32bb6e446175f33e5ecd324537c07c the result index was changed, too.

I would suspect that the change of the index in a91a7d6b0e32bb6e446175f33e5ecd324537c07c was a typo. It does not seem to make sense to check `result.at(1)` twice and skip `result.at(0)`.