### PR TITLE
Use v1 API to fix build with boost1.88

### DIFF
--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -12,10 +12,13 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/filesystem.hpp>
 #include <boost/nowide/cstdlib.hpp>
 #include <boost/nowide/convert.hpp>
 #include <boost/nowide/fstream.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/child.hpp>
 
 #ifdef WIN32
 
@@ -152,9 +155,14 @@ static int run_script(const std::string &script, const std::string &gcode, std::
 
 #include <cstdlib>   // getenv()
 #include <sstream>
-#include <boost/process.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async.hpp>
 
-namespace process = boost::process;
+namespace process = boost::process::v1;
 
 static int run_script(const std::string &script, const std::string &gcode, std::string &std_err)
 {

--- a/src/libslic3r/GCodeSender.cpp
+++ b/src/libslic3r/GCodeSender.cpp
@@ -113,7 +113,7 @@ GCodeSender::connect(std::string devname, unsigned int baud_rate)
     this->io.post(boost::bind(&GCodeSender::do_read, this));
     
     // start reading in the background thread
-    boost::thread t(boost::bind(&boost::asio::io_service::run, &this->io));
+    boost::thread t(boost::bind(&boost::asio::io_context::run, &this->io));
     this->background_thread.swap(t);
     
     // always send a M105 to check for connection because firmware might be silent on connect

--- a/src/libslic3r/GCodeSender.hpp
+++ b/src/libslic3r/GCodeSender.hpp
@@ -40,7 +40,7 @@ class GCodeSender : private boost::noncopyable {
     void reset();
     
     private:
-    asio::io_service io;
+    asio::io_context io;
     asio::serial_port serial;
     boost::thread background_thread;
     boost::asio::streambuf read_buffer, write_buffer;

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -365,7 +365,7 @@ bool FirmwareDialog::priv::check_model_id()
 	// 	return true;
 	// }
 
-	// asio::io_service io;
+	// asio::io_context io;
 	// Serial serial(io, port->port, 115200);
 	// serial.printer_setup();
 
@@ -429,7 +429,7 @@ void FirmwareDialog::priv::avr109_wait_for_bootloader(Avr109Pid usb_pid, unsigne
 
 void FirmwareDialog::priv::avr109_reboot(const SerialPortInfo &port)
 {
-	asio::io_service io;
+	asio::io_context io;
 	Serial serial(io, port.port, 1200);
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 }

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -33,9 +33,16 @@
 #include <sys/stat.h>
 #include <glob.h>
 #include <pwd.h>
-#include <boost/filesystem.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/filesystem.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/process.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
 #endif
 
 namespace Slic3r {
@@ -859,15 +866,15 @@ void RemovableDriveManager::eject_drive()
 		// but neither triggers "succesful safe removal messege"
 		
 		BOOST_LOG_TRIVIAL(info) << "Ejecting started";
-		boost::process::ipstream istd_err;
-    	boost::process::child child(
+		boost::process::v1::ipstream istd_err;
+		boost::process::v1::child child(
 #if __APPLE__		
-			boost::process::search_path("diskutil"), "eject", correct_path.c_str(), (boost::process::std_out & boost::process::std_err) > istd_err);
+			boost::process::v1::search_path("diskutil"), "eject", correct_path.c_str(), (boost::process::v1::std_out & boost::process::v1::std_err) > istd_err);
 		//Another option how to eject at mac. Currently not working.
 		//used insted of system() command;
 		//this->eject_device(correct_path);
 #else
-    		boost::process::search_path("umount"), correct_path.c_str(), (boost::process::std_out & boost::process::std_err) > istd_err);
+		boost::process::v1::search_path("umount"), correct_path.c_str(), (boost::process::v1::std_out & boost::process::v1::std_err) > istd_err);
 #endif
 		std::string line;
 		while (child.running() && std::getline(istd_err, line)) {

--- a/src/slic3r/Utils/Bonjour.cpp
+++ b/src/slic3r/Utils/Bonjour.cpp
@@ -624,7 +624,7 @@ UdpSession::UdpSession(Bonjour::ReplyFn rfn) : replyfn(rfn)
 	buffer.resize(DnsMessage::MAX_SIZE);
 }
 
-UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, const asio::ip::address& interface_address, std::shared_ptr< boost::asio::io_service > io_service)
+UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, const asio::ip::address& interface_address, std::shared_ptr< boost::asio::io_context > io_service)
 	: replyfn(replyfn)
 	, multicast_address(multicast_address)
 	, socket(*io_service)
@@ -658,7 +658,7 @@ UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multica
 }
 
 
-UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, std::shared_ptr< boost::asio::io_service > io_service)
+UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, std::shared_ptr< boost::asio::io_context > io_service)
 	: replyfn(replyfn)
 	, multicast_address(multicast_address)
 	, socket(*io_service)
@@ -714,7 +714,7 @@ void UdpSocket::receive_handler(SharedSession session, const boost::system::erro
 	// let io_service to handle the datagram on session
 	// from boost documentation io_service::post:
 	// The io_service guarantees that the handler will only be called in a thread in which the run(), run_one(), poll() or poll_one() member functions is currently being invoked.
-	io_service->post(boost::bind(&UdpSession::handle_receive, session, error, bytes));
+	boost::asio::post(*io_service, boost::bind(&UdpSession::handle_receive, session, error, bytes));
 	// immediately accept new datagrams
 	async_receive();
 }
@@ -871,7 +871,7 @@ void Bonjour::priv::lookup_perform()
 {
 	service_dn = (boost::format("_%1%._%2%.local") % service % protocol).str();
 
-	std::shared_ptr< boost::asio::io_service > io_service(new boost::asio::io_service);
+	std::shared_ptr< boost::asio::io_context > io_service(new boost::asio::io_context);
 
 	std::vector<LookupSocket*> sockets;
 
@@ -966,7 +966,7 @@ void Bonjour::priv::resolve_perform()
 			rpls.push_back(reply);
 	};
 
-	std::shared_ptr< boost::asio::io_service > io_service(new boost::asio::io_service);
+	std::shared_ptr< boost::asio::io_context > io_service(new boost::asio::io_context);
 	std::vector<ResolveSocket*> sockets;
 
 	// resolve interfaces - from PR#6646

--- a/src/slic3r/Utils/Bonjour.hpp
+++ b/src/slic3r/Utils/Bonjour.hpp
@@ -155,11 +155,11 @@ public:
 	UdpSocket(Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service);
+		, std::shared_ptr< boost::asio::io_context > io_service);
 
 	UdpSocket(Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service);
+		, std::shared_ptr< boost::asio::io_context > io_service);
 
 	void send();
 	void async_receive();
@@ -172,7 +172,7 @@ protected:
 	boost::asio::ip::address					    multicast_address;
 	boost::asio::ip::udp::socket					socket;
 	boost::asio::ip::udp::endpoint					mcast_endpoint;
-	std::shared_ptr< boost::asio::io_service >	io_service;
+	std::shared_ptr< boost::asio::io_context >	io_service;
 	std::vector<BonjourRequest>						requests;
 };
 
@@ -186,7 +186,7 @@ public:
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
+		, std::shared_ptr< boost::asio::io_context > io_service)
 		: UdpSocket(replyfn, multicast_address, interface_address, io_service)
 		, txt_keys(txt_keys)
 		, service(service)
@@ -203,7 +203,7 @@ public:
 		, std::string protocol
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
+		, std::shared_ptr< boost::asio::io_context > io_service)
 		: UdpSocket(replyfn, multicast_address, io_service)
 		, txt_keys(txt_keys)
 		, service(service)
@@ -241,7 +241,7 @@ public:
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
+		, std::shared_ptr< boost::asio::io_context > io_service)
 		: UdpSocket(replyfn, multicast_address, interface_address, io_service)
 		, hostname(hostname)
 
@@ -253,7 +253,7 @@ public:
 	ResolveSocket(const std::string& hostname
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
+		, std::shared_ptr< boost::asio::io_context > io_service)
 		: UdpSocket(replyfn, multicast_address, io_service)
 		, hostname(hostname)
 

--- a/src/slic3r/Utils/Serial.cpp
+++ b/src/slic3r/Utils/Serial.cpp
@@ -282,11 +282,11 @@ std::vector<std::string> scan_serial_ports()
 namespace asio = boost::asio;
 using boost::system::error_code;
 
-Serial::Serial(asio::io_service& io_service) :
+Serial::Serial(asio::io_context& io_service) :
 	asio::serial_port(io_service)
 {}
 
-Serial::Serial(asio::io_service& io_service, const std::string &name, unsigned baud_rate) :
+Serial::Serial(asio::io_context& io_service, const std::string &name, unsigned baud_rate) :
 	asio::serial_port(io_service, name)
 {
 	set_baud_rate(baud_rate);

--- a/src/slic3r/Utils/Serial.hpp
+++ b/src/slic3r/Utils/Serial.hpp
@@ -43,8 +43,8 @@ extern std::vector<SerialPortInfo> 	scan_serial_ports_extended();
 class Serial : public boost::asio::serial_port
 {
 public:
-	Serial(boost::asio::io_service &io_service);
-	Serial(boost::asio::io_service &io_service, const std::string &name, unsigned baud_rate);
+	Serial(boost::asio::io_context &io_service);
+	Serial(boost::asio::io_context &io_service, const std::string &name, unsigned baud_rate);
 	Serial(const Serial &) = delete;
 	Serial &operator=(const Serial &) = delete;
 	~Serial();

--- a/src/slic3r/Utils/TCPConsole.cpp
+++ b/src/slic3r/Utils/TCPConsole.cpp
@@ -161,7 +161,7 @@ bool TCPConsole::run_queue()
 
         auto endpoints = m_resolver.resolve(m_host_name, m_port_name);
 
-        m_socket.async_connect(endpoints->endpoint(),
+        m_socket.async_connect(endpoints.begin()->endpoint(),
             boost::bind(&TCPConsole::handle_connect, this, boost::placeholders::_1)
         );
 


### PR DESCRIPTION
`PrusaSlicer` is failing to build with latest boost 1.88
Used the v1 APIs to fix the build.