### PR TITLE
Apply fan_below_layer_time to dynamic fan speeds

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -873,7 +873,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
 
                 fan_speed_new                        = std::clamp(int(float(fan_speed_new) * factor + 0.5f), 0, 100);
                 bridge_fan_speed                     = std::clamp(int(float(bridge_fan_speed) * factor + 0.5f), 0, 100);
-                requested_fan_speed_limits.max_speed = fan_speed_new;
+                requested_fan_speed_limits.max_speed = std::clamp(int(float(requested_fan_speed_limits.max_speed) * factor + 0.5f), 0, 100);
             }
 
 #undef EXTRUDER_CONFIG


### PR DESCRIPTION
The current implementation of dynamic fan speeds are disabled entirely when fan_below_layer_time is in effect. This patch is a small change that makes dynamic fan speeds scale the way the normal fan speeds do.

The following images is are from an [attached file](https://github.com/user-attachments/files/18430356/dynamic_fan_speed_test.zip) that demonstrates the an abrupt change in fan speeds at the bottom of the sphere without the patch, but a smooth transition with the patch.

### Without Patch
![image](https://github.com/user-attachments/assets/81b2916c-350a-4da1-a313-199f397b73c3)

### With Patch
![image](https://github.com/user-attachments/assets/61b1c18c-af5a-4a67-9630-29ca1b0b758d)
