### PR TITLE
MPFR build fix (automake)

### DIFF
--- a/deps/+MPFR/MPFR.cmake
+++ b/deps/+MPFR/MPFR.cmake
@@ -34,6 +34,8 @@ else ()
         URL https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.bz2
         URL_HASH SHA256=b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0
         DOWNLOAD_DIR ${${PROJECT_NAME}_DEP_DOWNLOAD_DIR}/MPFR
+        PATCH_COMMAND
+        COMMAND autoreconf -vif
         BUILD_IN_SOURCE ON
         CONFIGURE_COMMAND env "CFLAGS=${_gmp_ccflags}" "CXXFLAGS=${_gmp_ccflags}" ./configure ${_cross_compile_arg} --prefix=${${PROJECT_NAME}_DEP_INSTALL_PREFIX} --enable-shared=no --enable-static=yes --with-gmp=${${PROJECT_NAME}_DEP_INSTALL_PREFIX} ${_gmp_build_tgt}
         BUILD_COMMAND make -j


### PR DESCRIPTION
The external MPFR project uses configure during the build, and appears to have hardwired an obsolete version of automake (1.16).  An autoregen during the dependency unpack corrects the problem and allows a clean build.

Note that the blank PATCH_COMMAND entry in the CMAKE config file appears to be necessary to trigger post-unpack fixups.