### PR TITLE
Make first layer and top flow ratio adjustable

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -500,7 +500,7 @@ static std::vector<std::string> s_Preset_print_options {
     "dont_support_bridges", "thick_bridges", "notes", "custom_parameters_print", "complete_objects",
     "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",
-    "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width",
+    "ooze_prevention", "standby_temperature_delta", "interface_shells", "extrusion_width", "first_layer_extrusion_width", 
     "perimeter_extrusion_width", "external_perimeter_extrusion_width", "infill_extrusion_width", "solid_infill_extrusion_width",
     "top_infill_extrusion_width", "support_material_extrusion_width", "infill_overlap", "infill_anchor", "infill_anchor_max", "bridge_flow_ratio",
     "elefant_foot_compensation", "xy_size_compensation", "resolution", "gcode_resolution", "arc_fitting",
@@ -512,7 +512,9 @@ static std::vector<std::string> s_Preset_print_options {
     "top_one_perimeter_type", "only_one_perimeter_first_layer",
     "automatic_extrusion_widths", "automatic_infill_combination", "automatic_infill_combination_max_layer_height",
     "bed_temperature_extruder", "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
-    "travel_short_distance_acceleration", "toolchange_ordering"
+    "travel_short_distance_acceleration", "toolchange_ordering",
+    "first_layer_flow_ratio",
+    "top_layer_flow_ratio",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -285,6 +285,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             osteps.emplace_back(posSupportMaterial);
         } else if (
                opt_key == "first_layer_extrusion_width" 
+            || opt_key == "first_layer_flow_ratio"
+            || opt_key == "top_layer_flow_ratio"
             || opt_key == "min_layer_height"
             || opt_key == "max_layer_height"
             || opt_key == "gcode_resolution") {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -772,6 +772,26 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("first_layer_flow_ratio", coFloat);
+    def->label = L("First layer flow ratio");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("This factor affects the amount of plastic for first layer. "
+                   "You can decrease it slightly (e.g. 0.85) to prevent rough first layer and sticking to the nozzle, "
+                   "or increase a bit to improve sticking to unflat bed (though it's better to have autoleveling or flat bed).");
+    def->min = 0.5;
+    def->max = 1.5;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1));
+
+    def = this->add("top_layer_flow_ratio", coFloat);
+    def->label = L("Top layer flow ratio");
+    def->category = L("Layers and Perimeters");
+    def->tooltip = L("This factor affects the amount of plastic for top layer. Play with this parameter to get smooth surface.");
+    def->min = 0.5;
+    def->max = 1.5;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1));
+
     def = this->add("bridge_speed", coFloat);
     def->label = L("Bridges");
     def->category = L("Speed");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -741,6 +741,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_angle))
     ((ConfigOptionInt,                  bottom_solid_layers))
     ((ConfigOptionFloat,                bottom_solid_min_thickness))
+    ((ConfigOptionFloat,                first_layer_flow_ratio))
+    ((ConfigOptionFloat,                top_layer_flow_ratio))
     ((ConfigOptionFloat,                bridge_flow_ratio))
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionEnum<EnsureVerticalShellThickness>, ensure_vertical_shell_thickness))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -728,6 +728,8 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "extra_perimeters"
             || opt_key == "extra_perimeters_on_overhangs"
             || opt_key == "first_layer_extrusion_width"
+            || opt_key == "first_layer_flow_ratio"
+            || opt_key == "top_layer_flow_ratio"
             || opt_key == "perimeter_extrusion_width"
             || opt_key == "infill_overlap"
             || opt_key == "external_perimeters_first"
@@ -819,7 +821,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "raft_first_layer_density"
             || opt_key == "raft_first_layer_expansion"
             || opt_key == "dont_support_bridges"
-            || opt_key == "first_layer_extrusion_width") {
+            || opt_key == "first_layer_extrusion_width"
+            || opt_key == "first_layer_flow_ratio"
+            || opt_key == "top_layer_flow_ratio") {
             steps.emplace_back(posSupportMaterial);
         } else if (opt_key == "bottom_solid_layers") {
             steps.emplace_back(posPrepareInfill);
@@ -853,7 +857,9 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "infill_anchor"
             || opt_key == "infill_anchor_max"
             || opt_key == "top_infill_extrusion_width"
-            || opt_key == "first_layer_extrusion_width") {
+            || opt_key == "first_layer_extrusion_width"
+            || opt_key == "first_layer_flow_ratio"
+            || opt_key == "top_layer_flow_ratio") {
             steps.emplace_back(posInfill);
         } else if (opt_key == "fill_pattern") {
             steps.emplace_back(posPrepareInfill);

--- a/src/libslic3r/PrintRegion.cpp
+++ b/src/libslic3r/PrintRegion.cpp
@@ -37,10 +37,12 @@ Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_he
 {
     const PrintConfig          &print_config = object.print()->config();
     ConfigOptionFloatOrPercent  config_width;
+    float flow_ratio  = 1;
     // Get extrusion width from configuration.
     // (might be an absolute value, or a percent value, or zero for auto)
-    if (first_layer && print_config.first_layer_extrusion_width.value > 0) {
+    if (first_layer) {
         config_width = print_config.first_layer_extrusion_width;
+        flow_ratio = m_config.first_layer_flow_ratio.value;
     } else if (role == frExternalPerimeter) {
         config_width = m_config.external_perimeter_extrusion_width;
     } else if (role == frPerimeter) {
@@ -51,6 +53,7 @@ Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_he
         config_width = m_config.solid_infill_extrusion_width;
     } else if (role == frTopSolidInfill) {
         config_width = m_config.top_infill_extrusion_width;
+        flow_ratio   = m_config.top_layer_flow_ratio.value;
     } else {
         throw Slic3r::InvalidArgument("Unknown role");
     }
@@ -61,7 +64,7 @@ Flow PrintRegion::flow(const PrintObject &object, FlowRole role, double layer_he
     // Get the configured nozzle_diameter for the extruder associated to the flow role requested.
     // Here this->extruder(role) - 1 may underflow to MAX_INT, but then the get_at() will follback to zero'th element, so everything is all right.
     auto nozzle_diameter = float(print_config.nozzle_diameter.get_at(this->extruder(role) - 1));
-    return Flow::new_from_config_width(role, config_width, nozzle_diameter, float(layer_height));
+    return Flow::new_from_config_width(role, config_width, nozzle_diameter, float(layer_height * flow_ratio));
 }
 
 coordf_t PrintRegion::nozzle_dmr_avg(const PrintConfig &print_config) const

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1699,9 +1699,12 @@ void TabPrint::build()
 
         optgroup = page->new_optgroup(L("Overlap"));
         optgroup->append_single_option_line("infill_overlap");
+        optgroup->append_single_option_line("bridge_density");
 
         optgroup = page->new_optgroup(L("Flow"));
         optgroup->append_single_option_line("bridge_flow_ratio");
+        optgroup->append_single_option_line("first_layer_flow_ratio");
+        optgroup->append_single_option_line("top_layer_flow_ratio");
 
         optgroup = page->new_optgroup(L("Slicing"));
         optgroup->append_single_option_line("slice_closing_radius");


### PR DESCRIPTION
Allow adjusting the flow rates of the first and top solid infill layers. Small adjustments hear can often result in significantly better looking surface areas.
