### PR TITLE
Support for 3DPrinterOS cloud integration

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -109,6 +109,7 @@ static const t_config_enum_values s_keys_map_PrintHostType {
     { "astrobox",       htAstroBox },
     { "repetier",       htRepetier },
     { "mks",            htMKS },
+    { "3dprinteros",    ht3DPrinterOS},
     { "prusaconnectnew", htPrusaConnectNew },
 
 };
@@ -2451,7 +2452,8 @@ void PrintConfigDef::init_fff_params()
         { "flashair",       "FlashAir" },
         { "astrobox",       "AstroBox" },
         { "repetier",       "Repetier" },
-        { "mks",            "MKS" }
+        { "mks",            "MKS" },
+        { "3dprinteros",    "3DPrinterOS" }
     });
     def->mode = comAdvanced;
     def->cli = ConfigOptionDef::nocli;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -88,7 +88,7 @@ enum class MachineLimitsUsage {
 };
 
 enum PrintHostType {
-   htPrusaLink, htPrusaConnect, htOctoPrint, htMoonraker, htDuet, htFlashAir, htAstroBox, htRepetier, htMKS, htPrusaConnectNew
+   htPrusaLink, htPrusaConnect, htOctoPrint, htMoonraker, htDuet, htFlashAir, htAstroBox, htRepetier, htMKS, ht3DPrinterOS, htPrusaConnectNew  
 };
 
 enum AuthorizationType {

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -394,6 +394,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/PrusaConnect.cpp
     Utils/ServiceConfig.hpp
     Utils/ServiceConfig.cpp
+    Utils/3DPrinterOS.hpp
+    Utils/3DPrinterOS.cpp
 )
 
 find_package(NanoSVG REQUIRED)

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -39,6 +39,7 @@
 #include "../Utils/FixModelByWin10.hpp"
 #include "../Utils/UndoRedo.hpp"
 #include "../Utils/ServiceConfig.hpp"
+#include "../Utils/3DPrinterOS.hpp"
 #include "RemovableDriveManager.hpp"
 #include "BitmapCache.hpp"
 #include "BonjourDialog.hpp"
@@ -432,6 +433,34 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
         return sizer;
     };
 
+    auto print_host_logout = [&](wxWindow *parent) {
+        auto sizer = create_sizer_with_btn(parent, &m_printhost_logout_btn, "", _L("Log Out"));
+
+        m_printhost_logout_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) {
+            std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
+            if (!host) {
+                const wxString text = _L("Could not get a valid Printer Host reference");
+                show_error(this, text);
+                return;
+            }
+
+            wxString msg_text = _L("Are you sure to log out?");
+            MessageDialog dialog(this, msg_text, "", wxICON_QUESTION | wxYES_NO);
+
+            if (dialog.ShowModal() == wxID_YES) {
+                host->log_out();
+                // update();
+                update_printhost_buttons();
+                this->Fit();
+                this->Layout();
+#ifdef __WXMSW__
+                this->Refresh();
+#endif
+            }
+        });
+        return sizer;
+    };
+
     auto print_host_printers = [this, create_sizer_with_btn](wxWindow* parent) {
         //add_scaled_button(parent, &m_printhost_port_browse_btn, "browse", _(L("Refresh Printers")), wxBU_LEFT | wxBU_EXACTFIT);
         auto sizer = create_sizer_with_btn(parent, &m_printhost_port_browse_btn, "browse", _(L("Refresh Printers")));
@@ -461,6 +490,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     Line host_line = m_optgroup->create_single_option_line(option);
     host_line.append_widget(printhost_browse);
     host_line.append_widget(print_host_test);
+    host_line.append_widget(print_host_logout);
     m_optgroup->append_line(host_line);
 
     m_optgroup->append_single_option_line("printhost_authorization_type");
@@ -621,6 +651,11 @@ void PhysicalPrinterDialog::update_printhost_buttons()
     std::unique_ptr<PrintHost> host(PrintHost::get_print_host(m_config));
     m_printhost_test_btn->Enable(!m_config->opt_string("print_host").empty() && host->can_test());
     m_printhost_browse_btn->Enable(host->has_auto_discovery());
+    if (host) {
+        m_printhost_browse_btn->Show(host->has_auto_discovery());
+        m_printhost_logout_btn->Show(host->is_logged_in());
+        m_printhost_test_btn->SetLabel(host->is_cloud() ? _L("Login/Test") : _L("Test"));
+    }
 }
 
 void PhysicalPrinterDialog::update(bool printer_change)
@@ -658,12 +693,23 @@ void PhysicalPrinterDialog::update(bool printer_change)
                 m_stored_host = printhost_win->GetValue();
                 printhost_win->SetValue(from_u8(Utils::ServiceConfig::instance().connect_url()));
             }
+        } else if (opt->value == ht3DPrinterOS) {
+            // hide show hostname and 3DPrinterOS address
+            Field *printhost_field = m_optgroup->get_field("print_host");
+            m_optgroup->show_field("printhost_apikey", false);
+            text_ctrl *printhost_win = printhost_field ?
+                dynamic_cast<text_ctrl *>(printhost_field->getWindow()) :
+                nullptr;
+            if (!m_opened_as_connect && printhost_win && m_last_host_type != ht3DPrinterOS) {
+                m_stored_host = printhost_win->GetValue();
+                printhost_win->SetValue(from_u8(C3DPrinterOS::default_host()));
+            }
         } else {
             m_printhost_browse_btn->Show();
             // hide PrusaConnect address and show hostname
             Field* printhost_field = m_optgroup->get_field("print_host");
             text_ctrl* printhost_win = printhost_field ? dynamic_cast<text_ctrl*>(printhost_field->getWindow()) : nullptr;
-            if (!m_opened_as_connect && printhost_win && m_last_host_type == htPrusaConnect) {
+            if (!m_opened_as_connect && printhost_win && (m_last_host_type == htPrusaConnect || m_last_host_type == ht3DPrinterOS)) {
                 wxString temp_host = printhost_win->GetValue();
                 printhost_win->SetValue(m_stored_host);
                 m_stored_host = temp_host;

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -74,6 +74,7 @@ class PhysicalPrinterDialog : public DPIDialog
     ScalableButton*     m_add_preset_btn                {nullptr};
     ScalableButton*     m_printhost_browse_btn          {nullptr};
     ScalableButton*     m_printhost_test_btn            {nullptr};
+    ScalableButton*     m_printhost_logout_btn          {nullptr};
     ScalableButton*     m_printhost_cafile_browse_btn   {nullptr};
     ScalableButton*     m_printhost_port_browse_btn     {nullptr};
     ScalableButton*     m_api_key_copy_btn              {nullptr};

--- a/src/slic3r/Utils/3DPrinterOS.cpp
+++ b/src/slic3r/Utils/3DPrinterOS.cpp
@@ -1,0 +1,710 @@
+#include "3DPrinterOS.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <exception>
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <wx/progdlg.h>
+#include <wx/string.h>
+#include <wx/event.h>
+#include <wx/dialog.h>
+#include <wx/radiobut.h>
+
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Utils.hpp"
+#include "slic3r/GUI/I18N.hpp"
+#include "slic3r/GUI/GUI.hpp"
+#include "slic3r/GUI/format.hpp"
+#include "slic3r/GUI/GUI_Utils.hpp"
+#include "slic3r/GUI/MsgDialog.hpp"
+#include "slic3r/GUI/Widgets/ComboBox.hpp"
+#include "slic3r/GUI/Widgets/Button.hpp"
+#include "slic3r/GUI/GUI_App.hpp"
+
+#include "Http.hpp"
+#include <wx/busyinfo.h>
+
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace {
+
+class UploadOptionsDialog : public Slic3r::GUI::DPIDialog
+{
+public:
+    UploadOptionsDialog(
+        wxWindow *parent,
+        const wxArrayString &cloud_projects,
+        const wxArrayString &cloud_printer_types,
+        const wxString preset_name
+    )
+        : Slic3r::GUI::DPIDialog(
+              parent,
+              wxID_ANY,
+              "3DPrinterOS Cloud upload options",
+              wxDefaultPosition,
+              wxSize(100 * Slic3r::GUI::wxGetApp().em_unit(), -1),
+              wxDEFAULT_DIALOG_STYLE
+          )
+        , okButton(nullptr) {
+        SetFont(Slic3r::GUI::wxGetApp().normal_font());
+        SetBackgroundColour(*wxWHITE);
+        SetForegroundColour(*wxBLACK);
+
+        singleRadio = new wxRadioButton(
+            this, wxID_ANY, "Single file", wxDefaultPosition, wxDefaultSize, wxRB_GROUP
+        );
+        projectRadio = new wxRadioButton(this, wxID_ANY, "Project File");
+        projectsLabel = new wxStaticText(this, wxID_ANY, "Project:");
+        wxStaticText *printerLabel = new wxStaticText(this, wxID_ANY, "Printer type:");
+
+        projectsComboBox = new wxComboBox(
+            this, wxID_ANY, wxString(""), wxDefaultPosition, wxDefaultSize, 0, nullptr,
+            DD_NO_CHECK_ICON
+        );
+        printerTypeComboBox = new wxComboBox(
+            this, wxID_ANY, wxString(""), wxDefaultPosition, wxDefaultSize, 0, nullptr,
+            DD_NO_CHECK_ICON | wxTE_READONLY
+        );
+
+        printerWarningLabel =
+            new wxStaticText(this, wxID_ANY, "Printer type not found, please select manually.");
+        printerWarningLabel->SetForegroundColour(*wxRED);
+        printerWarningLabel->Hide();
+
+        for (int i = 0; i < cloud_projects.size(); i++) {
+            projectsComboBox->Append(cloud_projects[i]);
+        }
+        if (cloud_printer_types.size() > 0) {
+            for (int i = 0; i < cloud_printer_types.size(); i++) {
+                printerTypeComboBox->Append(cloud_printer_types[i]);
+                if (cloud_printer_types[i].Find(preset_name) != wxNOT_FOUND &&
+                    printerTypeComboBox->GetSelection() == -1) {
+                    printerTypeComboBox->SetSelection(i);
+                }
+            }
+            if (printerTypeComboBox->GetCount() > 1) {
+                printerWarningLabel->Show();
+            } else {
+                printerTypeComboBox->SetSelection(0);
+            }
+        }
+
+        okButton = new wxButton(this, wxID_OK, "OK");
+        wxButton *cancelButton = new wxButton(this, wxID_CANCEL, "Cancel");
+
+        wxBoxSizer *radioSizer = new wxBoxSizer(wxHORIZONTAL);
+        wxBoxSizer *btnSizer = new wxBoxSizer(wxHORIZONTAL);
+        radioSizer->Add(singleRadio, 0, wxALL, 5);
+        radioSizer->Add(projectRadio, 0, wxALL, 5);
+        btnSizer->Add(okButton, 0, wxALL | wxALIGN_CENTER, 5);
+        btnSizer->Add(cancelButton, 0, wxALL | wxALIGN_CENTER, 5);
+
+        wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(radioSizer, 0, wxALL, 5);
+        sizer->Add(projectsLabel, 0, wxALL, 5);
+        sizer->Add(projectsComboBox, 0, wxALL | wxEXPAND, 5);
+        sizer->Add(printerLabel, 0, wxALL, 5);
+        sizer->Add(printerTypeComboBox, 0, wxALL | wxEXPAND, 5);
+        sizer->Add(printerWarningLabel, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
+        sizer->Add(btnSizer, 0, wxALL | wxALIGN_CENTER, 5);
+        SetSizer(sizer);
+        sizer->Fit(this);
+        projectsComboBox->Hide();
+        projectsLabel->Hide();
+        projectRadio->Bind(wxEVT_RADIOBUTTON, &UploadOptionsDialog::OnRadioButtonSelected, this);
+        singleRadio->Bind(wxEVT_RADIOBUTTON, &UploadOptionsDialog::OnRadioButtonSelected, this);
+        // Bind combo box selection change to validation
+        printerTypeComboBox->Bind(wxEVT_COMBOBOX, &UploadOptionsDialog::OnPrinterTypeChanged, this);
+        ValidateOkButton(); // Initial validation
+        Slic3r::GUI::wxGetApp().UpdateDlgDarkUI(this);
+
+        CenterOnParent();
+    }
+
+    void OnRadioButtonSelected(wxCommandEvent &event) {
+        wxRadioButton *selectedRadio = dynamic_cast<wxRadioButton *>(event.GetEventObject());
+        if (selectedRadio) {
+            wxString label = selectedRadio->GetLabel();
+            if (label == wxString("Project File")) {
+                projectsComboBox->Show();
+                projectsLabel->Show();
+            } else {
+                projectsComboBox->Hide();
+                projectsLabel->Hide();
+            }
+            Layout();
+        }
+    }
+
+    void on_dpi_changed(const wxRect &suggested_rect) {}
+
+    void OnPrinterTypeChanged(wxCommandEvent &event) {
+        ValidateOkButton();
+        event.Skip();
+    }
+
+    void ValidateOkButton() {
+        bool hasSelection = (printerTypeComboBox->GetSelection() != wxNOT_FOUND);
+        okButton->Enable(hasSelection);
+    }
+
+    void GetValues(std::string &project, std::string &printer_type) {
+        project = projectRadio->GetValue() ? std::string(projectsComboBox->GetValue().c_str()) : "";
+        printer_type = std::string(printerTypeComboBox->GetValue().c_str());
+    }
+
+private:
+    wxComboBox *projectsComboBox;
+    wxComboBox *printerTypeComboBox;
+    wxStaticText *projectsLabel;
+    wxStaticText *printerWarningLabel;
+    wxRadioButton *singleRadio;
+    wxRadioButton *projectRadio;
+    wxButton *okButton;
+};
+
+class TokenAuthDialog : public Slic3r::GUI::DPIDialog
+{
+public:
+    TokenAuthDialog(
+        wxWindow *parent,
+        const std::string &url,
+        const std::string &token,
+        const std::string &cafile,
+        pt::ptree &resp
+    )
+        : Slic3r::GUI::DPIDialog(
+              parent,
+              wxID_ANY,
+              "3DPrinterOS",
+              wxDefaultPosition,
+              wxSize(45 * Slic3r::GUI::wxGetApp().em_unit(), -1),
+              wxDEFAULT_DIALOG_STYLE
+          )
+        , m_url(url)
+        , m_token(token)
+        , m_cafile(cafile)
+        , m_resp(resp) {
+        SetFont(Slic3r::GUI::wxGetApp().normal_font());
+        SetBackgroundColour(*wxWHITE);
+        SetForegroundColour(*wxBLACK);
+
+        auto *sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(new wxStaticText(this, wxID_ANY, "Authorizing..."), 1, wxALL | wxCENTER, 10);
+        auto *cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
+        sizer->Add(cancelBtn, 0, wxALL | wxALIGN_CENTER, 10);
+        SetSizerAndFit(sizer);
+
+        Bind(wxEVT_THREAD, [this](wxThreadEvent &e) { EndModal(e.GetId()); });
+        Bind(wxEVT_TIMER, &TokenAuthDialog::OnRetry, this);
+        Bind(wxEVT_SHOW, &TokenAuthDialog::OnShow, this);
+        Bind(wxEVT_BUTTON, &TokenAuthDialog::OnCancel, this, wxID_CANCEL);
+
+        m_timer.SetOwner(this);
+        Slic3r::GUI::wxGetApp().UpdateDlgDarkUI(this);
+        CenterOnParent();
+    }
+
+    void on_dpi_changed(const wxRect &suggested_rect) {}
+
+private:
+    void OnShow(wxShowEvent &event) {
+        if (event.IsShown() && !m_started) {
+            m_started = true;
+            SendRequest();
+        }
+        event.Skip();
+    }
+
+    void OnCancel(wxCommandEvent &) {
+        m_cancelled = true;
+        if (m_http_ptr) {
+            m_http_ptr->cancel(); // abort the background request
+        }
+        EndModal(wxID_CANCEL);
+    }
+
+    void OnRetry(wxTimerEvent &) { SendRequest(); }
+
+    void SendRequest() {
+        if (m_cancelled || m_attempt >= m_max_retries) {
+            if (m_attempt >= m_max_retries) {
+                m_resp.put("result", false);
+                m_resp.put("message", "Maximum login retries exceeded");
+            }
+            wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_ABORT));
+            return;
+        }
+
+        m_attempt++;
+        std::string postBody = "token=" + m_token;
+        auto http = Slic3r::Http::post(m_url);
+        http.timeout_max(60);
+        if (!m_cafile.empty()) {
+            http.ca_file(m_cafile);
+        }
+        http.header("Content-Length", std::to_string(postBody.size()));
+        http.set_post_body(postBody);
+        http.on_error([this](std::string, std::string error, unsigned status) {
+                if (!m_cancelled) {
+                    m_resp.put("result", false);
+                    m_resp.put(
+                        "message", (status != 200) ? "HTTP error: " + std::to_string(status) : error
+                    );
+                    wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_ABORT));
+                }
+            }
+        ).on_complete([this](std::string body, unsigned status) {
+            if (!m_cancelled) {
+                if (status != 200) {
+                    m_resp.put("result", false);
+                    m_resp.put("message", "HTTP error: " + std::to_string(status));
+                    wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_ABORT));
+                    return;
+                }
+
+                try {
+                    std::stringstream ss(body);
+                    pt::read_json(ss, m_resp);
+                } catch (...) {
+                    m_resp.put("result", false);
+                    m_resp.put("message", "Could not parse server response");
+                }
+
+                if (m_resp.get<bool>("result", false) &&
+                    m_resp.get_optional<std::string>("message.session").has_value()) {
+                    wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_OK));
+                } else if (m_resp.get<bool>("result", false)) {
+                    if (m_attempt < m_max_retries)
+                        m_timer.StartOnce(m_retry_delay_ms);
+                    else
+                        wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_ABORT));
+                } else {
+                    wxQueueEvent(this, new wxThreadEvent(wxEVT_THREAD, wxID_ABORT));
+                }
+            }
+        });
+        m_http_ptr = http.perform();
+    }
+
+private:
+    std::string m_token;
+    std::string m_url;
+    std::string m_cafile;
+    pt::ptree &m_resp;
+    wxTimer m_timer;
+    std::shared_ptr<Slic3r::Http> m_http_ptr;
+    bool m_cancelled{false};
+    bool m_started{false};
+    int m_attempt{0};
+    const int m_max_retries{10};
+    const int m_retry_delay_ms{500};
+};
+
+} // namespace
+
+namespace Slic3r {
+
+static const std::string API_CREDENTIALS_PATH = "3dprinteros_api_cred.json";
+static const int API_SESSION_WAIT_TIMEOUT = 60;
+
+C3DPrinterOS::C3DPrinterOS(DynamicPrintConfig *config)
+    : m_host(config->opt_string("print_host"))
+    , m_apikey(config->opt_string("printhost_apikey"))
+    
+{
+    m_api_session_file_path = (boost::filesystem::path(Slic3r::data_dir()) / API_CREDENTIALS_PATH)
+                                  .make_preferred()
+                                  .string();
+    load_api_session();
+    m_preset_name = extract_model_name(std::string(config->opt_string("preset_name")));
+}
+
+const char *C3DPrinterOS::get_name() const { return "3DPrinterOS"; }
+
+bool C3DPrinterOS::login(wxString &msg) const {
+    // Get token for auth
+    msg.clear();
+    std::string token = get_api_auth_token(msg);
+    if (token.empty()) {
+        msg = "Error. Can't get api token for authorization";
+        return false;
+    }
+    auto login_url = make_url("noauth/apiglobal_login_with_token/" + token);
+    wxLaunchDefaultBrowser(login_url);
+    pt::ptree login_resp;
+    login_with_token(login_resp, token);
+    std::string session, email;
+    try {
+        if (login_resp.get<bool>("result")) {
+            session = login_resp.get<std::string>("message.session");
+            email = login_resp.get<std::string>("message.email");
+        } else {
+            msg = wxString(login_resp.get<std::string>("message").c_str());
+            return false;
+        }
+    } catch (const std::exception &) {
+        msg = "Could not parse server response";
+        return false;
+    }
+    bool res = save_api_session(session, email);
+    if (!res) {
+        msg = "Error saving session to file";
+    }
+    return res;
+}
+
+bool C3DPrinterOS::test(wxString &msg) const {
+    bool res = true;
+    res = check_session(msg);
+    if (!res) {
+        // confirm for login
+        GUI::MessageDialog
+            dlg(nullptr, _L("Valid session not detected. Proceed with login to 3DPrinterOS?"),
+                _L("Proceed"), wxICON_INFORMATION | wxYES | wxNO);
+        if (dlg.ShowModal() == wxID_NO) {
+            msg = "Aborted";
+            return false;
+        }
+        return login(msg);
+    }
+    return res;
+}
+
+wxString C3DPrinterOS::get_test_ok_msg() const {
+    return _("Connection to 3DPrinterOS cloud works correctly.") +
+        (!m_username.empty() ? "" + _(" Logined as user: ") + m_username : "");
+}
+
+wxString C3DPrinterOS::get_test_failed_msg(wxString &msg) const {
+    return GUI::format_wxstr("%s: %s\n\n", _L("Error session check"), msg);
+}
+
+bool C3DPrinterOS::upload(
+    PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn
+) const {
+    const char *name = get_name();
+    const auto upload_filename = upload_data.upload_path.filename();
+    const auto upload_parent_path = upload_data.upload_path.parent_path();
+
+    wxString test_msg;
+    if (!check_session(test_msg)) {
+        error_fn(std::move(test_msg));
+        return false;
+    }
+
+    pt::ptree cloud_project_resp;
+    pt::ptree cloud_printer_types_resp;
+
+    get_cloud_projects_list(cloud_project_resp);
+    get_cloud_printer_types(cloud_printer_types_resp, m_preset_name);
+    wxArrayString cloud_projects_list;
+    wxArrayString cloud_printer_types_list;
+
+    try {
+        if (cloud_project_resp.get<bool>("result")) {
+            for (const auto &messageItem : cloud_project_resp.get_child("message")) {
+                cloud_projects_list.Add(messageItem.second.get<std::string>("name"));
+            }
+        }
+
+        if (cloud_printer_types_resp.get<bool>("result")) {
+            for (const auto &messageItem : cloud_printer_types_resp.get_child("message")) {
+                cloud_printer_types_list.Add(messageItem.second.get<std::string>("description"));
+            }
+        }
+    } catch (const std::exception &) {
+        error_fn("Could not parse server response");
+        return false;
+    }
+    
+    // Show "Confirm cloud printer type and project for 3DPrinterOS upload
+    UploadOptionsDialog dlg(nullptr, cloud_projects_list, cloud_printer_types_list, wxString((m_preset_name).c_str()));
+
+    if (dlg.ShowModal() != wxID_OK) {
+        error_fn("Canceled");
+        return false;
+    }
+    
+    std::string selected_project;
+    std::string selected_printer_type;
+    dlg.GetValues(selected_project, selected_printer_type);
+
+    std::string project_id;
+    std::string printer_type_id;
+
+    // search for cloud project_id by name
+    if (!selected_project.empty()) {
+        for (const auto &messageItem : cloud_project_resp.get_child("message")) {
+            if (messageItem.second.get<std::string>("name") == selected_project) {
+                project_id = messageItem.second.get<std::string>("id");
+                break;
+            }
+        }
+    }
+
+    // search for cloud printer_type_id by name
+    for (const auto &messageItem : cloud_printer_types_resp.get_child("message")) {
+        if (messageItem.second.get<std::string>("description") == selected_printer_type) {
+            printer_type_id = messageItem.second.get<std::string>("id");
+            break;
+        }
+    } 
+
+    bool res = true;
+    auto url = make_url("apiglobal/upload");
+    std::string file_id;
+    pt::ptree uploadResponse;
+    auto http = Http::post(std::move(url));
+    http.form_add("session", m_apikey)
+        .form_add("upload_type_id", "7")
+        .form_add("upload_soft_name", SLIC3R_BUILD_ID)
+        .form_add("zip", "false")
+        .form_add_file("file", upload_data.source_path.string(), upload_filename.string());
+
+    if (!project_id.empty()) {
+        http.form_add("project_id", project_id);
+    } else if (!selected_project.empty()) {
+        http.form_add("project_name", selected_project);
+        http.form_add("project_color", "grey");
+    }
+
+    http.on_complete([&](std::string body, unsigned status) {
+            std::stringstream ss(body);
+            try {
+                pt::read_json(ss, uploadResponse);
+            } catch (const std::exception &) {
+                uploadResponse.put("result", false);
+                uploadResponse.put("message", "Could not parse server response");
+            }
+        })
+        .on_error([&](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(error)
+                << boost::format("%1%: Error uploading file: %2%, HTTP %3%, body: `%4%`") % name %
+                    error % status % body;
+            
+            error_fn(format_error(body, error, status));
+            res = false;
+        })
+        .on_progress([&](Http::Progress progress, bool &cancel) {
+            prorgess_fn(std::move(progress), cancel);
+            if (cancel) {
+                BOOST_LOG_TRIVIAL(error) << "3DPrinterOS: Upload canceled";
+                res = false;
+            }
+        })
+        .perform_sync();
+
+    try {
+        if (uploadResponse.get<bool>("result")) {
+            file_id = uploadResponse.get<std::string>("message.file_id");
+        } else {
+            res = false;
+            error_fn(uploadResponse.get<std::string>("message"));
+        }
+    } catch (const std::exception &) { 
+        res = false;
+        error_fn("Error during file upload");
+    }
+
+    // set printer type for uploaded gcode
+    if (res) {
+        pt::ptree update_file_response;
+        update_file(update_file_response, file_id, printer_type_id, SLIC3R_BUILD_ID);
+        try {
+            if (!update_file_response.get<bool>("result")) {
+                const std::string msg =
+                    update_file_response.get<std::string>("message", "Unknown update error");
+                BOOST_LOG_TRIVIAL(warning) << "Failed to update uploaded file: " << msg;
+            }
+        } catch (const std::exception &ex) {
+            BOOST_LOG_TRIVIAL(warning) << "Could not parse update response: " << ex.what();
+        }
+        if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
+            auto quick_print_url = make_url("quickprint?file_id=" + file_id);
+            wxLaunchDefaultBrowser(quick_print_url);
+        }
+    }
+
+    return res;
+}
+
+bool C3DPrinterOS::validate_version_text(const boost::optional<std::string> &version_text) const {
+    return version_text ? boost::starts_with(*version_text, "3DPrinterOS") : true;
+}
+
+void C3DPrinterOS::set_auth(Http &http) const {
+    http.header("Content-Type", "application/x-www-form-urlencoded");
+    http.header("Connection", "close");
+}
+
+std::string C3DPrinterOS::make_url(const std::string &path) const {
+    if (m_host.find("http://") == 0 || m_host.find("https://") == 0) {
+        if (m_host.back() == '/') {
+            return (boost::format("%1%%2%") % m_host % path).str();
+        } else {
+            return (boost::format("%1%/%2%") % m_host % path).str();
+        }
+    } else {
+        return (boost::format("https://%1%/%2%") % m_host % path).str();
+    }
+}
+
+std::string C3DPrinterOS::get_api_auth_token(wxString &err) const {
+    std::string result;
+    pt::ptree resp;
+    std::string postBody = "app_type=plugin&app_name=" + Http::url_encode(SLIC3R_BUILD_ID);
+    send_form("apiglobal/generate_login_token", postBody, resp);
+    try {
+        if (resp.get<bool>("result")) {
+            result = resp.get<std::string>("message");
+        } else {
+            err = wxString(resp.get<std::string>("message").c_str());
+        }
+    } catch (const std::exception &) {
+        err = "Could not parse server response";
+    }
+    return result;
+}
+
+void C3DPrinterOS::login_with_token(pt::ptree &resp, const std::string &token) const {
+    auto url = make_url("apiglobal/login_with_token");
+    TokenAuthDialog dlg(GUI::wxGetApp().GetTopWindow(), url, token, m_cafile, resp);
+    dlg.ShowModal();
+}
+
+bool C3DPrinterOS::check_session(wxString &msg) const {
+    std::string postBody = "session=" + m_apikey;
+    pt::ptree resp;
+    send_form("apiglobal/check_session", postBody, resp);
+    try {
+        if (resp.get<bool>("result")) {
+            return true;
+        } else {
+            msg = wxString(resp.get<std::string>("message").c_str());
+            return false;
+        }
+
+    } catch (const std::exception &) {
+        msg = wxString("Could not parse server response");
+        return false;
+    }
+    return false;
+}
+
+std::string C3DPrinterOS::extract_model_name(const std::string &input) const {
+    std::smatch matches;
+    // search for prusa
+    std::vector<std::string> patterns =
+        {R"(Original Prusa i3 MK2)", R"(Original Prusa XL)", R"(Original Prusa MINI)",
+         R"(Original Prusa MK4)", R"(Original Prusa MK4S)", R"(Prusa CORE One)"};
+
+    for (const auto &pattern : patterns) {
+        std::regex regex_pattern(pattern);
+        if (std::regex_search(input, matches, regex_pattern)) {
+            return matches[0];
+        }
+    }
+
+    std::regex pattern(
+        R"(^(.*?)\s*(?:\(|\||\b)\s*\d+(\.\d+)?\s*mm|\d+(\.\d+)?\s*Nozzle)", std::regex::icase
+    );
+
+    if (std::regex_search(input, matches, pattern)) {
+        return matches[1];
+    }
+    return input;
+}
+
+bool C3DPrinterOS::save_api_session(const std::string &session, const std::string &email) const {
+    pt::ptree j;
+    j.put("session", session);
+    j.put("email", email);
+    try {
+        pt::write_json(m_api_session_file_path, j);
+    } catch (const std::exception &err) {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": failed to write json to file. Path = "
+                                 << m_api_session_file_path
+                                 << " Reason = " << err.what();
+        return false;
+    }
+    return true;
+}
+
+void C3DPrinterOS::load_api_session() 
+{
+    m_apikey.clear();
+    if (boost::filesystem::exists(m_api_session_file_path)) {
+        pt::ptree j;
+        try {
+            pt::read_json(m_api_session_file_path, j);
+            m_apikey = j.get<std::string>("session");
+            m_username = j.get<std::string>("email");
+        } catch (const std::exception &err) {
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": load_api_session failed, reason = " << err.what();
+        }
+    };
+}
+
+void C3DPrinterOS::send_form(
+    const std::string &endpoint,
+    const std::string &postBody,
+    boost::property_tree::ptree &responseTree,
+    int timeout
+) const {
+    responseTree.clear();
+    auto url = make_url(endpoint);
+    auto http = Http::post(std::move(url));
+    if (timeout > 0) {
+        http.timeout_max(timeout);
+    }
+    http.header("Content-length", std::to_string(postBody.size()));
+    http.set_post_body(postBody);
+    http.on_error([&](std::string body, std::string error, unsigned status) {
+            responseTree.put("result", false);
+            responseTree.put("message", error);
+        })
+        .on_complete([&, this](std::string body, unsigned) {
+            std::stringstream ss(body);
+            try {
+                pt::read_json(ss, responseTree);
+            } catch (const std::exception &) {
+                responseTree.put("result", false);
+                responseTree.put("message", "Could not parse server response");
+            }
+        })
+        .perform_sync();
+}
+
+void C3DPrinterOS::get_cloud_projects_list(boost::property_tree::ptree &response) const {
+    std::string postBody = std::string("session=" + m_apikey);
+    send_form("apiglobal/get_projects", postBody, response);
+}
+
+void C3DPrinterOS::get_cloud_printer_types(boost::property_tree::ptree &response, const std::string &query) const {
+    std::string postBody = std::string("session=" + m_apikey);
+    if (!query.empty()) {
+        postBody += "&description=" + Http::url_encode(query) + "&software_version=" + Http::url_encode(SLIC3R_BUILD_ID);
+    }
+    send_form("apiglobal/get_printer_types", postBody, response);
+}
+
+void C3DPrinterOS::update_file(boost::property_tree::ptree &response, const std::string &file_id, const std::string &ptype, const std::string &gtype) const {
+    std::string postBody = "session=" + m_apikey 
+        + "&updates[" + file_id + "][ptype]=" + ptype
+        + "&updates[" + file_id + "][gtype]=" + Http::url_encode(gtype) 
+        + "&updates[" + file_id + "][zip]=false";
+    send_form("apiglobal/file_update", postBody, response);
+}
+
+void C3DPrinterOS::log_out() const { boost::filesystem::remove(m_api_session_file_path.c_str()); }
+
+};
+ // namespace Slic3r

--- a/src/slic3r/Utils/3DPrinterOS.hpp
+++ b/src/slic3r/Utils/3DPrinterOS.hpp
@@ -1,0 +1,86 @@
+#ifndef slic3r_3DPrinterOS_hpp_
+#define slic3r_3DPrinterOS_hpp_
+
+#include <string>
+#include <wx/string.h>
+#include <boost/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "PrintHost.hpp"
+#include "slic3r/GUI/GUI.hpp"
+
+
+
+namespace Slic3r {
+
+class DynamicPrintConfig;
+class Http;
+
+
+class C3DPrinterOS : public PrintHost
+{
+public:
+    C3DPrinterOS(DynamicPrintConfig *config);
+    ~C3DPrinterOS() override = default;
+
+    const char* get_name() const override;
+    bool test(wxString &curl_msg) const override;
+    bool login(wxString &msg) const;
+    wxString get_test_ok_msg () const override;
+    wxString get_test_failed_msg (wxString &msg) const override;
+    bool upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn, InfoFn info_fn) const override;
+    bool has_auto_discovery() const override { return false; }
+
+    bool can_test() const override { return true; }
+    bool is_cloud() const override { return true; }
+    void log_out() const override;
+    bool is_logged_in() const override { return !m_apikey.empty(); }
+    PrintHostPostUploadActions get_post_upload_actions() const override { return PrintHostPostUploadAction::StartPrint | PrintHostPostUploadAction::QueuePrint; }
+    std::string get_host() const override { return default_host(); }
+    static std::string default_host() { return "https://cloud.3dprinteros.com"; }
+    
+    
+protected:
+    bool validate_version_text(const boost::optional<std::string> &version_text) const;
+
+private:
+    std::string m_host;
+    std::string m_apikey;
+    std::string m_username;
+    std::string m_technology;
+    std::string m_host_type;
+    std::string m_cafile;
+    std::string m_preset_name;
+    std::string m_api_session_file_path;
+
+    void load_api_session();
+    bool save_api_session(const std::string &session, const std::string &email) const;
+    std::string extract_model_name(const std::string &input) const;
+    void set_auth(Http &http) const;
+    std::string make_url(const std::string &path) const;
+    std::string get_api_auth_token(wxString &err) const;
+    void login_with_token(boost::property_tree::ptree &resp, const std::string &token) const;
+    bool check_session(wxString &msg) const;
+    void send_form(
+        const std::string &endpoint,
+        const std::string &postBody,
+        boost::property_tree::ptree &responseTree,
+        int timeout = 0
+    ) const;
+    
+    void get_cloud_projects_list(boost::property_tree::ptree &response) const;
+    void get_cloud_printer_types(boost::property_tree::ptree &response, const std::string &querry) const;
+    void update_file(
+        boost::property_tree::ptree &response,
+        const std::string &file_id,
+        const std::string &ptype,
+        const std::string &gtype
+    ) const;
+
+    //void get_cloud_project_list(wxArrayString &projects) const;
+    //void get_cloud_printer_types(wxArrayString &printer_types, const std::string &pattern = "") const;
+};
+
+}
+
+#endif

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -30,6 +30,7 @@
 #include "MKS.hpp"
 #include "Moonraker.hpp"
 #include "PrusaConnect.hpp"
+#include "3DPrinterOS.hpp"
 #include "../GUI/PrintHostDialogs.hpp"
 
 namespace fs = boost::filesystem;
@@ -67,6 +68,7 @@ PrintHost* PrintHost::get_print_host(DynamicPrintConfig *config)
             case htPrusaConnectNew: return new PrusaConnectNew(config);
             case htMKS:       return new MKS(config);
             case htMoonraker: return new Moonraker(config);
+            case ht3DPrinterOS: return new C3DPrinterOS(config);
             default:          return nullptr;
         }
     } else {

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -78,6 +78,10 @@ public:
     virtual std::string get_unusable_symbols() const { return {}; }
 
     static PrintHost* get_print_host(DynamicPrintConfig *config);
+    // Support for cloud webui login
+    virtual bool is_cloud() const { return false; }
+    virtual bool is_logged_in() const { return false; }
+    virtual void log_out() const {}
 
 protected:
     virtual wxString format_error(const std::string &body, const std::string &error, unsigned status) const;


### PR DESCRIPTION
# Description
Add 3DPrinterOS cloud as a new host type for job uploads

-  Login & logout
-  Job upload
-  Display the 3DPrinterOS cloud website on the device tab

# Screenshots & Usage
1) Login:
<img width="1893" height="812" alt="image" src="https://github.com/user-attachments/assets/b3dd5f60-943d-4aa9-a1ff-f5efa7ba9f5c" />

2) Confirmation of access:

<img width="1894" height="707" alt="image" src="https://github.com/user-attachments/assets/0e66dc17-9e12-47fa-b2a3-2b3aa9b6a2bb" />

3) Confirm printer type and project during upload.

<img width="360" height="239" alt="image" src="https://github.com/user-attachments/assets/b3b6bad9-4467-4c40-bc7a-853d39465142" />


