### PR TITLE
version 2.9.4 git: prevent o-length segments from tripping multiple assertions when viewing layers in vase mode

### DIFF
--- a/src/libslic3r/EdgeGrid.hpp
+++ b/src/libslic3r/EdgeGrid.hpp
@@ -209,7 +209,7 @@ public:
 		assert(ixb >= 0 && size_t(ixb) < m_cols);
 		assert(iyb >= 0 && size_t(iyb) < m_rows);
 		// Account for the end points.
-		if (! visitor(iy, ix) || (ix == ixb && iy == iyb))
+		if ((ix == ixb && iy == iyb) || ! visitor(iy, ix))
 			// Both ends fall into the same cell.
 			return;
 		// Raster the centeral part of the line.

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -612,6 +612,8 @@ std::vector<PerExtruderAdjustments> CoolingBuffer::parse_layer_gcode(const std::
         if (*line_end == '\n')
             ++ line_end;
         CoolingLine line(0, line_start - gcode.c_str(), line_end - gcode.c_str());
+        if (line.length() == 0)
+            continue; // Empty line.
         if (boost::starts_with(sline, "G0 "))
             line.type = CoolingLine::TYPE_G0;
         else if (boost::starts_with(sline, "G1 "))

--- a/src/libslic3r/Polyline.cpp
+++ b/src/libslic3r/Polyline.cpp
@@ -401,9 +401,18 @@ void ThickPolyline::clip_end(double distance)
 
 void ThickPolyline::start_at_index(int index)
 {
-    assert(index >= 0 && index < this->points.size());
-    assert(this->points.front() == this->points.back() && this->width.front() == this->width.back());
-    if (index != 0 && index + 1 != int(this->points.size()) && this->points.front() == this->points.back() && this->width.front() == this->width.back()) {
+    assert(index >= 0 && index < (int)this->points.size());
+
+    // Operate only on properly closed ThickPolylines
+    if (this->points.empty())
+        return;
+    if (!(this->points.front() == this->points.back() &&
+          !this->width.empty() && this->width.front() == this->width.back())) {
+        // Not a properly closed ThickPolyline — nothing to rotate.
+        return;
+    }
+
+    if (index != 0 && index + 1 != int(this->points.size())) {
         this->points.pop_back();
         assert(this->points.size() * 2 == this->width.size());
         std::rotate(this->points.begin(), this->points.begin() + index, this->points.end());

--- a/src/slic3r/GUI/DoubleSliderForLayers.cpp
+++ b/src/slic3r/GUI/DoubleSliderForLayers.cpp
@@ -1045,10 +1045,14 @@ bool DSForLayers::is_wipe_tower_layer(int tick) const
         return false;
     if (tick == 0 || (tick == (int)m_values.size() - 1 && m_values[tick] > m_values[tick - 1]))
         return false;
-    if ((m_values[tick - 1] == m_values[tick + 1] && m_values[tick] < m_values[tick + 1]) ||
-        (tick > 0 && m_values[tick] < m_values[tick - 1]) ) // if there is just one wiping on the layer 
-        return true;
-
+    // Make sure we don't access past the end of m_values (tick+1 must be valid).
+    if (tick > 0) {
+        if (tick + 1 < (int)m_values.size() &&
+            m_values[tick - 1] == m_values[tick + 1] && m_values[tick] < m_values[tick + 1])
+            return true;
+        if (m_values[tick] < m_values[tick - 1]) // if there is just one wiping on the layer
+            return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Fixes #13739

Optimized if statement so functional operation appears on right-hand side of the `||` 
That way, faster == checks are performed first and function doesn't operate on 0-length lines.

That prevented some assertions but CoolingBuffer was still trying to process some empty gcode, which is worked-around by skipping empty lines.
```
+        if (line.length() == 0)
+            continue; // Empty line.
...
```
Added a bounds check to DoubleSliderForLayers.cpp so operating the slider doesn't crash plater on bottom layer.
Finally, replaced two assertions in Polyline.cpp with if statements to prevent crash when trying to rotate the view.