### PR TITLE
Add option to wait for cooling temperature when changing filament.

### DIFF
--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -250,6 +250,7 @@ public:
         int                 cooling_moves = 0;
         float               cooling_initial_speed = 0.f;
         float               cooling_final_speed = 0.f;
+        bool                cooling_wait_for_temp = false;
         float               ramming_line_width_multiplicator = 1.f;
         float               ramming_step_multiplicator = 1.f;
         float               max_e_speed = std::numeric_limits<float>::max();

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -519,7 +519,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_colour", "filament_diameter", "filament_type", "filament_soluble", "filament_abrasive", "filament_notes", "filament_max_volumetric_speed", "filament_infill_max_speed", "filament_infill_max_crossing_speed",
     "extrusion_multiplier", "filament_density", "filament_cost", "filament_spool_weight", "filament_loading_speed", "filament_loading_speed_start", "filament_load_time",
     "filament_unloading_speed", "filament_unloading_speed_start", "filament_unload_time", "filament_toolchange_delay", "filament_cooling_moves", "filament_stamping_loading_speed", "filament_stamping_distance",
-    "filament_cooling_initial_speed", "filament_purge_multiplier", "filament_cooling_final_speed", "filament_ramming_parameters", "filament_minimal_purge_on_wipe_tower",
+    "filament_cooling_initial_speed", "filament_purge_multiplier", "filament_cooling_final_speed", "filament_cooling_wait_for_temp", "filament_ramming_parameters", "filament_minimal_purge_on_wipe_tower",
     "filament_multitool_ramming", "filament_multitool_ramming_volume", "filament_multitool_ramming_flow", 
     "temperature", "idle_temperature", "first_layer_temperature", "bed_temperature", "first_layer_bed_temperature", "fan_always_on", "cooling", "cooling_slowdown_logic",
     "cooling_perimeter_transition_distance", "min_fan_speed",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -238,6 +238,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "filament_minimal_purge_on_wipe_tower"
             || opt_key == "filament_cooling_initial_speed"
             || opt_key == "filament_cooling_final_speed"
+            || opt_key == "filament_cooling_wait_for_temp"
             || opt_key == "filament_purge_multiplier"
             || opt_key == "filament_ramming_parameters"
             || opt_key == "filament_multitool_ramming"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1379,6 +1379,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloats { 3.4 });
 
+    def = this->add("filament_cooling_wait_for_temp", coBools);
+    def->label = L("Wait for the nozzle to cool before the last cooling move");
+    def->tooltip = L("During the cooling moves, the nozzle gradually approaches the optimal temperature for forming "
+                     "a good filament tip prior to unloading. If the ambient temperature is too high, the nozzle may not "
+                     "reach the desired temperature, resulting in stringing which can cause blobs or misloads later. "
+                     "When checked, the printer will wait for the optimal temperature before finishing the last cooling "
+                     "move to increase the chances of a good tip. This option requires at least 2 cooling moves to work.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBools { false });
+
     def = this->add("filament_purge_multiplier", coPercents);
     def->label = L("Purge volume multiplier");
     def->tooltip = L("Purging volume on the wipe tower is determined by 'multimaterial_purging' in Printer Settings. "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -845,6 +845,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              filament_cooling_initial_speed))
     ((ConfigOptionFloats,              filament_minimal_purge_on_wipe_tower))
     ((ConfigOptionFloats,              filament_cooling_final_speed))
+    ((ConfigOptionBools,               filament_cooling_wait_for_temp))
     ((ConfigOptionPercents,            filament_purge_multiplier))
     ((ConfigOptionStrings,             filament_ramming_parameters))
     ((ConfigOptionBools,               filament_multitool_ramming))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2323,6 +2323,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_cooling_moves");
         optgroup->append_single_option_line("filament_cooling_initial_speed");
         optgroup->append_single_option_line("filament_cooling_final_speed");
+        optgroup->append_single_option_line("filament_cooling_wait_for_temp");
         optgroup->append_single_option_line("filament_stamping_loading_speed");
         optgroup->append_single_option_line("filament_stamping_distance");
         optgroup->append_single_option_line("filament_purge_multiplier");


### PR DESCRIPTION
When looking into #14784, I found a helpful posting that suggested that the air inside the CORE One enclosure might be too hot for the existing cooling moves to be effective: https://forum.prusa3d.com/forum/original-prusa-i3-mmu3-assembly-and-first-prints-troubleshooting/core-one-mmu3-2/#post-759855

I tested this theory by extending the number of cooling moves to 6 up from 2, and this had a great improvement on my Core ONE + MMU3 reliability. Prints started working flawlessly, where previously I would have blobs and MMU load failures (the tip ends were very bad when unloaded too hot).

But just setting the number of cooling moves adds a lot of time when it may not be necessary. This PR adds an option to wait for the target cooling temperature near the end of the cooling moves, before the filament is unloaded. This has the same very positive effect on the reliability without adding too much time to each filament change. It is self-tuning in that it will only wait as long as needed, so with good ambient temperature should add almost no time.

I've tested it with Prusament PLA, PETG, and Woodfill all with great results. I hope this can be added as an option and maybe even become the default at some point. Thanks!

<img width="634" height="226" alt="Screenshot 2025-09-17 at 22 05 51" src="https://github.com/user-attachments/assets/b920e287-8582-4f81-85f8-eab6716c8517" />
