### PR TITLE
Per object extrusion multiplier overrides

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3449,7 +3449,8 @@ std::string GCodeGenerator::_extrude(
     }
 
     // calculate extrusion length per distance unit
-    double e_per_mm = m_writer.extruder()->e_per_mm3() * path_attr.mm3_per_mm;
+    double e_per_mm = m_writer.extruder()->e_per_mm3() * path_attr.mm3_per_mm *
+        m_config.print_extrusion_multiplier.value;
     if (m_writer.extrusion_axis().empty())
         // gcfNoExtrusion
         e_per_mm = 0;

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -660,6 +660,7 @@ inline bool has_compatible_layer_regions(const PrintRegionConfig &config, const 
            config.thin_walls                                            == other_config.thin_walls &&
            config.external_perimeters_first                             == other_config.external_perimeters_first &&
            config.infill_overlap                                        == other_config.infill_overlap &&
+           config.print_extrusion_multiplier                            == other_config.print_extrusion_multiplier &&
            has_compatible_dynamic_overhang_speed(config, other_config);
 }
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -512,7 +512,8 @@ static std::vector<std::string> s_Preset_print_options {
     "top_one_perimeter_type", "only_one_perimeter_first_layer",
     "automatic_extrusion_widths", "automatic_infill_combination", "automatic_infill_combination_max_layer_height",
     "bed_temperature_extruder", "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
-    "travel_short_distance_acceleration", "toolchange_ordering"
+    "travel_short_distance_acceleration", "toolchange_ordering",
+    "print_extrusion_multiplier",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -772,6 +772,19 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("print_extrusion_multiplier", coFloat);
+    def->label = L("Extrusion multiplier");
+    def->category = L("Advanced");
+    def->tooltip = L("This factor changes the amount of flow proportionally. You may need to tweak "
+        "this setting to get nice surface finish and correct single wall widths. "
+        "Usual values are between 90% and 110%. This print setting is multiplied "
+        "with the extrusion_multiplier from the filament tab.  Its only purpose is to "
+        "offer the same functionality but on a per-object basis.");
+    def->mode = comAdvanced;
+    def->min = 0.5;
+    def->max = 1.5;
+    def->set_default_value(new ConfigOptionFloat(1));
+
     def = this->add("bridge_speed", coFloat);
     def->label = L("Bridges");
     def->category = L("Speed");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -809,6 +809,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                    scarf_seam_length))
     ((ConfigOptionFloat,                    scarf_seam_max_segment_length))
     ((ConfigOptionBool,                     scarf_seam_on_inner_perimeters))
+    ((ConfigOptionFloat,                    print_extrusion_multiplier))
 )
 
 PRINT_CONFIG_CLASS_DEFINE(


### PR DESCRIPTION
Useful for finetuning specific objects on a plate or when dialing in new filaments to calibrate the extrusion multiplier
