### PR TITLE
The angle_threshold check is backwards in filter_convex_concave_points_by_angle_threshold

### DIFF
--- a/src/libslic3r/Polygon.cpp
+++ b/src/libslic3r/Polygon.cpp
@@ -247,7 +247,7 @@ Points filter_points_by_vectors(const Points &poly, FilterFn filter)
         // p2 is next point to the currently visited point p1.
         Vec2d v2 = (p2 - p1).cast<double>();
         if (filter(v1, v2))
-            out.emplace_back(p2);
+            out.emplace_back(p1);
         v1 = v2;
         p1 = p2;
     }


### PR DESCRIPTION
Obviously nobody must be using this... but here you go anyway