### PR TITLE
TriangleMesh.cpp: fix undefined refs to slice_mesh_ex(), s_empty_facet, Qhull, triangulate_expolygons_3d()

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -571,6 +571,7 @@ add_library(libslic3r_cgal STATIC
     CutSurface.hpp CutSurface.cpp
     Geometry/VoronoiUtilsCgal.hpp Geometry/VoronoiUtilsCgal.cpp
     IntersectionPoints.hpp IntersectionPoints.cpp
+    TriangleMesh.hpp TriangleMesh.cpp
     MeshBoolean.hpp MeshBoolean.cpp
     TryCatchSignal.hpp TryCatchSignal.cpp
     Triangulation.hpp Triangulation.cpp

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -21,6 +21,7 @@ if (TARGET OpenVDB::openvdb)
     set(OpenVDBUtils_SOURCES OpenVDBUtils.cpp OpenVDBUtils.hpp OpenVDBUtilsLegacy.hpp)
 endif()
 
+find_package(Qhull REQUIRED COMPONENTS qhullcpp qhull_r)
 find_package(LibBGCode REQUIRED COMPONENTS Convert)
 slic3r_remap_configs(LibBGCode::bgcode_core RelWithDebInfo Release)
 slic3r_remap_configs(LibBGCode::bgcode_binarize RelWithDebInfo Release)
@@ -572,7 +573,10 @@ add_library(libslic3r_cgal STATIC
     Geometry/VoronoiUtilsCgal.hpp Geometry/VoronoiUtilsCgal.cpp
     IntersectionPoints.hpp IntersectionPoints.cpp
     TriangleMesh.hpp TriangleMesh.cpp
+    TriangleMeshSlicer.hpp TriangleMeshSlicer.cpp
     MeshBoolean.hpp MeshBoolean.cpp
+    Tesselate.cpp
+    Tesselate.hpp
     TryCatchSignal.hpp TryCatchSignal.cpp
     Triangulation.hpp Triangulation.cpp
     SLA/SupportIslands/VoronoiDiagramCGAL.hpp SLA/SupportIslands/VoronoiDiagramCGAL.cpp
@@ -596,7 +600,7 @@ if (_opts)
     target_compile_options(libslic3r_cgal PRIVATE "${_opts_bad}")
 endif()
 
-target_link_libraries(libslic3r_cgal PRIVATE ${_cgal_tgt} libigl)
+target_link_libraries(libslic3r_cgal PRIVATE ${_cgal_tgt} libigl ankerl qhull glu-libtess)
 target_link_libraries(libslic3r_cgal PUBLIC semver admesh localesutils)
 
 if (MSVC AND "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4") # 32 bit MSVC workaround
@@ -619,6 +623,7 @@ target_link_libraries(libslic3r PRIVATE
     libexpat
     glu-libtess
     qhull
+    qhull_r
     TBB::tbb
     TBB::tbbmalloc
     libslic3r_cgal
@@ -634,13 +639,13 @@ target_link_libraries(libslic3r PUBLIC
     Eigen3::Eigen
     semver
     admesh
+    ankerl
     localesutils
     LibBGCode::bgcode_convert
     tcbspan
     miniz
     libigl
     agg
-    ankerl
     boost_headeronly
     libseqarrange
 )

--- a/src/libslic3r/TriangleMesh.hpp
+++ b/src/libslic3r/TriangleMesh.hpp
@@ -138,7 +138,7 @@ public:
     TriangleMesh(const std::vector<Vec3f> &vertices, const std::vector<Vec3i> &faces);
     TriangleMesh(std::vector<Vec3f> &&vertices, const std::vector<Vec3i> &&faces);
     explicit TriangleMesh(const indexed_triangle_set &M);
-    explicit TriangleMesh(indexed_triangle_set &&M, const RepairedMeshErrors& repaired_errors = RepairedMeshErrors());
+    explicit TriangleMesh(indexed_triangle_set &&M, RepairedMeshErrors const& repaired_errors = RepairedMeshErrors());
     void clear() { this->its.clear(); m_stats.clear(); }
     void from_facets(std::vector<stl_facet> &&facets, bool repair = true);
     bool ReadSTLFile(const char* input_file, bool repair = true);

--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -2206,6 +2206,17 @@ std::vector<ExPolygons> slice_mesh_ex(
     return layers;
 }
 
+std::vector<ExPolygons>  slice_mesh_ex(
+    const indexed_triangle_set       &mesh,
+    const std::vector<float>         &zs,
+    float                             closing_radius,
+    std::function<void()>             throw_on_cancel)
+{
+    MeshSlicingParamsEx params;
+    params.closing_radius = closing_radius;
+    return slice_mesh_ex(mesh, zs, params, throw_on_cancel);
+}
+
 // Slice a triangle set with a set of Z slabs (thick layers).
 // The effect is similar to producing the usual top / bottom layers from a sliced mesh by 
 // subtracting layer[i] from layer[i - 1] for the top surfaces resp.

--- a/src/libslic3r/TriangleMeshSlicer.hpp
+++ b/src/libslic3r/TriangleMeshSlicer.hpp
@@ -103,23 +103,18 @@ std::vector<ExPolygons>         slice_mesh_ex(
     const MeshSlicingParamsEx        &params,
     std::function<void()>             throw_on_cancel = []{});
 
+std::vector<ExPolygons>  slice_mesh_ex(
+    const indexed_triangle_set       &mesh,
+    const std::vector<float>         &zs,
+    float                             closing_radius,
+    std::function<void()>             throw_on_cancel = []{});
+
 inline std::vector<ExPolygons>  slice_mesh_ex(
     const indexed_triangle_set       &mesh,
     const std::vector<float>         &zs,
     std::function<void()>             throw_on_cancel = []{})
 {
     return slice_mesh_ex(mesh, zs, MeshSlicingParamsEx{}, throw_on_cancel);
-}
-
-inline std::vector<ExPolygons>  slice_mesh_ex(
-    const indexed_triangle_set       &mesh,
-    const std::vector<float>         &zs,
-    float                             closing_radius,
-    std::function<void()>             throw_on_cancel = []{})
-{
-    MeshSlicingParamsEx params;
-    params.closing_radius = closing_radius;
-    return slice_mesh_ex(mesh, zs, params, throw_on_cancel);
 }
 
 // Slice a triangle set with a set of Z slabs (thick layers).


### PR DESCRIPTION
Fixes a few more undefined references so Git version can successfully build on Linux Fedora 42.
