### PR TITLE
Spelling errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 
 # Create a slic3r executable
-# Process mainfests for various platforms.
+# Process manifests for various platforms.
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/platform/msw/PrusaSlicer.rc.in ${CMAKE_CURRENT_BINARY_DIR}/PrusaSlicer.rc @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/platform/msw/PrusaSlicer-gcodeviewer.rc.in ${CMAKE_CURRENT_BINARY_DIR}/PrusaSlicer-gcodeviewer.rc @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/platform/msw/PrusaSlicer.manifest.in ${CMAKE_CURRENT_BINARY_DIR}/PrusaSlicer.manifest @ONLY)

--- a/src/slic3r/GUI/PresetArchiveDatabase.cpp
+++ b/src/slic3r/GUI/PresetArchiveDatabase.cpp
@@ -911,7 +911,7 @@ bool PresetArchiveDatabase::sync_blocking(PresetUpdaterUIStatus* ui_status)
     assert(ui_status);
 	std::string manifest;
     bool sync_res = false;
-    ui_status->set_target("Archive Database Mainfest");
+    ui_status->set_target("Archive Database Manifest");
     sync_res = sync_inner(manifest, ui_status);
     if (!sync_res) {
         return false;


### PR DESCRIPTION
Manifest is spelled incorrectly in two places.  This PR fixes them both.