### PR TITLE
Emit toolchange before fan speed

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -906,13 +906,13 @@ std::string CoolingBuffer::apply_layer_cooldown(
         if (line_start > pos)
             new_gcode.append(pos, line_start - pos);
         if (line->type & CoolingLine::TYPE_SET_TOOL) {
+            new_gcode.append(line_start, line_end - line_start);
             unsigned int new_extruder = 0;
             auto res = std::from_chars(line_start + m_toolchange_prefix.size(), line_end, new_extruder);
             if (res.ec != std::errc::invalid_argument && new_extruder != m_current_extruder) {
                 m_current_extruder = new_extruder;
                 change_extruder_set_fan();
             }
-            new_gcode.append(line_start, line_end - line_start);
         } else if (line->type & CoolingLine::TYPE_SET_FAN_SPEED) {
             change_extruder_set_fan(line->fan_speed);
         } else if (line->type & CoolingLine::TYPE_RESET_FAN_SPEED){


### PR DESCRIPTION
The order of the toolchange and fan speed G-codes is wrong for IDEX printers.
The tool needs to be changed before the fan speed is set or else the fan speed is set for the wrong extruder.

Fixes #13057.