### PR TITLE
CGAL gcc-15 build fix

### DIFF
--- a/deps/+CGAL/CGAL-gcc-15.patch
+++ b/deps/+CGAL/CGAL-gcc-15.patch
@@ -1,0 +1,59 @@
+--- BGL/include/CGAL/boost/graph/iterator.h
++++ BGL/include/CGAL/boost/graph/iterator.h
+@@ -213,18 +213,7 @@ class Halfedge_around_source_iterator { (public)
+   {}
+ 
+ #ifndef DOXYGEN_RUNNING
+-  // design patter: "safe bool"
+-  // will be replaced by explicit operator bool with C++11
+-  typedef void (Halfedge_around_source_iterator::*bool_type)() const;
+ 
+-  void this_type_does_not_support_comparisons() const {}
+-
+-  operator bool_type() const
+-  {
+-    return (! (this->base() == nullptr)) ?
+-      &Halfedge_around_source_iterator::this_type_does_not_support_comparisons : 0;
+-  }
+-
+   bool operator==( const Self& i) const {
+     CGAL_assertion( anchor == anchor);
+     return  ( g == i.g) && ( pos == i.pos) && ( winding == i.winding);
+@@ -313,18 +302,7 @@ class Halfedge_around_target_iterator { (public)
+   {}
+ 
+ #ifndef DOXYGEN_RUNNING
+-  // design patter: "safe bool"
+-  // will be replaced by explicit operator bool with C++11
+-  typedef void (Halfedge_around_target_iterator::*bool_type)() const;
+ 
+-  void this_type_does_not_support_comparisons() const {}
+-
+-  operator bool_type() const
+-  {
+-    return (! (this->base() == nullptr)) ?
+-      &Halfedge_around_target_iterator::this_type_does_not_support_comparisons : 0;
+-  }
+-
+   bool operator==( const Self& i) const {
+     CGAL_assertion( anchor == anchor);
+     return  ( g == i.g) && ( pos == i.pos) && ( winding == i.winding);
+@@ -411,18 +389,6 @@ class Halfedge_around_face_iterator { (public)
+   const value_type& operator *  ( ) const { return  pos; }
+   pointer           operator -> ( )       { return &pos; }
+   const value_type* operator -> ( ) const { return &pos; }
+-
+-  // design patter: "safe bool"
+-  // will be replaced by explicit operator bool with C++11
+-  typedef void (Halfedge_around_face_iterator::*bool_type)() const;
+-
+-  void this_type_does_not_support_comparisons() const {}
+-
+-  operator bool_type() const
+-  {
+-    return (! (this->base() == nullptr)) ?
+-      &Halfedge_around_face_iterator::this_type_does_not_support_comparisons : 0;
+-  }
+ 
+   bool operator==( const Self& i) const {
+     CGAL_assertion( anchor == anchor);

--- a/deps/+CGAL/CGAL.cmake
+++ b/deps/+CGAL/CGAL.cmake
@@ -5,6 +5,7 @@ add_cmake_project(
     # For whatever reason, this keeps downloading forever (repeats downloads if finished)
     URL      https://github.com/CGAL/cgal/archive/refs/tags/v5.4.zip
     URL_HASH SHA256=d7605e0a5a5ca17da7547592f6f6e4a59430a0bc861948974254d0de43eab4c0
+    PATCH_COMMAND git apply -p0 --ignore-whitespace ${CMAKE_CURRENT_LIST_DIR}/CGAL-gcc-15.patch
 )
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Another example of C++ method calls that don't exist due to mismatched inheritance.  These didn't get flagged until gcc-15 (not sure why clamg19 doesn't complain too, or maybe it does).

Eliminate three iterator methods in CGAL that are unused and would not have worked if they were, removing the erroneous code.