### PR TITLE
Add filament max speed override

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3362,6 +3362,10 @@ double cap_speed(
     if (filament_volumetric_cap > 0) {
         speed = std::min(speed, filament_volumetric_cap / path_attr.mm3_per_mm);
     }
+    const double filament_max_speed{config.filament_max_speed.get_at(extruder_id)};
+    if (filament_max_speed > 0) {
+        speed = std::min(speed, filament_max_speed);
+    }
     if (path_attr.role == ExtrusionRole::InternalInfill) {
         const double infill_cap{
             path_attr.maybe_self_crossing ?

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -252,6 +252,7 @@ public:
         float               cooling_final_speed = 0.f;
         float               ramming_line_width_multiplicator = 1.f;
         float               ramming_step_multiplicator = 1.f;
+        float               max_speed = std::numeric_limits<float>::max();
         float               max_e_speed = std::numeric_limits<float>::max();
         std::vector<float>  ramming_speed;
         float               nozzle_diameter;
@@ -275,6 +276,7 @@ private:
     }
 
 
+	const PrintConfig* m_config;
 	bool   m_semm               = true; // Are we using a single extruder multimaterial printer?
 	bool   m_is_mk4mmu3         = false;
     bool   m_switch_filament_monitoring = false;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -535,7 +535,9 @@ static std::vector<std::string> s_Preset_filament_options {
     // Shrinkage compensation
     "filament_shrinkage_compensation_xy", "filament_shrinkage_compensation_z",
     // Seams overrides
-    "filament_seam_gap_distance"
+    "filament_seam_gap_distance",
+    // BOSS
+    "filament_max_speed",
 };
 
 static std::vector<std::string> s_Preset_machine_limits_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -246,6 +246,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "filament_multitool_ramming"
             || opt_key == "filament_multitool_ramming_volume"
             || opt_key == "filament_multitool_ramming_flow"
+            || opt_key == "filament_max_speed"
             || opt_key == "filament_max_volumetric_speed"
             || opt_key == "filament_infill_max_speed"
             || opt_key == "filament_infill_max_crossing_speed"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1291,6 +1291,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionStrings { "" });
 
+    def = this->add("filament_max_speed", coFloats);
+    def->label = L("Max speed");
+    def->tooltip = L("Maximum speed allowed for this filament. Limits the maximum "
+        "speed of a print to the minimum of the print speed and the filament speed. "
+        "Set zero for no limit.");
+    def->sidetext = L("mm/s");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats{ 0. });
+
     def = this->add("filament_max_volumetric_speed", coFloats);
     def->label = L("Max volumetric speed");
     def->tooltip = L("Maximum volumetric speed allowed for this filament. Limits the maximum volumetric "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -946,6 +946,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
+    ((ConfigOptionFloats,              filament_max_speed))
 )
 
 static inline std::string get_extrusion_axis(const GCodeConfig &cfg)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2295,6 +2295,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_abrasive");
 
         optgroup = page->new_optgroup(L("Print speed override"));
+        optgroup->append_single_option_line("filament_max_speed", "max-speed_127176");
         optgroup->append_single_option_line("filament_max_volumetric_speed", "max-volumetric-speed_127176");
 
         line = { "", "" };


### PR DESCRIPTION
Allow filaments to set a max speed which will be applied to all extruding moves where this filament is used
