### PR TITLE
feat: add "push other parts" to GizmoScale.

### DIFF
--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -83,6 +83,30 @@ void break_to_debugger()
     #endif /* _WIN32 */
 }
 
+const std::string& shortkey_ctrl()
+{
+    static const std::string str =
+#ifdef __APPLE__
+        "⌘"
+#else
+        "Ctrl"
+#endif
+        ;
+    return str;
+}
+
+const std::string& shortkey_alt()
+{
+    static const std::string str =
+#ifdef __APPLE__
+        "⌥"
+#else
+        "Alt"
+#endif
+        ;
+    return str;
+}
+
 const std::string& shortkey_ctrl_prefix()
 {
 	static const std::string str =

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -36,6 +36,10 @@ void enable_screensaver();
 bool debugged();
 void break_to_debugger();
 
+// Platform specific Ctrl/Alt (Windows, Linux) vs. ⌘/⌥ (OSX) keys
+extern const std::string& shortkey_ctrl();
+extern const std::string& shortkey_alt();
+
 // Platform specific Ctrl+/Alt+ (Windows, Linux) vs. ⌘/⌥ (OSX) prefixes 
 extern const std::string& shortkey_ctrl_prefix();
 extern const std::string& shortkey_alt_prefix();

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.cpp
@@ -3,10 +3,13 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "GLGizmoScale.hpp"
+
+#include <boost/nowide/convert.hpp>
 #include "slic3r/GUI/GLCanvas3D.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
 #include "slic3r/GUI/GUI_ObjectManipulation.hpp"
 #include "slic3r/GUI/Plater.hpp"
+#include "slic3r/Utils/UndoRedo.hpp"
 #include "libslic3r/Model.hpp"
 
 #include <GL/glew.h>
@@ -34,24 +37,36 @@ GLGizmoScale3D::GLGizmoScale3D(GLCanvas3D& parent, const std::string& icon_filen
     m_grabber_connections[4].grabber_indices = { 7, 8 }; 
     m_grabber_connections[5].grabber_indices = { 8, 9 };
     m_grabber_connections[6].grabber_indices = { 9, 6 };
+
+    // Must match the order of PartsRelationsAdjustment enum
+    m_relations_adjustment_modes = {_u8L("Move None"), _u8L("Move All")};
 }
 
 std::string GLGizmoScale3D::get_tooltip() const
 {
     const Vec3d scale = 100.0 * m_scale;
+    Vec3d delta = Vec3d::Zero();
+    if (m_starting.box.defined) {
+        delta = m_starting.box.min - m_bounding_box.min;
+        delta *= 2;
+        if (m_imperial_units) {
+            delta *= ObjectManipulation::mm_to_in;
+        }
+
+    }
 
     if (m_hover_id == 0 || m_hover_id == 1 || m_grabbers[0].dragging || m_grabbers[1].dragging)
-        return "X: " + format(scale.x(), 4) + "%";
+        return "X: " + format(scale.x(), 4) + "% (size delta: " + format(delta.x(), 4) + ")";
     else if (m_hover_id == 2 || m_hover_id == 3 || m_grabbers[2].dragging || m_grabbers[3].dragging)
-        return "Y: " + format(scale.y(), 4) + "%";
+        return "Y: " + format(scale.y(), 4) + "% (size delta: " + format(delta.y(), 4) + ")";
     else if (m_hover_id == 4 || m_hover_id == 5 || m_grabbers[4].dragging || m_grabbers[5].dragging)
-        return "Z: " + format(scale.z(), 4) + "%";
-    else if (m_hover_id == 6 || m_hover_id == 7 || m_hover_id == 8 || m_hover_id == 9 || 
+        return "Z: " + format(scale.z(), 4) + "% (size delta: " + format(delta.z(), 4) + ")";
+    else if (m_hover_id == 6 || m_hover_id == 7 || m_hover_id == 8 || m_hover_id == 9 ||
         m_grabbers[6].dragging || m_grabbers[7].dragging || m_grabbers[8].dragging || m_grabbers[9].dragging)
     {
-        std::string tooltip = "X: " + format(scale.x(), 4) + "%\n";
-        tooltip += "Y: " + format(scale.y(), 4) + "%\n";
-        tooltip += "Z: " + format(scale.z(), 4) + "%";
+        std::string tooltip = "X: " + format(scale.x(), 4) + "% (size delta: " + format(delta.x(), 4) + ")\n";
+        tooltip += "Y: " + format(scale.y(), 4) + "% (size delta: " + format(delta.y(), 4) + ")\n";
+        tooltip += "Z: " + format(scale.z(), 4) + "% (size delta: " + format(delta.z(), 4) + ")";
         return tooltip;
     }
     else
@@ -62,6 +77,37 @@ static int constraint_id(int grabber_id)
 {
   static const std::vector<int> id_map = { 1, 0, 3, 2, 5, 4, 8, 9, 6, 7 };
   return (0 <= grabber_id && grabber_id < (int)id_map.size()) ? id_map[grabber_id] : -1;
+}
+
+GLGizmoScale3D::AdjacentVolumes GLGizmoScale3D::get_adjacent_volumes(
+    Selection& selection, const BoundingBoxf3& world_bounding_box
+) {
+    const int object_id = selection.get_object_idx();
+    AdjacentVolumes adjacent_volumes{};
+    if (object_id != -1) {
+        const std::vector<unsigned int> unselected_volume_idxes = selection.get_unselected_volume_idxs_from(
+            selection.get_volume_idxs_from_object(object_id)
+        );
+
+        for (auto curr_unselected_volume_idx : unselected_volume_idxes) {
+            const auto& curr_unselected_volume = selection.get_volume(curr_unselected_volume_idx);
+
+            BoundingBoxf3 curr_unselected_bound_box =
+                curr_unselected_volume->transformed_convex_hull_bounding_box();
+
+            for (const auto axis : {X, Y, Z}) {
+                if (is_approx(curr_unselected_bound_box.min[axis], world_bounding_box.max[axis]) ||
+                    curr_unselected_bound_box.min[axis] >= world_bounding_box.max[axis]) {
+                    adjacent_volumes.volumes[axis][0].insert(curr_unselected_volume_idx);
+                } else if (is_approx(curr_unselected_bound_box.max[axis], world_bounding_box.min[axis]) ||
+                           world_bounding_box.min[axis] >= curr_unselected_bound_box.max[axis]) {
+                    adjacent_volumes.volumes[axis][1].insert(curr_unselected_volume_idx);
+                }
+            }
+        }
+    }
+
+    return adjacent_volumes;
 }
 
 bool GLGizmoScale3D::on_mouse(const wxMouseEvent &mouse_event)
@@ -81,6 +127,8 @@ bool GLGizmoScale3D::on_mouse(const wxMouseEvent &mouse_event)
                 transformation_type.set_independent();
 
             Selection& selection = m_parent.get_selection();
+            const BoundingBoxf3 world_bounding_box_before = selection.get_bounding_box();
+
             selection.scale(m_scale, transformation_type);
             if (m_starting.ctrl_down) {
                 // constrained scale:
@@ -91,6 +139,49 @@ bool GLGizmoScale3D::on_mouse(const wxMouseEvent &mouse_event)
                 // re-apply the scale because the selection always applies the transformations with respect to the initial state 
                 // set into on_start_dragging() with the call to selection.setup_cache()
                 m_parent.get_selection().scale_and_translate(m_scale, m_starting.constraint_position - constraint_position, transformation_type);
+            }
+
+            const BoundingBoxf3 world_bounding_box_after = selection.get_bounding_box();
+
+            for (const auto axis : {X, Y, Z}) {
+                if (world_bounding_box_before.max[axis] != world_bounding_box_after.max[axis] &&
+                    !m_starting.adjacent_volumes.volumes[axis][0].empty()) {
+
+                    Vec3d displacement = Vec3d::Zero();
+                    displacement[axis] = (world_bounding_box_after.max[axis] - world_bounding_box_before.max[axis]);
+                    for (const auto current_unselected_volume_idx :
+                         m_starting.adjacent_volumes.volumes[axis][0]) {
+                        GLVolume* current_unselected_volume = selection.get_volume(current_unselected_volume_idx);
+
+                        const Geometry::Transformation& vol_trafo = current_unselected_volume->get_volume_transformation();
+                        const Geometry::Transformation& inst_trafo = current_unselected_volume->get_instance_transformation();
+
+                        const Vec3d inst_pivot = vol_trafo.get_offset();
+                        const Transform3d inst_matrix_no_offset = inst_trafo.get_matrix_no_offset();
+                        const Transform3d trafo = Geometry::translation_transform(inst_pivot) * inst_matrix_no_offset.inverse() * Geometry::translation_transform(displacement) * inst_matrix_no_offset * Geometry::translation_transform(-inst_pivot);
+                        current_unselected_volume->set_volume_transformation(trafo * vol_trafo.get_matrix());
+                    }
+                }
+
+                if (world_bounding_box_before.min[axis] != world_bounding_box_after.min[axis] &&
+                    !m_starting.adjacent_volumes.volumes[axis][1].empty()) {
+
+                    Vec3d displacement = Vec3d::Zero();
+                    displacement[axis] = (world_bounding_box_after.min[axis] - world_bounding_box_before.min[axis]);
+                    for (const auto current_unselected_volume_idx :
+                         m_starting.adjacent_volumes.volumes[axis][1]) {
+                        GLVolume* current_unselected_volume = selection.get_volume(current_unselected_volume_idx);
+
+                        const Geometry::Transformation& vol_trafo = current_unselected_volume->get_volume_transformation();
+                        const Geometry::Transformation& inst_trafo = current_unselected_volume->get_instance_transformation();
+
+                        const Vec3d inst_pivot = vol_trafo.get_offset();
+                        const Transform3d inst_matrix_no_offset = inst_trafo.get_matrix_no_offset();
+                        const Transform3d trafo = Geometry::translation_transform(inst_pivot) * inst_matrix_no_offset.inverse() * Geometry::translation_transform(displacement) * inst_matrix_no_offset * Geometry::translation_transform(-inst_pivot);
+                        current_unselected_volume->set_volume_transformation(trafo * vol_trafo.get_matrix());
+                    }
+                }
+
             }
         }
     }
@@ -114,6 +205,16 @@ bool GLGizmoScale3D::on_init()
     }
 
     m_shortcut_key = WXK_CONTROL_S;
+
+    // initiate info shortcuts
+    const std::string ctrl  = _u8L(GUI::shortkey_ctrl());
+    const std::string alt   = _u8L(GUI::shortkey_alt());
+    const std::string shift = _u8L("Shift");
+
+    m_shortcuts.emplace_back(ctrl, _u8L("Scale in one direction"));
+    m_shortcuts.emplace_back(shift, _u8L("Scale in fixed increments"));
+    m_shortcuts.emplace_back(alt, _u8L("Scale independent (when multi-select)"));
+
     return true;
 }
 
@@ -134,15 +235,24 @@ void GLGizmoScale3D::on_start_dragging()
     m_starting.ctrl_down = wxGetKeyState(WXK_CONTROL);
     m_starting.drag_position = m_grabbers_transform * m_grabbers[m_hover_id].center;
     m_starting.box = m_bounding_box;
+    if (m_relations_adjustment_mode == PartsRelationsAdjustment::MoveNone) {
+        m_starting.adjacent_volumes = {};
+    }
+    else {
+        m_starting.adjacent_volumes = get_adjacent_volumes(m_parent.get_selection(), m_parent.get_selection().get_bounding_box());
+    }
+
     m_starting.center = m_center;
     m_starting.instance_center = m_instance_center;
     m_starting.constraint_position = m_grabbers_transform * m_grabbers[constraint_id(m_hover_id)].center;
+    m_imperial_units = wxGetApp().app_config->get_bool("use_inches");
 }
 
 void GLGizmoScale3D::on_stop_dragging()
 {
     m_parent.do_scale(L("Gizmo-Scale"));
     m_starting.ctrl_down = false;
+    m_starting.box.reset();
 }
 
 void GLGizmoScale3D::on_dragging(const UpdateData& data)
@@ -363,6 +473,83 @@ void GLGizmoScale3D::on_register_raycasters_for_picking()
 void GLGizmoScale3D::on_unregister_raycasters_for_picking()
 {
     m_parent.set_raycaster_gizmos_on_top(false);
+}
+
+void GLGizmoScale3D::on_render_input_window(float x, float y, float bottom_limit)
+{
+    const std::string relations_adjustment = "Relations Adjustment";
+
+
+    ImGuiPureWrap::begin(get_name(), ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
+
+    // adjust window position to avoid overlap the view toolbar
+    adjust_window_position(x, y, bottom_limit);
+
+    // add shortcuts panel
+    render_shortcuts();
+
+    ImGui::Separator();
+
+    if (m_label_width == 0.f) {
+        m_label_width = ImGuiPureWrap::calc_text_size(_u8L(relations_adjustment)).x;
+        m_label_width += m_imgui->scaled(1.f);
+    }
+
+    ImGui::AlignTextToFramePadding();
+    int selection_idx = static_cast<int>(m_relations_adjustment_mode);
+    const bool is_changed = ImGuiPureWrap::combo(_u8L(relations_adjustment), m_relations_adjustment_modes, selection_idx, 0, m_label_width, m_control_width);
+
+    if (is_changed) {
+        Plater::TakeSnapshot snapshot(wxGetApp().plater(), _L("Change Scale & Push mode"), UndoRedo::SnapshotType::GizmoAction);
+        m_relations_adjustment_mode = static_cast<PartsRelationsAdjustment>(selection_idx);
+    }
+
+    ImGuiPureWrap::end();
+}
+
+void GLGizmoScale3D::render_shortcuts()
+{
+    std::wstring btn_label;
+    btn_label = m_show_shortcuts ? ImGui::CollapseBtn : ImGui::ExpandBtn;
+
+    if (ImGuiPureWrap::button("? " + boost::nowide::narrow(btn_label)))
+        m_show_shortcuts = !m_show_shortcuts;
+
+    if (m_shortcut_label_width < 0.f) {
+        for (const auto& shortcut : m_shortcuts) {
+            const float width = ImGuiPureWrap::calc_text_size(shortcut.first).x;
+            if (m_shortcut_label_width < width)
+                m_shortcut_label_width = width;
+        }
+        m_shortcut_label_width += +m_imgui->scaled(1.f);
+    }
+
+    if (m_show_shortcuts)
+        for (const auto& [shortcut, meaning] : m_shortcuts ){
+            ImGuiPureWrap::text_colored(ImGuiPureWrap::COL_ORANGE_LIGHT, shortcut);
+            ImGui::SameLine(m_shortcut_label_width);
+            ImGuiPureWrap::text(meaning);
+        }
+}
+
+void GLGizmoScale3D::adjust_window_position(float x, float y, float bottom_limit)
+{
+    static float last_y = 0.0f;
+    static float last_h = 0.0f;
+
+    const float win_h = ImGui::GetWindowHeight();
+    y                 = std::min(y, bottom_limit - win_h);
+
+    ImGui::SetWindowPos(ImVec2(x, y), ImGuiCond_Always);
+
+    if (!is_approx(last_h, win_h) || !is_approx(last_y, y)) {
+        // ask canvas for another frame to render the window in the correct position
+        m_imgui->set_requires_extra_frame();
+        if (!is_approx(last_h, win_h))
+            last_h = win_h;
+        if (!is_approx(last_y, y))
+            last_y = y;
+    }
 }
 
 void GLGizmoScale3D::render_grabbers_connection(unsigned int id_1, unsigned int id_2, const ColorRGBA& color)

--- a/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoScale.hpp
@@ -6,6 +6,7 @@
 #define slic3r_GLGizmoScale_hpp_
 
 #include "GLGizmoBase.hpp"
+#include "slic3r/GUI/Selection.hpp"
 
 namespace Slic3r {
 namespace GUI {
@@ -16,6 +17,10 @@ class GLGizmoScale3D : public GLGizmoBase
 {
     static const double Offset;
 
+    struct AdjacentVolumes
+    {
+        Selection::IndicesList    volumes[3][2]; // [X/Y/Z][Max/Min]
+    };
     struct StartingData
     {
         bool ctrl_down{ false };
@@ -25,6 +30,14 @@ class GLGizmoScale3D : public GLGizmoBase
         Vec3d instance_center{ Vec3d::Zero() };
         Vec3d constraint_position{ Vec3d::Zero() };
         BoundingBoxf3 box;
+        AdjacentVolumes adjacent_volumes;
+    };
+
+    // Indicates which other parts around the selected part will move.
+    enum class PartsRelationsAdjustment
+    {
+        MoveNone = 0,
+        MoveAll
     };
 
     BoundingBoxf3 m_bounding_box;
@@ -34,6 +47,15 @@ class GLGizmoScale3D : public GLGizmoBase
     Vec3d m_scale{ Vec3d::Ones() };
     double m_snap_step{ 0.05 };
     StartingData m_starting;
+    bool  m_imperial_units{ false };
+    PartsRelationsAdjustment m_relations_adjustment_mode{PartsRelationsAdjustment::MoveNone};
+    std::vector<std::string> m_relations_adjustment_modes{};
+    float m_label_width{ 0.f };
+    float m_control_width{ 200.f };
+    bool m_show_shortcuts{ false };
+    std::vector<std::pair<std::string, std::string>>  m_shortcuts;
+    float m_shortcut_label_width{ -1.f };
+
 
     struct GrabberConnection
     {
@@ -77,6 +99,9 @@ protected:
     virtual void on_render() override;
     virtual void on_register_raycasters_for_picking() override;
     virtual void on_unregister_raycasters_for_picking() override;
+    void on_render_input_window(float x, float y, float bottom_limit) override;
+    void render_shortcuts();
+    void adjust_window_position(float x, float y, float bottom_limit);
 
 private:
     void render_grabbers_connection(unsigned int id_1, unsigned int id_2, const ColorRGBA& color);
@@ -86,6 +111,9 @@ private:
 
     double calc_ratio(const UpdateData& data) const;
     void update_render_data();
+    static AdjacentVolumes get_adjacent_volumes(
+        Selection &selection, const BoundingBoxf3& world_bounding_box
+    );
 };
 
 


### PR DESCRIPTION
Hi! 👋
This PR partly implements [#7563](https://github.com/prusa3d/prusaslicer/issues/7563)

* When you do two cuts and then extend the middle piece, the upper piece will move along with it (see GIFs below).

* Since all the main shortcut keys were already taken, I added a small UI input window to enable this mode, please let me know if you have a better idea.

* Added “size delta” to the scale tool-tip for more info while scaling.

The code around matrices is a bit messy since I’m still learning how to work with them. Any feedback or cleanup tips would be appreciated!

Thanks!
![scale-and-push-other-parts](https://github.com/user-attachments/assets/82e58e12-0814-47cd-a286-b1cfb177c6ac)
