### PR TITLE
Slicing.cpp: PrintObjectSlice.cpp: Allow switching printers with incompatible min/max layer height.

### DIFF
--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -573,7 +573,7 @@ void PrintObject::slice()
             }
         });
     if (m_layers.empty())
-        throw Slic3r::SlicingError("No layers were detected. You might want to repair your STL file(s) or check their size or thickness and retry.\n");    
+        throw Slic3r::SlicingError("No layers were detected. Either variable layer height exceeded this printer's min/max layer height capabilities or STL file(s) need repair. Change sizes or thickness and retry slicing.\n");    
     this->set_done(posSlice);
 }
 

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -642,7 +642,15 @@ std::vector<coordf_t> generate_object_layers(
                 const coordf_t z2 = layer_height_profile[next] * shrinkage_compensation_z;
                 const coordf_t h2 = layer_height_profile[next + 1];
                 height = lerp(h1, h2, (slice_z - z1) / (z2 - z1));
-                assert(height >= slicing_params.min_layer_height - EPSILON && height <= slicing_params.max_layer_height + EPSILON);
+                // FIXME: This function needs error return.
+                // Going to try aborting with empty {} instead of assert.
+                if (height < slicing_params.min_layer_height - EPSILON) {
+                    std::cerr << "Error: Layer height (" << height << ") below printer's minimum (" << slicing_params.min_layer_height << ").\n";
+                    return {};
+                } else if (height > slicing_params.max_layer_height + EPSILON) {
+                    std::cerr << "Error: Layer height (" << height << ") above printer's maximum (" << slicing_params.max_layer_height << ").\n";
+                    return {};
+                }
             }
         }
         slice_z = print_z + 0.5 * height;


### PR DESCRIPTION
Print a friendly warning instead of crashing when user changes printer to one with an unsupported minimum or maximum layer height setting. Thus allowing them to choose different layer height, turn off VLH, adjust printer settings, etc.
$ make test
Running tests...
Test project /home/k/Downloads/src/Prusa/build
    Start 1: libseqarrange_tests
1/7 Test #1: libseqarrange_tests ..............   Passed   53.59 sec
    Start 2: arrange_tests
2/7 Test #2: arrange_tests ....................   Passed    3.50 sec
    Start 3: thumbnails_tests
3/7 Test #3: thumbnails_tests .................   Passed    0.01 sec
    Start 4: libslic3r_tests
4/7 Test #4: libslic3r_tests ..................   Passed    7.82 sec
    Start 5: fff_print_tests
5/7 Test #5: fff_print_tests ..................   Passed   33.44 sec
    Start 6: sla_print_tests
6/7 Test #6: sla_print_tests ..................   Passed   33.50 sec
    Start 7: slic3rutils_tests
7/7 Test #7: slic3rutils_tests ................   Passed    3.30 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 135.16 sec