### PR TITLE
GMP: fix build failure with gcc-15

### DIFF
--- a/deps/+GMP/GMP.cmake
+++ b/deps/+GMP/GMP.cmake
@@ -57,6 +57,8 @@ else ()
         URL https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2
         URL_HASH SHA256=eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c
         DOWNLOAD_DIR ${${PROJECT_NAME}_DEP_DOWNLOAD_DIR}/GMP
+        PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_LIST_DIR}/gmp-gcc-15.patch
+	COMMAND autoreconf -vif
         BUILD_IN_SOURCE ON 
         CONFIGURE_COMMAND  env "CFLAGS=${_gmp_ccflags}" "CXXFLAGS=${_gmp_ccflags}" ./configure ${_cross_compile_arg} --enable-shared=no --enable-cxx=yes --enable-static=yes "--prefix=${${PROJECT_NAME}_DEP_INSTALL_PREFIX}" ${_gmp_build_tgt}
         BUILD_COMMAND     make -j

--- a/deps/+GMP/gmp-gcc-15.patch
+++ b/deps/+GMP/gmp-gcc-15.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+diff -r e84c5c785bbe -r 8e7bb4ae7a18 acinclude.m4
+--- a/acinclude.m4	Wed Dec 04 18:26:27 2024 +0100
++++ b/acinclude.m4	Wed Jan 29 22:38:02 2025 +0100
+@@ -609,7 +609,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+ 


### PR DESCRIPTION
GMP has a prototype declaration bug that is rejected by the latest release of GCC (15). This prevents PrusaSlicer from building, erroring out during the external dependency build.

The same patch is committed to upstream GMP HEAD, though there's not yet been a subsequent release:

https://gmplib.org/repo/gmp/rev/d66d66d82dbb

The included patch has been hand-edited to play nicely with / apply during the CMAKE build.