### PR TITLE
Fix MPFR URL

### DIFF
--- a/deps/+MPFR/MPFR.cmake
+++ b/deps/+MPFR/MPFR.cmake
@@ -31,7 +31,7 @@ else ()
         EXCLUDE_FROM_ALL ON
         #URL http://ftp.vim.org/ftp/gnu/mpfr/mpfr-3.1.6.tar.bz2 https://www.mpfr.org/mpfr-3.1.6/mpfr-3.1.6.tar.bz2  # mirrors are allowed
         #URL_HASH SHA256=cf4f4b2d80abb79e820e78c8077b6725bbbb4e8f41896783c899087be0e94068
-        URL https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.bz2
+        URL https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.bz2
         URL_HASH SHA256=b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0
         DOWNLOAD_DIR ${${PROJECT_NAME}_DEP_DOWNLOAD_DIR}/MPFR
         BUILD_IN_SOURCE ON


### PR DESCRIPTION
Fixes MPFR URL. It currently points to the page for the current version, but since MPFR released a new version, the URL is now invalid. This updates the URL to point to the page for version 4.2.1.

Fixes #14309