### PR TITLE
Wipe enhancements

### DIFF
--- a/src/libslic3r/GCode/Wipe.cpp
+++ b/src/libslic3r/GCode/Wipe.cpp
@@ -78,7 +78,7 @@ std::string Wipe::wipe(GCodeGenerator &gcodegen, bool toolchange)
     if ((retract_length > 0 || min_length > 0) && this->has_path()) {
         // Delayed emitting of a wipe start tag.
         bool wiped = false;
-        const double wipe_speed = this->calc_wipe_speed(gcodegen.writer().config);
+        const double wipe_speed = gcodegen.writer().config.max_print_speed.value;
         auto start_wipe = [&wiped, &gcode, &gcodegen, wipe_speed](){
             if (! wiped) {
                 wiped = true;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -526,7 +526,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "overhang_fan_speed_0", "overhang_fan_speed_1", "overhang_fan_speed_2", "overhang_fan_speed_3",
     // Retract overrides
     "filament_retract_length", "filament_retract_lift", "filament_retract_lift_above", "filament_retract_lift_below", "filament_retract_speed", "filament_deretract_speed", "filament_retract_restart_extra", "filament_retract_before_travel",
-    "filament_retract_layer_change", "filament_wipe", "filament_retract_before_wipe", "filament_retract_length_toolchange", "filament_retract_restart_extra_toolchange", "filament_travel_ramping_lift",
+    "filament_retract_layer_change", "filament_wipe", "filament_min_wipe_length", "filament_retract_before_wipe", "filament_retract_length_toolchange", "filament_retract_restart_extra_toolchange", "filament_travel_ramping_lift",
     "filament_travel_slope", "filament_travel_max_lift", "filament_travel_lift_before_obstacle",
     // Profile compatibility
     "filament_vendor", "compatible_prints", "compatible_prints_condition", "compatible_printers", "compatible_printers_condition", "inherits",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -153,6 +153,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "travel_max_lift",
         "travel_lift_before_obstacle",
         "retract_before_travel",
+        "min_wipe_length",
         "retract_before_wipe",
         "retract_layer_change",
         "retract_length",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2644,6 +2644,13 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 2. });
 
+    def = this->add("min_wipe_length", coFloats);
+    def->label = L("Minimum wipe length");
+    def->tooltip = L("Minimum length to move while wiping, even if retraction finishes earlier.");
+    def->sidetext = L("mm");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats { 2.0 });
+
     def = this->add("retract_before_wipe", coPercents);
     def->label = L("Retract amount before wipe");
     def->tooltip = L("With bowden extruders, it may be wise to do some amount of quick retract "
@@ -3904,6 +3911,7 @@ void PrintConfigDef::init_fff_params()
         "retract_length", "retract_lift", "retract_lift_above", "retract_lift_below", "retract_speed",
         "travel_max_lift",
         "deretract_speed", "retract_restart_extra", "retract_before_travel", "retract_length_toolchange", "retract_restart_extra_toolchange",
+        "min_wipe_length",
         // bools
         "retract_layer_change", "wipe", "travel_lift_before_obstacle", "travel_ramping_lift",
         // percents
@@ -3969,7 +3977,7 @@ void PrintConfigDef::init_extruder_option_keys()
     m_extruder_option_keys = {
         "nozzle_diameter", "min_layer_height", "max_layer_height", "extruder_offset",
         "retract_length", "retract_lift", "retract_lift_above", "retract_lift_below", "retract_speed", "deretract_speed",
-        "retract_before_wipe", "retract_restart_extra", "retract_before_travel", "wipe",
+        "retract_before_wipe", "retract_restart_extra", "retract_before_travel", "wipe", "min_wipe_length",
         "travel_slope", "travel_max_lift", "travel_ramping_lift", "travel_lift_before_obstacle",
         "retract_layer_change", "retract_length_toolchange", "retract_restart_extra_toolchange", "extruder_colour",
         "default_filament_profile", "nozzle_high_flow"
@@ -3977,6 +3985,7 @@ void PrintConfigDef::init_extruder_option_keys()
 
     m_extruder_retract_keys = {
         "deretract_speed",
+        "min_wipe_length",
         "retract_before_travel",
         "retract_before_wipe",
         "retract_layer_change",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -864,6 +864,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              travel_slope))
     ((ConfigOptionBools,               travel_lift_before_obstacle))
     ((ConfigOptionBools,               nozzle_high_flow))
+    ((ConfigOptionFloats,              min_wipe_length))
     ((ConfigOptionPercents,            retract_before_wipe))
     ((ConfigOptionFloats,              retract_length))
     ((ConfigOptionFloats,              retract_length_toolchange))


### PR DESCRIPTION
These changes make it possible to wipe after retraction is completed and to use the wipe feature with firmware retraction.

The second commit fixes a problem where the wipe length for retraction during wipe becomes extremely long (and slow) if the travel speed is set high. I encountered this on my delta which runs at 2400 mm/s travel (only achievable on long moves) but it's likely an issue on many modern printers using 600-1000 mm/s requested travel speeds.
