### PR TITLE
Expansion of the Zig Zag Infill to Allow Control of Angles for Patterning like Cura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
+/build-default

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
-/build-default

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
+/build-default
+/.gitignore
+/.gitignore
+/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,3 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
-/build-default
-/.gitignore
-/.gitignore
-/.gitignore

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -179,7 +179,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        params.pattern 		 = region_config.fill_pattern.value;
 		        params.density       = float(region_config.fill_density);
 
-				std::vector<int> zz_angles;
+		        std::vector<int> zz_angles;
                 //Parsing the angles from the setting
                 if (params.pattern == ipZigZag) {
                     std::string split_me = region_config.infill_zigzag_angles;

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -179,7 +179,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        params.pattern 		 = region_config.fill_pattern.value;
 		        params.density       = float(region_config.fill_density);
 
-		        std::vector<int> zz_angles;
+                std::vector<int> zz_angles;
                 //Parsing the angles from the setting
                 if (params.pattern == ipZigZag) {
                     std::string split_me = region_config.infill_zigzag_angles;

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -181,7 +181,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 
 				std::vector<int> zz_angles;
                 //Parsing the angles from the setting
-				if (params.pattern == ipZigZag) {
+                if (params.pattern == ipZigZag) {
                     std::string split_me = region_config.infill_zigzag_angles;
                     std::stringstream ss(split_me);
 

--- a/src/libslic3r/Fill/FillBase.hpp
+++ b/src/libslic3r/Fill/FillBase.hpp
@@ -104,6 +104,8 @@ public:
     coordf_t    overlap;
     // in radians, ccw, 0 = East
     float       angle;
+    //For the Zig Zag infill, there is a setting to control the line directions
+    std::vector<int> zigzag_infill_angles;
     // In scaled coordinates. Maximum lenght of a perimeter segment connecting two infill lines.
     // Used by the FillRectilinear2, FillGrid2, FillTriangles, FillStars and FillCubic.
     // If left to zero, the links will not be limited.

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -2795,7 +2795,7 @@ bool FillRectilinear::fill_surface_by_lines(const Surface *surface, const FillPa
         return true;
     }
 
-     // For infill that needs to be consistent between layers (like Zig Zag),
+    // For infill that needs to be consistent between layers (like Zig Zag),
     // we use bounding box of whole object to match vertical lines between layers.
     BoundingBox bounding_box_src = poly_with_offset.bounding_box_src();
     BoundingBox bounding_box     = this->has_consistent_pattern() ? this->extended_object_bounding_box() : bounding_box_src;

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -2896,7 +2896,7 @@ bool FillRectilinear::fill_surface_by_lines(const Surface *surface, const FillPa
             // increments.
             flip = ((adjusted_angle / 180) % 2) == 1;
         } 
-		traverse_graph_generate_polylines(poly_with_offset, params, segs, this->has_consistent_pattern(), flip, polylines_out);
+        traverse_graph_generate_polylines(poly_with_offset, params, segs, this->has_consistent_pattern(), flip, polylines_out);
     }
 
 #ifdef SLIC3R_DEBUG

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -1367,6 +1367,7 @@ static void traverse_graph_generate_polylines(const ExPolygonWithOffset         
                                               const FillParams                       &params,
                                               std::vector<SegmentedIntersectionLine> &segs,
                                               const bool                              consistent_pattern,
+                                              const bool                             flip,
                                               Polylines                              &polylines_out)
 {
     // For each outer only chords, measure their maximum distance to the bow of the outer contour.
@@ -1412,7 +1413,12 @@ static void traverse_graph_generate_polylines(const ExPolygonWithOffset         
 
                     // For infill that needs to be consistent between layers (like Zig Zag),
                     // we are switching between forward and backward passes based on the line index.
-                    const bool forward_pass = !consistent_pattern || (i_vline2 % 2 == 0);
+                    bool forward_pass = (!consistent_pattern || (i_vline2 % 2 == 0)); 
+                    //With Consistent Patterns (aka Zigzag), swap forward/backwards passes
+                    //based on the flip parameter.
+                    if (consistent_pattern && flip)
+                        forward_pass = !forward_pass;
+
                     for (int i = 0; i < int(vline.intersections.size()); ++i) {
                         const int                  intrsctn_idx = forward_pass ? i : int(vline.intersections.size()) - i - 1;
                         const SegmentIntersection &intrsctn     = vline.intersections[intrsctn_idx];
@@ -2789,7 +2795,7 @@ bool FillRectilinear::fill_surface_by_lines(const Surface *surface, const FillPa
         return true;
     }
 
-    // For infill that needs to be consistent between layers (like Zig Zag),
+     // For infill that needs to be consistent between layers (like Zig Zag),
     // we use bounding box of whole object to match vertical lines between layers.
     BoundingBox bounding_box_src = poly_with_offset.bounding_box_src();
     BoundingBox bounding_box     = this->has_consistent_pattern() ? this->extended_object_bounding_box() : bounding_box_src;
@@ -2832,7 +2838,7 @@ bool FillRectilinear::fill_surface_by_lines(const Surface *surface, const FillPa
 
     std::vector<SegmentedIntersectionLine> segs = slice_region_by_vertical_lines(poly_with_offset, n_vlines, x0, line_spacing);
     // Connect by horizontal / vertical links, classify the links based on link_max_length as too long.
-	connect_segment_intersections_by_contours(poly_with_offset, segs, params, link_max_length);
+    connect_segment_intersections_by_contours(poly_with_offset, segs, params, link_max_length);
 
 #ifdef SLIC3R_DEBUG
     // Paint the segments and finalize the SVG file.
@@ -2875,7 +2881,22 @@ bool FillRectilinear::fill_surface_by_lines(const Surface *surface, const FillPa
 		    polylines_from_paths(path, poly_with_offset, segs, polylines_out);
         }
 	} else {
-		traverse_graph_generate_polylines(poly_with_offset, params, segs, this->has_consistent_pattern(), polylines_out);
+        bool flip = false;
+        std::vector<int> zigzag_angles = this->zigzag_infill_angles;
+        int num_angles = zigzag_angles.size();
+
+        if (num_angles > 1) {
+            int adjusted_angle = this->angle;
+            adjusted_angle = zigzag_angles[((this->layer_id / surface->thickness_layers) % num_angles)];
+
+            // With the ZigZag Infill, the original code was not differentiating between 180 and 0.
+            // The lines were all going in the same direction. To combat that, if our angle is
+            // over 180, let's tell the next function to flip (do a backwards pass instead of a forward).
+            // Just in case someone enters more than 360 degrees, we'll go ahead and adjust that to 180
+            // increments.
+            flip = ((adjusted_angle / 180) % 2) == 1;
+        } 
+		traverse_graph_generate_polylines(poly_with_offset, params, segs, this->has_consistent_pattern(), flip, polylines_out);
     }
 
 #ifdef SLIC3R_DEBUG

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -474,7 +474,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ensure_vertical_shell_thickness", "extra_perimeters", "extra_perimeters_on_overhangs",
     "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",
     "seam_position", "staggered_inner_seams", "seam_gap_distance",
-    "external_perimeters_first", "fill_density", "fill_pattern", "top_fill_pattern", "bottom_fill_pattern",
+    "external_perimeters_first", "fill_density", "fill_pattern", "infill_zigzag_angles", "top_fill_pattern", "bottom_fill_pattern",
     "scarf_seam_placement", "scarf_seam_only_on_smooth", "scarf_seam_start_height", "scarf_seam_entire_loop", "scarf_seam_length", "scarf_seam_max_segment_length", "scarf_seam_on_inner_perimeters",
     "infill_every_layers", /*"infill_only_where_needed",*/ "solid_infill_every_layers", "fill_angle", "bridge_angle",
     "solid_infill_below_area", "only_retract_when_crossing_perimeters", "infill_first",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1557,6 +1557,16 @@ void PrintConfigDef::init_fff_params()
     });
     def->set_default_value(new ConfigOptionEnum<InfillPattern>(ipStars));
 
+    def = this->add("infill_zigzag_angles", coString);
+    def->label = L("Zig Zag Angles");
+    def->category = L("Infill");
+    def->tooltip = L("List of angles to exercise more control over the Zig Zag Infill pattern. Enter in whole number degrees 0 through "
+                     "360. The multiple angles are separated by commas. If this setting is blank, "
+                     "has only one angle, or has invalid input (like letters), the \"Fill angle\" setting is used.");
+    def->sidetext = L("°,°,…");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionString("90,0"));
+
     def = this->add("first_layer_acceleration", coFloat);
     def->label = L("First layer");
     def->tooltip = L("This is the acceleration your printer will use for first layer. Set zero "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -708,6 +708,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                fill_angle))
     ((ConfigOptionPercent,              fill_density))
     ((ConfigOptionEnum<InfillPattern>,  fill_pattern))
+    ((ConfigOptionString,               infill_zigzag_angles))
     ((ConfigOptionEnum<FuzzySkinType>,  fuzzy_skin))
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_dist))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -300,6 +300,13 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         toggle_field(el, have_infill);
     }
 
+    //Do we enable the extra zigzag angle setting?
+    const bool have_zigzag_infill = have_infill && (config->option<ConfigOptionEnum<InfillPattern>>("fill_pattern")
+                                  ->value == ipZigZag);
+    for (auto el : {"infill_zigzag_angles"}) {
+        toggle_field(el, have_zigzag_infill);
+    }
+
     toggle_field("infill_every_layers", have_infill && !has_automatic_infill_combination);
     toggle_field("automatic_infill_combination_max_layer_height", have_infill && has_automatic_infill_combination);
 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -315,7 +315,18 @@ void Field::get_value_by_opt_type(wxString& str, const bool check_value/* = true
         m_value = val;
 		break; }
 	case coString:
-	case coStrings:
+        if (m_opt_id == "infill_zigzag_angles") {
+            wxString label = m_opt.full_label.empty() ? _(m_opt.label) : _(m_opt.full_label);
+            //^(\d+,\s*)+(\d+(,\s*)*)+$
+            if (!is_matched(str.ToStdString(), "^(\\d+,\\s*)+(\\d+(,\\s*)*)+$")) {
+                show_error(m_parent, format_wxstr(_L("%s is expecting a comma-delimited list of whole number, positive, angles in degrees. For example, \"90,0\"."), label));
+                m_value = into_u8(str);
+                break;
+            }
+        }
+        //Note - Leaving out a break; here so it falls through. "Thumbnails" is a coString
+        //but its logic is in the coFloatOrPercent case.
+    case coStrings:
     case coFloatsOrPercents:
     case coFloatOrPercent: {
         if (m_opt.type == coFloatOrPercent && m_opt.opt_key == "first_layer_height" && !str.IsEmpty() && str.Last() == '%') {

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -317,7 +317,6 @@ void Field::get_value_by_opt_type(wxString& str, const bool check_value/* = true
 	case coString:
         if (m_opt_id == "infill_zigzag_angles") {
             wxString label = m_opt.full_label.empty() ? _(m_opt.label) : _(m_opt.full_label);
-            //^(\d+,\s*)+(\d+(,\s*)*)+$
             if (!is_matched(str.ToStdString(), "^(\\d+,\\s*)+(\\d+(,\\s*)*)+$")) {
                 show_error(m_parent, format_wxstr(_L("%s is expecting a comma-delimited list of whole number, positive, angles in degrees. For example, \"90,0\"."), label));
                 m_value = into_u8(str);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1489,6 +1489,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Infill"));
         optgroup->append_single_option_line("fill_density", category_path + "fill-density");
         optgroup->append_single_option_line("fill_pattern", category_path + "fill-pattern");
+        optgroup->append_single_option_line("infill_zigzag_angles", category_path + "infill_zigzag_angles");
         optgroup->append_single_option_line("infill_anchor", category_path + "fill-pattern");
         optgroup->append_single_option_line("infill_anchor_max", category_path + "fill-pattern");
         optgroup->append_single_option_line("top_fill_pattern", category_path + "top-fill-pattern");


### PR DESCRIPTION
This code expands upon the work done for [Issue 12613](https://github.com/prusa3d/PrusaSlicer/issues/12613) which made the Zig Zag Infill consistently aligned like Cura's. One thing that makes the technique of printing without perimeters so powerful in Cura is providing a list of angles for the Zig Zag Infill to use. This helps produce patterns in the slice. 

This code adds that ability with a new "**Expert Mode**" setting under **Infill** called "**Zig Zag Angles**". It is only enabled if "**Zig Zag**" is selected from the **Fill pattern** dropdown. It expects a comma-delimited list of whole number angles. There is a popup via a regular expression to alert the user if his/her input is flawed. Should the user continue without correcting the data, it doesn't crash the application. If necessary, the default PrusaSlicer 2.9.0 behavior kicks in using the "Infill angle" setting.

![image](https://github.com/user-attachments/assets/2a945551-2247-430a-a149-5f8c66dcfa14)
 _New "Zig Zag Angles" Setting_
  
![image](https://github.com/user-attachments/assets/b3ce4953-0f9c-4448-8561-90b6dbf8f127)
 _"Zig Zag Angles" Only Enabled for the Zig Zag Fill Pattern_

![image](https://github.com/user-attachments/assets/667326e2-e0dd-4d60-b4f4-345c346374bd)
 _Warning Message on Input_
 
###  **Examples from Testing**
 
![image](https://github.com/user-attachments/assets/2f9e5734-731b-4bf7-ad59-7c268a793213)
_90,0,90,0,90,0,90,180,90,180,90,180_

![image](https://github.com/user-attachments/assets/4f942adf-60b9-4f79-aee4-3c6408e28810)
_60, 120, 180, 240, 300, 360_

![image](https://github.com/user-attachments/assets/ba6b1668-8e84-41df-b331-415623d7caa4)
_100,220,340,110,220,350,120,240,360_

### **Comparison with Cura**
Using a [shoe-like model](https://www.printables.com/model/73061-wooden-clog-shoe-dolls/)* , the patterns do seem to translate well from what Cura users would be accustomed to.
![image](https://github.com/user-attachments/assets/a77790bb-aa90-46a1-a832-e3bee8509984)
![image](https://github.com/user-attachments/assets/37b227ac-3c9a-46a7-86d3-a109091594ef)
_Model in Cura and PrusaSlicer with New Code Using the Same Angles_

*Note - Model was fixed in 3D Builder before testing.

### **Regression Testing of Other Features**
Other infills types that use FillRectlinear.cpp were tested to make sure they still match the output of PrusaSlicer 2.9.0
![image](https://github.com/user-attachments/assets/3bd1fd04-07fb-49e5-8583-e1373dab3796)
![image](https://github.com/user-attachments/assets/ad30794c-a687-4ca4-ab06-910ef9662cc7)
![image](https://github.com/user-attachments/assets/9161a1f8-53dc-4a7a-a621-50753ad5ca34)

The input validation for the **G-code Thumbnails** setting to confirm that is still working after the updates.
![image](https://github.com/user-attachments/assets/8f0c454b-ff27-4adc-8973-0cc1001eac71)
