### PR TITLE
Handle libcurl v8+

### DIFF
--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -200,7 +200,7 @@ bool Http::priv::ca_file_supported(::CURL *curl)
 
 	if (curl == nullptr) { return res; }
 
-#if LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 48
+#if LIBCURL_VERSION_NUM >= 0x073000 // equivalent to v7.48 or greater
 	::curl_tlssessioninfo *tls;
 	if (::curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &tls) == CURLE_OK) {
 		if (tls->backend == CURLSSLBACKEND_SCHANNEL || tls->backend == CURLSSLBACKEND_DARWINSSL) {
@@ -364,7 +364,7 @@ void Http::priv::http_perform(const HttpRetryOpt& retry_opts)
 	::curl_easy_setopt(curl, CURLOPT_READFUNCTION, form_file_read_cb);
 
 	::curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-#if LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 32
+#if LIBCURL_VERSION_NUM >= 0x072000 // equivalent to v7.32 or higher
 	::curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xfercb);
 	::curl_easy_setopt(curl, CURLOPT_XFERINFODATA, static_cast<void*>(this));
 #ifndef _WIN32


### PR DESCRIPTION
The tests for curl versions in Http.cpp are intended to check if libcurl is at least a given version, but they don't account for the fact that the minor version will reset when the major version increments.

Fix this by testing `LIBCURL_VERSION_NUM`, which encodes the full version as a single three-byte number, with bytes corresponding to the major, minor and patch numbers.

Fixes #14009