### PR TITLE
 Fix null pointer warnings 

### DIFF
--- a/bundled_deps/admesh/admesh/stlinit.cpp
+++ b/bundled_deps/admesh/admesh/stlinit.cpp
@@ -109,7 +109,7 @@ static FILE* stl_open_count_facets(stl_file *stl, const char *file)
 		// do another null check to be safe
     	if (fp == nullptr) {
 			BOOST_LOG_TRIVIAL(error) << "stl_open_count_facets: Couldn't open " << file << " for reading";
-      		fclose(fp);
+      		//fclose(fp);
       		return nullptr;
     	}
     

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1411,7 +1411,7 @@ void MenuFactory::append_menu_items_instance_manipulation(wxMenu* menu)
 void MenuFactory::update_menu_items_instance_manipulation(MenuType type)
 {
     wxMenu* menu = type == mtObjectFFF ? &m_object_menu : type == mtObjectSLA ? &m_sla_object_menu : nullptr;
-    if (menu)
+    if (!menu)
         return;
     // Remove/Prepend "increase/decrease instances" menu items according to the view mode.
     // Suppress to show those items for a Simple mode


### PR DESCRIPTION
 The changes are as follows:
-   stlinit.cpp: Removed fclose(fp) call that was being executed after the fp was already checked to be nullptr. 
-   GUI_Factories.cpp: Corrected the conditional check for the menu pointer. 

Compilation warnings : 
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/bundled_deps/admesh/admesh/stlinit.cpp:112:23: warning: argument 1 null where non-null expected [-Wnonnull]
 * /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/char_traits.h:391:32: warning: argument 1 null where non-null expected [-Wnonnull]
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/src/slic3r/GUI/GUI_Factories.cpp:1419:27: warning: ‘this’ pointer is null [-Wnonnull]
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/src/slic3r/GUI/GUI_Factories.cpp:1424:25: warning: ‘this’ pointer is null [-Wnonnull]
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/src/slic3r/GUI/GUI_Factories.cpp:1425:25: warning: ‘this’ pointer is null [-Wnonnull]
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/src/slic3r/GUI/GUI_Factories.cpp:1426:25: warning: ‘this’ pointer is null [-Wnonnull]
 * /var/tmp/portage/media-gfx/prusaslicer-9999/work/prusaslicer-9999/src/slic3r/GUI/GUI_Factories.cpp:1430:27: warning: ‘this’ pointer is null [-Wnonnull]
 * /usr/include/wx-3.2/wx/menu.h:156:22: warning: ‘this’ pointer is null [-Wnonnull] 