### PR TITLE
z3 build fixes for GCC-15

### DIFF
--- a/deps/+z3/z3-CXX23-fix.patch
+++ b/deps/+z3/z3-CXX23-fix.patch
@@ -1,0 +1,411 @@
+Patches backported from:
+
+commit 2ce89e5f491fa817d02d8fdce8c62798beab258b by David Seifert <16636962+SoapGentoo@users.noreply.github.com>
+
+* Fix `-Wclass-memaccess`
+
+* Fix for GCC 15 two-phase lookup
+
+* GCC 15 is more aggressive about checking dependent names:
+  https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=r15-2117-g313afcfdabeab3
+
+Bug: https://bugs.gentoo.org/936634
+
+and
+
+commit e4b3df218952c2a0ccef13e11abb8e5c5ad3a61b by Lev Nachmanson <levnach@hotmail.com>
+
+* remove unused column_info.h
+
+---
+ src/math/lp/column.h      |   1 -
+ src/math/lp/column_info.h       | 255 --------------------------------------
+ src/math/lp/nla_defs.h          |   1 -
+ src/math/lp/lp_settings.h       | 69 ++++++++++++++++-----------------
+ src/math/lp/static_matrix.h     |  2 +-
+ src/math/lp/static_matrix_def.h |  2 +-
+
+ 6 files changed, 36 insertions(+), 294 deletions(-)
+ delete mode 100644 src/math/lp/column_info.h
+
+diff a/src/math/lp/lp_settings.h b/src/math/lp/lp_settings.h
+--- a/src/math/lp/lp_settings.h
++++ b/src/math/lp/lp_settings.h
+@@ -97,39 +97,39 @@ struct statistics {
+ };
+ 
+ struct statistics {
+-    unsigned m_make_feasible;
+-    unsigned m_total_iterations;
+-    unsigned m_iters_with_no_cost_growing;
+-    unsigned m_num_factorizations;
+-    unsigned m_num_of_implied_bounds;
+-    unsigned m_need_to_solve_inf;
+-    unsigned m_max_cols;
+-    unsigned m_max_rows;
+-    unsigned m_gcd_calls;
+-    unsigned m_gcd_conflicts;
+-    unsigned m_cube_calls;
+-    unsigned m_cube_success;
+-    unsigned m_patches;
+-    unsigned m_patches_success;
+-    unsigned m_hnf_cutter_calls;
+-    unsigned m_hnf_cuts;
+-    unsigned m_nla_calls;
+-    unsigned m_gomory_cuts;
+-    unsigned m_nla_add_bounds;
+-    unsigned m_nla_propagate_bounds;
+-    unsigned m_nla_propagate_eq;
+-    unsigned m_nla_lemmas;
+-    unsigned m_nra_calls;
+-    unsigned m_nla_bounds_improvements;
+-    unsigned m_horner_calls;
+-    unsigned m_horner_conflicts;
+-    unsigned m_cross_nested_forms;
+-    unsigned m_grobner_calls;
+-    unsigned m_grobner_conflicts;
+-    unsigned m_offset_eqs;
+-    unsigned m_fixed_eqs;
++    unsigned m_make_feasible = 0;
++    unsigned m_total_iterations = 0;
++    unsigned m_iters_with_no_cost_growing = 0;
++    unsigned m_num_factorizations = 0;
++    unsigned m_num_of_implied_bounds = 0;
++    unsigned m_need_to_solve_inf = 0;
++    unsigned m_max_cols = 0;
++    unsigned m_max_rows = 0;
++    unsigned m_gcd_calls = 0;
++    unsigned m_gcd_conflicts = 0;
++    unsigned m_cube_calls = 0;
++    unsigned m_cube_success = 0;
++    unsigned m_patches = 0;
++    unsigned m_patches_success = 0;
++    unsigned m_hnf_cutter_calls = 0;
++    unsigned m_hnf_cuts = 0;
++    unsigned m_nla_calls = 0;
++    unsigned m_gomory_cuts = 0;
++    unsigned m_nla_add_bounds = 0;
++    unsigned m_nla_propagate_bounds = 0;
++    unsigned m_nla_propagate_eq = 0;
++    unsigned m_nla_lemmas = 0;
++    unsigned m_nra_calls = 0;
++    unsigned m_nla_bounds_improvements = 0;
++    unsigned m_horner_calls = 0;
++    unsigned m_horner_conflicts = 0;
++    unsigned m_cross_nested_forms = 0;
++    unsigned m_grobner_calls = 0;
++    unsigned m_grobner_conflicts = 0;
++    unsigned m_offset_eqs = 0;
++    unsigned m_fixed_eqs = 0;
+     statistics() { reset(); }
+-    void reset() { memset(this, 0, sizeof(*this)); }
++    void reset() { *this = statistics{}; }
+     void collect_statistics(::statistics& st) const {
+         st.update("arith-factorizations", m_num_factorizations);
+         st.update("arith-make-feasible", m_make_feasible);
+diff a/src/math/lp/static_matrix.h b/src/math/lp/static_matrix.h
+--- a/src/math/lp/static_matrix.h
++++ b/src/math/lp/static_matrix.h
+@@ -79,7 +79,7 @@ class static_matrix (public)
+         ref(static_matrix & m, unsigned row, unsigned col):m_matrix(m), m_row(row), m_col(col) {}
+         ref & operator=(T const & v) { m_matrix.set( m_row, m_col, v); return *this; }
+ 
+-        ref operator=(ref & v) { m_matrix.set(m_row, m_col, v.m_matrix.get(v.m_row, v.m_col)); return *this; }
++        ref operator=(ref & v) { m_matrix.set(m_row, m_col, v.m_matrix.get_elem(v.m_row, v.m_col)); return *this; }
+ 
+         operator T () const { return m_matrix.get_elem(m_row, m_col); }
+     };
+diff a/src/math/lp/static_matrix_def.h b/src/math/lp/static_matrix_def.h
+--- a/src/math/lp/static_matrix_def.h
++++ b/src/math/lp/static_matrix_def.h
+@@ -92,7 +92,7 @@ static_matrix<T, X>::static_matrix(static_matrix const
+     init_row_columns(m, m);
+     for (; m-- > 0; ) 
+         for (auto & col : A.m_columns[m]) 
+-            set(col.var(), m, A.get_value_of_column_cell(col));
++            set(col.var(), m, A.get_column_cell(col));
+ }
+ 
+ template <typename T, typename X> void static_matrix<T, X>::clear() {
+diff a/src/math/lp/column.h b/src/math/lp/column.h
+--- a/src/math/lp/column.h
++++ b/src/math/lp/column.h
+@@ -17,7 +17,6 @@ Copyright (c) 2017 Microsoft Corporation
+ #include <string>
+ #include <algorithm>
+ #include <utility>
+-#include "math/lp/column_info.h"
+ #include "math/lp/lp_types.h"
+ 
+ namespace lp {
+diff a/src/math/lp/column_info.h b/src/math/lp/column_info.h
+deleted file mode 100644
+--- a/src/math/lp/column_info.h
++++ /dev/null
+@@ -1,255 +0,0 @@
+-/*++
+-Copyright (c) 2017 Microsoft Corporation
+-
+-Module Name:
+-
+-    <name>
+-
+-Abstract:
+-
+-    <abstract>
+-
+-Author:
+-
+-    Lev Nachmanson (levnach)
+-
+-Revision History:
+-
+-
+---*/
+-
+-#pragma once
+-#include "util/vector.h"
+-#include <unordered_map>
+-#include <string>
+-#include <algorithm>
+-#include "math/lp/lp_settings.h"
+-namespace lp {
+-inline bool is_valid(unsigned j) { return static_cast<int>(j) >= 0;}
+-
+-template <typename T>
+-class column_info {
+-    std::string m_name;
+-    bool        m_lower_bound_is_set;
+-    bool        m_lower_bound_is_strict;
+-    bool        m_upper_bound_is_set;
+-    bool        m_upper_bound_is_strict;
+-    T           m_lower_bound;
+-    T           m_upper_bound;
+-    T           m_fixed_value;
+-    bool        m_is_fixed;
+-    T           m_cost;
+-    unsigned    m_column_index;
+-public:
+-    bool operator==(const column_info & c) const {
+-        return m_name == c.m_name &&
+-            m_lower_bound_is_set == c.m_lower_bound_is_set &&
+-            m_lower_bound_is_strict == c.m_lower_bound_is_strict &&
+-            m_upper_bound_is_set == c.m_upper_bound_is_set&&
+-            m_upper_bound_is_strict == c.m_upper_bound_is_strict&&
+-            (!m_lower_bound_is_set || m_lower_bound == c.m_low_bound) &&
+-            (!m_upper_bound_is_set || m_upper_bound == c.m_upper_bound) &&
+-            m_cost == c.m_cost &&
+-            m_is_fixed == c.m_is_fixed &&
+-            (!m_is_fixed || m_fixed_value == c.m_fixed_value) &&
+-            m_column_index == c.m_column_index;
+-    }
+-    bool operator!=(const column_info & c) const { return !((*this) == c); }
+-    void set_column_index(unsigned j) {
+-        m_column_index = j;
+-    }
+-    // the default constructor
+-    column_info():
+-        m_lower_bound_is_set(false),
+-        m_lower_bound_is_strict(false),
+-        m_upper_bound_is_set (false),
+-        m_upper_bound_is_strict (false),
+-        m_is_fixed(false),
+-        m_cost(numeric_traits<T>::zero()),
+-        m_column_index(static_cast<unsigned>(-1))
+-    {}
+-    
+-    column_info(const column_info & ci) {
+-        m_name = ci.m_name;
+-        m_lower_bound_is_set = ci.m_lower_bound_is_set;
+-        m_lower_bound_is_strict = ci.m_lower_bound_is_strict;
+-        m_upper_bound_is_set = ci.m_upper_bound_is_set;
+-        m_upper_bound_is_strict = ci.m_upper_bound_is_strict;
+-        m_lower_bound = ci.m_lower_bound;
+-        m_upper_bound = ci.m_upper_bound;
+-        m_cost = ci.m_cost;
+-        m_fixed_value = ci.m_fixed_value;
+-        m_is_fixed = ci.m_is_fixed;
+-        m_column_index = ci.m_column_index;
+-    }
+-
+-    unsigned get_column_index() const {
+-        return m_column_index;
+-    }
+-
+-    column_type get_column_type() const {
+-        return m_is_fixed? column_type::fixed : (m_lower_bound_is_set? (m_upper_bound_is_set? column_type::boxed : column_type::lower_bound) : (m_upper_bound_is_set? column_type::upper_bound: column_type::free_column));
+-    }
+-
+-    column_type get_column_type_no_flipping() const {
+-        if (m_is_fixed) {
+-            return column_type::fixed;
+-        }
+-
+-        if (m_lower_bound_is_set) {
+-            return m_upper_bound_is_set? column_type::boxed: column_type::lower_bound;
+-        }
+-        // we are flipping the bounds!
+-        return m_upper_bound_is_set? column_type::upper_bound
+-            : column_type::free_column;
+-    }
+-
+-    T get_lower_bound() const {
+-        lp_assert(m_lower_bound_is_set);
+-        return m_lower_bound;
+-    }
+-    T get_upper_bound() const {
+-        lp_assert(m_upper_bound_is_set);
+-        return m_upper_bound;
+-    }
+-
+-    bool lower_bound_is_set() const {
+-        return m_lower_bound_is_set;
+-    }
+-
+-    bool upper_bound_is_set() const {
+-        return m_upper_bound_is_set;
+-    }
+-
+-    T get_shift() {
+-        if (is_fixed()) {
+-            return m_fixed_value;
+-        }
+-        if (is_flipped()){
+-            return m_upper_bound;
+-        }
+-        return m_lower_bound_is_set? m_lower_bound : numeric_traits<T>::zero();
+-    }
+-
+-    bool is_flipped() {
+-        return m_upper_bound_is_set && !m_lower_bound_is_set;
+-    }
+-
+-    bool adjusted_lower_bound_is_set() {
+-        return !is_flipped()? lower_bound_is_set(): upper_bound_is_set();
+-    }
+-
+-    bool adjusted_upper_bound_is_set() {
+-        return !is_flipped()? upper_bound_is_set(): lower_bound_is_set();
+-    }
+-
+-    T  get_adjusted_upper_bound() {
+-        return get_upper_bound() - get_lower_bound();
+-    }
+-
+-    bool is_fixed() const {
+-        return m_is_fixed;
+-    }
+-
+-    bool is_free() {
+-        return !m_lower_bound_is_set && !m_upper_bound_is_set;
+-    }
+-
+-    void set_fixed_value(T v) {
+-        m_is_fixed = true;
+-        m_fixed_value = v;
+-    }
+-
+-    T get_fixed_value() const {
+-        lp_assert(m_is_fixed);
+-        return m_fixed_value;
+-    }
+-
+-    T get_cost() const {
+-        return m_cost;
+-    }
+-
+-    void set_cost(T const & cost) {
+-        m_cost = cost;
+-    }
+-
+-    void set_name(std::string const & s) {
+-        m_name = s;
+-    }
+-
+-    std::string get_name() const {
+-        return m_name;
+-    }
+-
+-    void set_lower_bound(T const & l) {
+-        m_lower_bound = l;
+-        m_lower_bound_is_set = true;
+-    }
+-
+-    void set_upper_bound(T const & l) {
+-        m_upper_bound = l;
+-        m_upper_bound_is_set = true;
+-    }
+-
+-    void unset_lower_bound() {
+-        m_lower_bound_is_set = false;
+-    }
+-
+-    void unset_upper_bound() {
+-        m_upper_bound_is_set = false;
+-    }
+-
+-    void unset_fixed() {
+-        m_is_fixed = false;
+-    }
+-
+-    bool lower_bound_holds(T v) {
+-        return !lower_bound_is_set() || v >= m_lower_bound -T(0.0000001);
+-    }
+-
+-    bool upper_bound_holds(T v) {
+-        return !upper_bound_is_set() || v <= m_upper_bound + T(0.000001);
+-    }
+-
+-    bool bounds_hold(T v) {
+-        return lower_bound_holds(v) && upper_bound_holds(v);
+-    }
+-
+-    bool adjusted_bounds_hold(T v) {
+-        return adjusted_lower_bound_holds(v) && adjusted_upper_bound_holds(v);
+-    }
+-
+-    bool adjusted_lower_bound_holds(T v) {
+-        return !adjusted_lower_bound_is_set() || v >= -T(0.0000001);
+-    }
+-
+-    bool adjusted_upper_bound_holds(T v) {
+-        return !adjusted_upper_bound_is_set() || v <= get_adjusted_upper_bound() + T(0.000001);
+-    }
+-    bool is_infeasible() {
+-        if ((!upper_bound_is_set()) || (!lower_bound_is_set()))
+-            return false;
+-        // ok, both bounds are set
+-        bool at_least_one_is_strict = upper_bound_is_strict() || lower_bound_is_strict();
+-        if (!at_least_one_is_strict)
+-            return get_upper_bound() < get_lower_bound();
+-        // at least on bound is strict
+-        return get_upper_bound() <= get_lower_bound(); // the equality is impossible
+-    }
+-    bool lower_bound_is_strict() const {
+-        return m_lower_bound_is_strict;
+-    }
+-
+-    void set_lower_bound_strict(bool val) {
+-        m_lower_bound_is_strict = val;
+-    }
+-
+-    bool upper_bound_is_strict() const {
+-        return m_upper_bound_is_strict;
+-    }
+-
+-    void set_upper_bound_strict(bool val) {
+-        m_upper_bound_is_strict = val;
+-    }
+-};
+-}
+diff a/src/math/lp/nla_defs.h b/src/math/lp/nla_defs.h
+--- a/src/math/lp/nla_defs.h
++++ b/src/math/lp/nla_defs.h
+@@ -10,7 +10,6 @@
+   --*/
+ #pragma once
+ #include "math/lp/lp_types.h"
+-#include "math/lp/column_info.h"
+ #include "math/lp/explanation.h"
+ 
+ namespace nla {

--- a/deps/+z3/z3.cmake
+++ b/deps/+z3/z3.cmake
@@ -1,6 +1,7 @@
 add_cmake_project(z3
   URL https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.13.0.zip
   URL_HASH SHA256=81543736dcbbbcb037a7df55d0be596245d509f3f69f56610df32728e48ee050
+  PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_LIST_DIR}/z3-CXX23-fix.patch
   CMAKE_ARGS
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DZ3_INCLUDE_GIT_HASH=OFF


### PR DESCRIPTION
This PR is a backport of two patches from the main branch of the z3 project that fixes a few build problems that (miraculously) didn't surface before.  Each is a typo/bitrot where an unused header-defined override calls a method by the wrong name, or calls a method that just doesn't exist.

In addition, it turns out lp/column_info.h (which contains a few such bugs) has been completely unused for some time.  This patch removes it.

See upstream commits 2ce89e5f491fa817d02d8fdce8c62798beab258b and e4b3df218952c2a0ccef13e11abb8e5c5ad3a61b.