### PR TITLE
Ender 5 Plus and others: Fix post print bed dropping to bottom

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -1653,6 +1653,10 @@ pause_print_gcode = M25 ; pause print
 
 # Intended for printers where the Z-axis lowers the print bed during printing, like the Ender-5 series
 [printer:*descendingz*]
+end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; move print head out of the way\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
+
+# Intended for printers where the Z-axis lowers the print bed during printing, like the Ender-5 series and want to lower the bed a large amount to present the print
+[printer:*descendingzprintpresentation*]
 end_gcode = {if max_layer_z < max_print_height}G1 Z{z_offset+min(max_layer_z+2, max_print_height)} F600{endif} ; Move print bed down\nG1 X50 Y50 F{travel_speed*60} ; move print head out of the way\n{if max_layer_z < max_print_height-10}G1 Z{z_offset+max_print_height-10} F600{endif} ; Move print bed close to the bottom\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors
 
 # Intended for printers with a much larger bed, like the CR-10 S4/S5 series


### PR DESCRIPTION
- Removed "Move print bed close to the bottom" from [printer:*descendingz*] group so the printer bed doesn't "drop a mile" at the end of every print. This is slow and inefficient behavior, especially on large printers like the Ender 5 plus.

- Create [printer:*descendingzprintpresentation*] to allow existing print presentation behavior for those who want "Move print bed close to the bottom" to be maintained.