### PR TITLE
Allow disabling autoemit of toolchange commands

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3993,7 +3993,7 @@ std::string GCodeGenerator::set_extruder(unsigned int extruder_id, double print_
 
     // We inform the writer about what is happening, but we may not use the resulting gcode.
     std::string toolchange_command = m_writer.toolchange(extruder_id);
-    if (! custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), extruder_id))
+    if (m_config.autoemit_toolchange_commands && !custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), extruder_id))
         gcode += toolchange_command;
     else {
         // user provided his own toolchange gcode, no need to do anything

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -560,7 +560,8 @@ static std::vector<std::string> s_Preset_printer_options {
     "max_print_height", "default_print_profile", "inherits",
     "remaining_times", "silent_mode",
     "machine_limits_usage", "thumbnails", "thumbnails_format",
-    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height"
+    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height",
+    "autoemit_toolchange_commands",
 };
 
 static std::vector<std::string> s_Preset_sla_print_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -190,7 +190,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "use_volumetric_e",
         "variable_layer_height",
         "wipe",
-        "wipe_tower_acceleration"
+        "wipe_tower_acceleration",
+        "autoemit_toolchange_commands",
     };
 
     static std::unordered_set<std::string> steps_ignore;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3189,6 +3189,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionString(""));
 
+    def = this->add("autoemit_toolchange_commands", coBool);
+    def->label = L("Emit toolchange commands automatically");
+    def->tooltip = L("When enabled, PrusaSlicer verifies if your custom Toolchange G-Code includes G-codes to "
+                     "switch to the next extruder (T0, T1, etc.). If no toolchange commands are found, they are "
+                     "automatically appended to the custom Toolchange G-Code. Conversely, when disabled, the "
+                     "presence of toolchange commands is not checked, allowing you to customize the order of "
+                     "toolchange operations and other custom actions. Note that you can use placeholder variables "
+                     "for all PrusaSlicer settings, enabling you to insert a \"T[next_extruder]\" command wherever "
+                     "desired.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("start_gcode", coString);
     def->label = L("Start G-code");
     def->tooltip = L("This start procedure is inserted at the beginning, possibly prepended by "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -946,6 +946,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
+    ((ConfigOptionBool,                autoemit_toolchange_commands))
 )
 
 static inline std::string get_extrusion_axis(const GCodeConfig &cfg)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2945,6 +2945,9 @@ void TabPrinter::build_fff()
         option.opt.height = gcode_field_height;//150;
         optgroup->append_single_option_line(option);
 
+        optgroup = page->new_optgroup(L("Tool change G-Code options"));
+        optgroup->append_single_option_line("autoemit_toolchange_commands");
+
         optgroup = page->new_optgroup(L("Between objects G-code (for sequential printing)"), 0);
         optgroup->on_change = [this, &optgroup_title = optgroup->title](const t_config_option_key& opt_key, const boost::any& value) {
             validate_custom_gcode_cb(this, optgroup_title, opt_key, value);
@@ -5164,7 +5167,7 @@ bool Tab::validate_custom_gcodes()
         if (!opt_group->is_activated())
             break;
         std::string key = opt_group->opt_map().begin()->first;
-        if (key == "autoemit_temperature_commands")
+        if (key == "autoemit_temperature_commands" || key == "autoemit_toolchange_commands")
             continue;
         valid &= validate_custom_gcode(opt_group->title, boost::any_cast<std::string>(opt_group->get_value(key)));
         if (!valid)


### PR DESCRIPTION
For some setup like Klipper where custom macros are common there might not be explict T[x] commands in the toolchange G-Code snippet.
Automatically adding these to the G-Code is interfering with those setups, provide and option to disable that behavior and allow users full control.
