### PR TITLE
Fix slider dragging when leaving window

### DIFF
--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -293,7 +293,7 @@ bool ImGuiWrapper::update_mouse_data(wxMouseEvent& evt)
 
     ImGuiIO& io = ImGui::GetIO();
     io.MousePos = ImVec2((float)evt.GetX(), (float)evt.GetY());
-    io.MouseDown[0] = evt.LeftIsDown();
+    io.MouseDown[0] = evt.LeftIsDown() || (evt.Leaving() && (m_mouse_buttons & 1));
     io.MouseDown[1] = evt.RightIsDown();
     io.MouseDown[2] = evt.MiddleIsDown();
     io.MouseDoubleClicked[0] = evt.LeftDClick();


### PR DESCRIPTION
There seems to be a bug on macOS where even when the left mouse button is pressed, if you drag the cursor out of the main window, the button will read as not pressed. This will end a drag gesture, which causes unwanted behavior with the layer & gcode sliders if they are still being dragged.

This commit checks if the event is a 'leaving' event, and if so, will use the prior update call's left mouse down state. This avoids the erroneous reading and maintains the drag, if there was one.

Fixes #12879 