### PR TITLE
[BUGFIX] Avoid invalid Wipetower G-Code (G1 F-2147483648)

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -278,6 +278,9 @@ public:
 // Loads filament while also moving towards given points in x-axis (x feedrate is limited by cutting the distance short if necessary)
     WipeTowerWriter& load_move_x_advanced(float farthest_x, float loading_dist, float loading_speed, float max_x_speed = 50.f)
     {
+        if (loading_dist == 0.f || loading_speed == 0.f)
+            return *this;
+
         float time = std::abs(loading_dist / loading_speed); // time that the move must take
         float x_distance = std::abs(farthest_x - x());       // max x-distance that we can travel
         float x_speed = x_distance / time;                   // x-speed to do it in that time


### PR DESCRIPTION
Setup instructions for some open source MMUs recommend setting all ramming and cooling parameters to 0 when using a filament cutter. This in turn leads to division by zero errors in the wipe tower g-code, and the outcome depends on the operating system and compiler being used.

At least on builds for Windows with VC2019 the bug leads to invalid code for the cooling moves that looks like this:

```
;WIDTH:0.5
G1 X98.896 Y232.718
G1 F3000
G1 F-2147483648
G1 F3000
G1 F-2147483648
G1 F3000
G1 F-2147483648
G1 F3000
G1 F-2147483648
G1 F2000
G1 X98.846 Y232.718 F2400
```

The behavior seems to originate from the compiller spec recommending turning a NaN float value (from the division by zero) into an INT_MIN when casting from float to int.

This diff avoids emitting the whole cooling move when either speed or distance are 0.
