### PR TITLE
TriangleMesh: fix header inline undefined slice_mesh_ex()

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -571,6 +571,7 @@ add_library(libslic3r_cgal STATIC
     CutSurface.hpp CutSurface.cpp
     Geometry/VoronoiUtilsCgal.hpp Geometry/VoronoiUtilsCgal.cpp
     IntersectionPoints.hpp IntersectionPoints.cpp
+    TriangleMesh.hpp TriangleMesh.cpp
     MeshBoolean.hpp MeshBoolean.cpp
     TryCatchSignal.hpp TryCatchSignal.cpp
     Triangulation.hpp Triangulation.cpp

--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -2206,6 +2206,17 @@ std::vector<ExPolygons> slice_mesh_ex(
     return layers;
 }
 
+std::vector<ExPolygons>  slice_mesh_ex(
+    const indexed_triangle_set       &mesh,
+    const std::vector<float>         &zs,
+    float                             closing_radius,
+    std::function<void()>             throw_on_cancel)
+{
+    MeshSlicingParamsEx params;
+    params.closing_radius = closing_radius;
+    return slice_mesh_ex(mesh, zs, params, throw_on_cancel);
+}
+
 // Slice a triangle set with a set of Z slabs (thick layers).
 // The effect is similar to producing the usual top / bottom layers from a sliced mesh by 
 // subtracting layer[i] from layer[i - 1] for the top surfaces resp.

--- a/src/libslic3r/TriangleMeshSlicer.hpp
+++ b/src/libslic3r/TriangleMeshSlicer.hpp
@@ -103,23 +103,18 @@ std::vector<ExPolygons>         slice_mesh_ex(
     const MeshSlicingParamsEx        &params,
     std::function<void()>             throw_on_cancel = []{});
 
+std::vector<ExPolygons>  slice_mesh_ex(
+    const indexed_triangle_set       &mesh,
+    const std::vector<float>         &zs,
+    float                             closing_radius,
+    std::function<void()>             throw_on_cancel = []{});
+
 inline std::vector<ExPolygons>  slice_mesh_ex(
     const indexed_triangle_set       &mesh,
     const std::vector<float>         &zs,
     std::function<void()>             throw_on_cancel = []{})
 {
     return slice_mesh_ex(mesh, zs, MeshSlicingParamsEx{}, throw_on_cancel);
-}
-
-inline std::vector<ExPolygons>  slice_mesh_ex(
-    const indexed_triangle_set       &mesh,
-    const std::vector<float>         &zs,
-    float                             closing_radius,
-    std::function<void()>             throw_on_cancel = []{})
-{
-    MeshSlicingParamsEx params;
-    params.closing_radius = closing_radius;
-    return slice_mesh_ex(mesh, zs, params, throw_on_cancel);
 }
 
 // Slice a triangle set with a set of Z slabs (thick layers).


### PR DESCRIPTION
Fixes compiler error.