### PR TITLE
Add organic support base layer option

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -496,7 +496,7 @@ static std::vector<std::string> s_Preset_print_options {
     "support_material_contact_distance", "support_material_bottom_contact_distance",
     "support_material_buildplate_only", 
     "support_tree_angle", "support_tree_angle_slow", "support_tree_branch_diameter", "support_tree_branch_diameter_angle", "support_tree_branch_diameter_double_wall", 
-    "support_tree_top_rate", "support_tree_branch_distance", "support_tree_tip_diameter",
+    "support_tree_top_rate", "support_tree_branch_distance", "support_tree_tip_diameter", "support_tree_base_layers",
     "dont_support_bridges", "thick_bridges", "notes", "custom_parameters_print", "complete_objects",
     "gcode_comments", "gcode_label_objects", "output_filename_format", "post_process", "gcode_substitutions", "perimeter_extruder",
     "infill_extruder", "solid_infill_extruder", "support_material_extruder", "support_material_interface_extruder",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3614,6 +3614,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionPercent(15));
 
+    def = this->add("support_tree_base_layers", coInt);
+    def->label = L("Branch Base Layers");
+    def->category = L("Support material");
+    // TRN PrintSettings: "Organic supports" > "Support Base Layers"
+    def->tooltip = L("Number of base layers to generate for Organic supports. Increasing this can make the support base sturdier and easier to remove.");
+    def->min = 1;
+    def->max = 10;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(1));
+
     def = this->add("temperature", coInts);
     def->label = L("Other layers");
     def->tooltip = L("Nozzle temperature for layers after the first one. Set this to zero to disable "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -685,6 +685,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercent,             support_tree_top_rate))
     ((ConfigOptionFloat,               support_tree_branch_distance))
     ((ConfigOptionFloat,               support_tree_tip_diameter))
+    ((ConfigOptionInt,                 support_tree_base_layers))
     // The rest
     ((ConfigOptionBool,                thick_bridges))
     ((ConfigOptionFloat,               xy_size_compensation))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -812,6 +812,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "support_tree_top_rate"
             || opt_key == "support_tree_branch_distance"
             || opt_key == "support_tree_tip_diameter"
+            || opt_key == "support_tree_base_layers"
             || opt_key == "raft_expansion"
             || opt_key == "raft_first_layer_density"
             || opt_key == "raft_first_layer_expansion"

--- a/src/libslic3r/Support/OrganicSupport.cpp
+++ b/src/libslic3r/Support/OrganicSupport.cpp
@@ -1399,6 +1399,18 @@ void organic_draw_branches(
                 }
         }
 
+    if (int base_layers = std::clamp(config.support_tree_base_layers, 1, 10);
+        base_layers > 1 && ! slices.empty()) {
+        Polygons base_polygons = slices[0].num_branches > 1 ? union_(slices[0].polygons) : slices[0].polygons;
+        if (! base_polygons.empty()) {
+            size_t limit = std::min(size_t(base_layers), slices.size());
+            for (size_t i = 1; i < limit; ++i) {
+                append(slices[i].polygons, base_polygons);
+                slices[i].num_branches++; 
+            }
+        }
+    }
+
     tbb::parallel_for(tbb::blocked_range<size_t>(0, std::min(move_bounds.size(), slices.size()), 1),
         [&print_object, &config, &slices, &bottom_contacts, &top_contacts, &intermediate_layers, &layer_storage, &throw_on_cancel](const tbb::blocked_range<size_t> &range) {
         for (size_t layer_idx = range.begin(); layer_idx < range.end(); ++layer_idx) {

--- a/src/libslic3r/Support/TreeSupportCommon.cpp
+++ b/src/libslic3r/Support/TreeSupportCommon.cpp
@@ -86,6 +86,7 @@ TreeSupportMeshGroupSettings::TreeSupportMeshGroupSettings(const PrintObject &pr
     this->support_tree_top_rate       = config.support_tree_top_rate.value; // percent
 //    this->support_tree_tip_diameter = this->support_line_width;
     this->support_tree_tip_diameter = std::clamp(scaled<coord_t>(config.support_tree_tip_diameter.value), 0, this->support_tree_branch_diameter);
+    this->support_tree_base_layers = std::clamp(config.support_tree_base_layers.value, 1, 10);
 }
 
 TreeSupportSettings::TreeSupportSettings(const TreeSupportMeshGroupSettings &mesh_group_settings, const SlicingParameters &slicing_params)
@@ -119,6 +120,7 @@ TreeSupportSettings::TreeSupportSettings(const TreeSupportMeshGroupSettings &mes
       support_line_spacing(mesh_group_settings.support_line_spacing),
       support_bottom_offset(mesh_group_settings.support_bottom_offset),
       support_wall_count(mesh_group_settings.support_wall_count),
+      support_tree_base_layers(mesh_group_settings.support_tree_base_layers),
       resolution(mesh_group_settings.resolution),
       support_roof_line_distance(mesh_group_settings.support_roof_line_distance), // in the end the actual infill has to be calculated to subtract interface from support areas according to interface_preference.
       settings(mesh_group_settings),

--- a/src/libslic3r/Support/TreeSupportCommon.hpp
+++ b/src/libslic3r/Support/TreeSupportCommon.hpp
@@ -220,6 +220,8 @@ struct TreeSupportMeshGroupSettings {
     // The diameter of the top of the tip of the branches of tree support.
     // minimum: min_wall_line_width, minimum warning: min_wall_line_width+0.05, maximum_value: support_tree_branch_diameter, value: support_line_width
     coord_t                         support_tree_tip_diameter               { scaled<coord_t>(0.4) };
+    // Number of base layers to generate for Organic supports.
+    int                             support_tree_base_layers                { 1 };
 
     // Support Interface Priority
     // How support interface and support will interact when they overlap. Currently only implemented for support roof.
@@ -355,6 +357,10 @@ public:
      * \brief Amount of walls the support area will have.
      */
     int support_wall_count;
+    /*
+     * \brief Number of base layers to generate for Organic supports.
+     */
+    int support_tree_base_layers;
     /*
      * \brief Maximum allowed deviation when simplifying.
      */

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -368,7 +368,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
                                       config->opt_int("support_material_enforce_layers") > 0);
     for (const std::string& key : { "support_tree_angle", "support_tree_angle_slow", "support_tree_branch_diameter",
                                     "support_tree_branch_diameter_angle", "support_tree_branch_diameter_double_wall", 
-                                    "support_tree_tip_diameter", "support_tree_branch_distance", "support_tree_top_rate" })
+                                    "support_tree_tip_diameter", "support_tree_branch_distance", "support_tree_top_rate",
+                                    "support_tree_base_layers" })
         toggle_field(key, has_organic_supports);
 
     for (auto el : { "support_material_bottom_interface_layers", "support_material_interface_spacing", "support_material_interface_extruder",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1592,6 +1592,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_tree_tip_diameter", path);
         optgroup->append_single_option_line("support_tree_branch_distance", path);
         optgroup->append_single_option_line("support_tree_top_rate", path);
+        optgroup->append_single_option_line("support_tree_base_layers", path);
 
     page = add_options_page(L("Speed"), "time");
         optgroup = page->new_optgroup(L("Speed for print moves"));


### PR DESCRIPTION
Add configurable organic support base layers (1–10) to stiffen the base and ease removal.

Requested by [@abbymath](https://x.com/abbymath/status/1992985636975026646?s=12).