### PR TITLE
Fix compiling with wxWidgets 3.3

### DIFF
--- a/src/slic3r/GUI/Search.cpp
+++ b/src/slic3r/GUI/Search.cpp
@@ -38,7 +38,7 @@ using GUI::into_u8;
 
 namespace Search {
 
-static char marker_by_type(Preset::Type type, PrinterTechnology pt)
+static wchar_t marker_by_type(Preset::Type type, PrinterTechnology pt)
 {
     switch(type) {
     case Preset::TYPE_PRINT:
@@ -53,7 +53,7 @@ static char marker_by_type(Preset::Type type, PrinterTechnology pt)
     case Preset::TYPE_PREFERENCES:
         return ImGui::PreferencesButton;
     default:
-        return ' ';
+        return L' ';
 	}
 }
 


### PR DESCRIPTION
wxWidgets 3.3 has stopped defining in global scope all operators
including "+" on wx types, causing some string concatenations to fail.

All the constants from ImGui used by marker_by_type() are of type
wchar_t. Stop returning them as type char.

```
PrusaSlicer-version_2.9.3/src/slic3r/GUI/Search.cpp:253:62: error: no match for ‘operator+’ (operand types are ‘char’ and ‘const std::wstring’ {aka ‘const std::__cxx11::basic_string<wchar_t>’})
  253 |         return  marker_by_type(opt.type, printer_technology) +
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
      |                               |
      |                               char
  254 |                 opt.category_local + sep +
      |                 ~~~~~~~~~~~~~~~~~~
      |                     |
      |                     const std::wstring {aka const std::__cxx11::basic_string<wchar_t>}
```
---

wxWidgets Changelog:
https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.3.0/docs/changes.txt

C++ isn't my first language so please take this as an illustration of the issue and check carefully.
