### PR TITLE
[BUGFIX] Update Eigen SHA

### DIFF
--- a/deps/+Eigen/Eigen.cmake
+++ b/deps/+Eigen/Eigen.cmake
@@ -1,4 +1,4 @@
 add_cmake_project(Eigen
     URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip"
-    URL_HASH SHA256=e09b89aae054e9778ee3f606192ee76d645eec82c402c01c648b1fe46b6b9857
+    URL_HASH SHA256=4815118c085ff1d5a21f62218a3b2ac62555e9b8d7bacd5093892398e7a92c4b
 )


### PR DESCRIPTION
v2.9.2 build fails due to an invalid Eigen hash. Recommend cherry-picking this into the latest release.