### PR TITLE
libseqarrange: Fix building with debug build type (2.9.2-rc2)

### DIFF
--- a/src/libseqarrange/src/seq_sequential.cpp
+++ b/src/libseqarrange/src/seq_sequential.cpp
@@ -11679,11 +11679,6 @@ bool optimize_SubglobalConsequentialPolygonNonoverlappingBinaryCentered(const So
 		{
 		    printf("  %d\n", undecided[j]);
 		}
-		printf("Missing\n");
-		for (unsigned int j = 0; j < missing.size(); ++j)
-		{
-		    printf("  %d\n", missing[j]);
-		}		
 		printf("Decided\n");
 		for (unsigned int j = 0; j < decided_polygons.size(); ++j)
 		{


### PR DESCRIPTION
Fix building PrusaSlicer with `-DCMAKE_BUILD_TYPE=Debug`.