### PR TITLE
Fix unable to type in search bar on Windows

### DIFF
--- a/src/slic3r/GUI/TopBar.cpp
+++ b/src/slic3r/GUI/TopBar.cpp
@@ -286,7 +286,6 @@ void TopBarItemsCtrl::CreateSearch()
     ctrl->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& event)
     {
         TriggerSearch();
-        event.Skip();
     });
 
     ctrl->Bind(wxEVT_LEFT_UP, [this](wxMouseEvent& event)


### PR DESCRIPTION
TopBar's 'left click' handler triggers a search, but also calls 'event.Skip()' which allows other handlers to run. There appear to be no other wxWidget handlers bound to this event, but calling 'Skip' allows the event to make it the default CallWindowProc() call.

It appears that on Windows 11 on a DPI-scaling enabled monitor that both handling AND Skipping this event causes the search box to spaz out. Simply removing the 'Skip' prevents Windows from double-handling the event.

Should close https://github.com/prusa3d/PrusaSlicer/issues/14131 https://github.com/prusa3d/PrusaSlicer/issues/14828 https://github.com/prusa3d/PrusaSlicer/issues/15137