### PR TITLE
Add user preference to hide Printables tab

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -806,8 +806,10 @@ void MainFrame::create_preset_tabs()
     add_created_tab(new TabPrinter(m_tabpanel), wxGetApp().preset_bundle->printers.get_edited_preset().printer_technology() == ptFFF ? "printer" : "sla_printer");
     
     m_printables_webview = new PrintablesWebViewPanel(m_tabpanel);
-    add_printables_webview_tab();
-   
+
+    if (!wxGetApp().app_config->has("show_printables_button") || wxGetApp().app_config->get_bool("show_printables_button"))
+        add_printables_webview_tab();
+
     m_connect_webview = new ConnectWebViewPanel(m_tabpanel);
     m_printer_webview = new PrinterWebViewPanel(m_tabpanel, L"");
    
@@ -908,7 +910,6 @@ void MainFrame::add_printables_webview_tab()
     m_printables_webview_added = true;
 }
 
-// no longer needed?
 void MainFrame::remove_printables_webview_tab()
 {
     if (!m_printables_webview_added) {
@@ -2322,6 +2323,15 @@ void MainFrame::update_ui_from_settings()
 //    m_plater->sidebar().Layout();
 
     update_topbars();
+
+    if (wxGetApp().app_config->has("show_printables_button"))
+    {
+        if (wxGetApp().app_config->get_bool("show_printables_button")) {
+            add_printables_webview_tab();
+        } else {
+            remove_printables_webview_tab();
+        }
+    }
 
     if (m_plater)
         m_plater->update_ui_from_settings();

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -135,7 +135,7 @@ void PreferencesDialog::show(const std::string& highlight_opt_key /*= std::strin
 		downloader->set_path_name(app_config->get("url_downloader_dest"));
 		downloader->allow(!app_config->has("downloader_url_registered") || app_config->get_bool("downloader_url_registered"));
 
-		for (const std::string opt_key : {"suppress_hyperlinks", "downloader_url_registered", "show_login_button", "show_step_import_parameters"})
+		for (const std::string opt_key : {"suppress_hyperlinks", "downloader_url_registered", "show_login_button"})
 			m_optgroup_other->set_value(opt_key, app_config->get_bool(opt_key));
 		// by default "Log in" button is visible
 		if (!app_config->has("show_login_button"))
@@ -643,6 +643,11 @@ void PreferencesDialog::build()
 			L("Allow downloads from Printables.com"),
 			L("If enabled, PrusaSlicer will be allowed to download from Printables.com"),
 			app_config->get_bool("downloader_url_registered"));
+
+		append_bool_option(m_optgroup_other, "show_printables_button",
+			L("Show \"Printables\" button in application top bar"),
+			L("If enabled, PrusaSlicer will show the \"Printables\" button in application top bar."),
+			app_config->get_bool("show_printables_button"));
 
 		activate_options_tab(m_optgroup_other);
 


### PR DESCRIPTION
Hello,

I added a user preference to be able to hide the Printables button

I also find that I misclick the button quite often since it is next to the physical printers button and for some reason my muscle memory will click it accidentally. I don't need the feature so it would be better to have the ability to optionally hide it
I followed the code from 7ec2f34 but feel free to suggest any modifications or testing as needed

For testing, I tried:
* making sure that it's enabled and visible by default
* with and without an existing preference
* enabling and disabling the preference
* the preference is properly persisted

Fixes #13927

Thanks for your consideration