### PR TITLE
Make disabling linear advance in wipe tower configurable

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -543,6 +543,7 @@ WipeTower::ToolChangeResult WipeTower::construct_tcr(WipeTowerWriter& writer,
 
 WipeTower::WipeTower(const Vec2f& pos, double rotation_deg, const PrintConfig& config, const PrintRegionConfig& default_region_config, const std::vector<std::vector<float>>& wiping_matrix, size_t initial_tool) :
     m_semm(config.single_extruder_multi_material.value),
+    m_disable_linear_advance(config.wipe_tower_disable_linear_advance.value),
     m_wipe_tower_pos(pos),
     m_wipe_tower_width(float(config.wipe_tower_width)),
     m_wipe_tower_brim_width(float(config.wipe_tower_brim_width)),
@@ -901,7 +902,7 @@ void WipeTower::toolchange_Unload(
 
     if (do_ramming) {
         writer.travel(ramming_start_pos); // move to starting position
-        if (! m_is_mk4mmu3)
+        if (!m_is_mk4mmu3 && m_disable_linear_advance)
             writer.disable_linear_advance();
         if (cold_ramming)
             writer.set_extruder_temp(old_temperature - 20);
@@ -1011,7 +1012,7 @@ void WipeTower::toolchange_Unload(
 
         float speed_inc = (final_speed - initial_speed) / (2.f * number_of_cooling_moves - 1.f);
 
-        if (m_is_mk4mmu3)
+        if (m_is_mk4mmu3 && m_disable_linear_advance)
             writer.disable_linear_advance();
 
         writer.suppress_preview()

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -308,6 +308,8 @@ private:
     bool            m_adhesion                  = true;
     GCodeFlavor     m_gcode_flavor;
 
+	bool			m_disable_linear_advance    = true;
+
     // Bed properties
     enum {
         RectangularBed,

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -512,7 +512,8 @@ static std::vector<std::string> s_Preset_print_options {
     "top_one_perimeter_type", "only_one_perimeter_first_layer",
     "automatic_extrusion_widths", "automatic_infill_combination", "automatic_infill_combination_max_layer_height",
     "bed_temperature_extruder", "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
-    "travel_short_distance_acceleration", "toolchange_ordering"
+    "travel_short_distance_acceleration", "toolchange_ordering",
+    "wipe_tower_disable_linear_advance",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3272,6 +3272,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("wipe_tower_disable_linear_advance", coBool);
+    def->label = L("Disable linear advance");
+    def->tooltip = L("If enabled, linear advance will be disabled before purging an extruder.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("slice_closing_radius", coFloat);
     def->label = L("Slice gap closing radius");
     def->category = L("Advanced");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -946,6 +946,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
+    ((ConfigOptionBool,                wipe_tower_disable_linear_advance))
 )
 
 static inline std::string get_extrusion_axis(const GCodeConfig &cfg)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -393,7 +393,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_wipe_tower = config->opt_bool("wipe_tower");
     for (auto el : { "wipe_tower_width",  "wipe_tower_brim_width", "wipe_tower_cone_angle",
-                     "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "wipe_tower_bridging", "wipe_tower_no_sparse_layers", "single_extruder_multi_material_priming" })
+                     "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "wipe_tower_bridging", "wipe_tower_no_sparse_layers", "single_extruder_multi_material_priming",
+                     "wipe_tower_disable_linear_advance" })
         toggle_field(el, have_wipe_tower);
 
     toggle_field("avoid_crossing_curled_overhangs", !config->opt_bool("avoid_crossing_perimeters"));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -694,7 +694,8 @@ Plater::priv::priv(Plater* q, MainFrame* main_frame)
         "layer_height", "first_layer_height", "min_layer_height", "max_layer_height",
         "brim_width", "perimeters", "perimeter_extruder", "fill_density", "infill_extruder", "top_solid_layers",
         "support_material", "support_material_extruder", "support_material_interface_extruder",
-        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers"
+        "support_material_contact_distance", "support_material_bottom_contact_distance", "raft_layers",
+        "wipe_tower_disable_linear_advance",
         }))
     , sidebar(new Sidebar(q))
     , notification_manager(std::make_unique<NotificationManager>(q))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1670,6 +1670,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wipe_tower_extra_flow");
         optgroup->append_single_option_line("wipe_tower_no_sparse_layers");
         optgroup->append_single_option_line("single_extruder_multi_material_priming");
+        optgroup->append_single_option_line("wipe_tower_disable_linear_advance");
 
         optgroup = page->new_optgroup(L("Advanced"));
         optgroup->append_single_option_line("toolchange_ordering");


### PR DESCRIPTION
By default PS disables linear/pressure advance in the Wipetower for Klipper firmware.
Without custom filament G-Code pressure advance will not / can not be re-enabled after a toolchange, leading to suboptimal print quality.

This PR adds a config option to the wipetower settings to allow disabling this feature.

Fixes #11021 