### PR TITLE
Allow hw rendering in rdp if it reports GL >= 3.2

### DIFF
--- a/src/PrusaSlicer_app_msvc.cpp
+++ b/src/PrusaSlicer_app_msvc.cpp
@@ -244,14 +244,11 @@ int wmain(int argc, wchar_t **argv)
 #ifdef SLIC3R_GUI
     // Here one may push some additional parameters based on the wrapper type.
     bool force_mesa = false;
-    bool force_hw   = false;
 #endif /* SLIC3R_GUI */
     for (int i = 1; i < argc; ++ i) {
 #ifdef SLIC3R_GUI
         if (wcscmp(argv[i], L"--sw-renderer") == 0)
             force_mesa = true;
-        else if (wcscmp(argv[i], L"--no-sw-renderer") == 0)
-            force_hw = true;
 #endif /* SLIC3R_GUI */
         argv_extended.emplace_back(argv[i]);
     }
@@ -262,9 +259,6 @@ int wmain(int argc, wchar_t **argv)
     bool load_mesa =
         // Forced from the command line.
         force_mesa ||
-        // Running over a rempote desktop, and the RemoteFX is not enabled, therefore Windows will only provide SW OpenGL 1.1 context.
-        // In that case, use Mesa.
-        (::GetSystemMetrics(SM_REMOTESESSION) && !force_hw) ||
         // Try to load the default OpenGL driver and test its context version.
         ! opengl_version_check.load_opengl_dll() || ! opengl_version_check.is_version_greater_or_equal_to(3, 2);
 #endif /* SLIC3R_GUI */


### PR DESCRIPTION
[This PR](https://github.com/prusa3d/PrusaSlicer/commit/88059baddba34fafd9952775491732192999fb3d) changed it so RDP always uses software rendering. But my experience is that RDP supports hardware rendering just fine as long as it meets the GL >= 3.2 requirement. So I removed that check, which especially helps speed up rendering in the slice viewer.