### PR TITLE
Update GCode.cpp's support_material_bottom_contact_distance check to allow 0 value

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -363,7 +363,7 @@ GCodeGenerator::ObjectsLayerToPrint GCodeGenerator::collect_layers_to_print(cons
             // Allow empty support layers, as the support generator may produce no extrusions for non-empty support regions.
             || (layer_to_print.support_layer /* && layer_to_print.support_layer->has_extrusions() */)) {
             double top_cd = object.config().support_material_contact_distance;
-            double bottom_cd = object.config().support_material_bottom_contact_distance == 0. ? top_cd : object.config().support_material_bottom_contact_distance;
+            double bottom_cd = object.config().support_material_bottom_contact_distance == -1 ? top_cd : object.config().support_material_bottom_contact_distance;
 
             double extra_gap = (layer_to_print.support_layer ? bottom_cd : top_cd);
 


### PR DESCRIPTION
See Issue #14205

Fixed the check on line 366 to allow 0 values for the support_material_bottom_contact_distance. Whoever wrote this never imagined that the value would be set to 0, which is not uncommon.