### PR TITLE
[BUGFIX] Ensure unique names when labeling objects

### DIFF
--- a/src/libslic3r/GCode/LabelObjects.cpp
+++ b/src/libslic3r/GCode/LabelObjects.cpp
@@ -105,12 +105,13 @@ void LabelObjects::init(const SpanOfConstPtrs<PrintObject>& objects, LabelObject
                 name += " id:" + std::to_string(object_id) + " copy " + std::to_string(instance_id); 
             }
             else if (m_label_objects_style == LabelObjectsStyle::Firmware) {
-                // use one-based indexing for objects and instances so indices match what we see in PrusaSlicer.
-                ++object_id;
-                ++instance_id;
+                // uses one-based indexing for objects and instances so indices match what we see in PrusaSlicer.
+
+                // Ensure unique name in case multiple objects have the same name
+                name += "_" + std::to_string(object_id + 1);
 
                 if (object_has_more_instances)
-                    name += " (Instance " + std::to_string(instance_id) + ")";
+                    name += " (Instance " + std::to_string(instance_id + 1) + ")";
                 if (m_flavor == gcfKlipper) {
                     // Disallow Klipper special chars, common illegal filename chars, etc.
                     const std::string banned = "\b\t\n\v\f\r \"#%&\'*-./:;<>\\";


### PR DESCRIPTION
When using firmware specific object labeling the object names generated are not unique. To reproduce add multiple shapes to the build plate and export the g-code.
This will result in exclude object definitions like this:

```
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box' ...
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box' ...
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box' ...
...
```

With this patch the naming scheme has been changed:
- The object ID is only increased when a new object is being processed
- The object ID is always appended to the base name of the object
- The instance ID is appended to objects with multiple instances.

This results in the following names:
```
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_1'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_2'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_3'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_4'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_5_(Instance_1)'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_5_(Instance_2)'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_5_(Instance_3)'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_5_(Instance_4)'
EXCLUDE_OBJECT_DEFINE NAME='Shape_Box_6'
```

This has been reported in https://github.com/prusa3d/PrusaSlicer/issues/13308
