### PR TITLE
bugfix / unable to login on ubuntu 24.04 / fixes #14356

### DIFF
--- a/src/slic3r/GUI/ConfigWizardWebViewPage.cpp
+++ b/src/slic3r/GUI/ConfigWizardWebViewPage.cpp
@@ -93,7 +93,7 @@ case type: \
         WX_ERROR_CASE(wxWEBVIEW_NAV_ERR_OTHER);
     }
 
-    BOOST_LOG_TRIVIAL(error) << "ConfigWizardWebViewPage error: " << category << " for URL: " << evt.GetURL();
+    BOOST_LOG_TRIVIAL(error) << "ConfigWizardWebViewPage error: " << category;
     
     // Don't treat wxWEBVIEW_NAV_ERR_OTHER as fatal - it often occurs for subresources
     // or cancelled requests while the main page continues loading successfully.

--- a/src/slic3r/GUI/ConfigWizardWebViewPage.cpp
+++ b/src/slic3r/GUI/ConfigWizardWebViewPage.cpp
@@ -93,8 +93,19 @@ case type: \
         WX_ERROR_CASE(wxWEBVIEW_NAV_ERR_OTHER);
     }
 
-    BOOST_LOG_TRIVIAL(error) << "ConfigWizardWebViewPage error: " << category;
-    load_error_page();
+    BOOST_LOG_TRIVIAL(error) << "ConfigWizardWebViewPage error: " << category << " for URL: " << evt.GetURL();
+    
+    // Don't treat wxWEBVIEW_NAV_ERR_OTHER as fatal - it often occurs for subresources
+    // or cancelled requests while the main page continues loading successfully.
+    // Only show error page for serious errors like connection or certificate failures.
+    int err = evt.GetInt();
+    if (err == wxWEBVIEW_NAV_ERR_CONNECTION || 
+        err == wxWEBVIEW_NAV_ERR_CERTIFICATE ||
+        err == wxWEBVIEW_NAV_ERR_AUTH ||
+        err == wxWEBVIEW_NAV_ERR_SECURITY) {
+        load_error_page();
+    }
+    // For wxWEBVIEW_NAV_ERR_OTHER, wxWEBVIEW_NAV_ERR_REQUEST, etc. - just log and continue
 }
 
 void ConfigWizardWebViewPage::load_error_page() {

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -417,7 +417,7 @@ case type: \
         WX_ERROR_CASE(wxWEBVIEW_NAV_ERR_OTHER);
     }
 
-    BOOST_LOG_TRIVIAL(error) << "WebViewDialog error: " << category << " for URL: " << evt.GetURL();
+    BOOST_LOG_TRIVIAL(error) << "WebViewDialog error: " << category;
     
     // Don't treat wxWEBVIEW_NAV_ERR_OTHER as fatal - it often occurs for cancelled 
     // subresource requests while the main page continues loading successfully.

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -417,8 +417,19 @@ case type: \
         WX_ERROR_CASE(wxWEBVIEW_NAV_ERR_OTHER);
     }
 
-    BOOST_LOG_TRIVIAL(error) << "WebViewDialog error: " << category;
-    load_error_page();
+    BOOST_LOG_TRIVIAL(error) << "WebViewDialog error: " << category << " for URL: " << evt.GetURL();
+    
+    // Don't treat wxWEBVIEW_NAV_ERR_OTHER as fatal - it often occurs for cancelled 
+    // subresource requests while the main page continues loading successfully.
+    // Only show error page for serious errors like connection or certificate failures.
+    int err = evt.GetInt();
+    if (err == wxWEBVIEW_NAV_ERR_CONNECTION || 
+        err == wxWEBVIEW_NAV_ERR_CERTIFICATE ||
+        err == wxWEBVIEW_NAV_ERR_AUTH ||
+        err == wxWEBVIEW_NAV_ERR_SECURITY) {
+        load_error_page();
+    }
+    // For wxWEBVIEW_NAV_ERR_OTHER, wxWEBVIEW_NAV_ERR_REQUEST, etc. - just log and continue
 }
 
 void WebViewDialog::load_error_page()


### PR DESCRIPTION
i was unable to log in to prusaslicer 2.9.4 on ubuntu 24.04 using either flatpak or (after making some adjustments to be able to compile on ubuntu 24.04) on binaries produced by compiling from source.

steps to reproduce:  
1. after a clean/fresh slicer install, launch prusaslicer and wait for the config wizard to appear.  
2. hit the next button until you get to the login prompt - from here i was able to repro two ways
   a) by hitting the login via google or
   b) by attempting to log in with prusa directly with username/password
3. clicking the button in either a) or b) displayed error-spool icon and text that said "something went wrong".  

This appeared to be the same issue reported in #14356

i dug into it a bit and it seems like non-critical errors (even if for non-required external resources) would cause the error page to display, interrupting the login page from loading.

I can now log into prusa connect and manage my printer, see jobs, upload files and all that good stuff again with the slicer 

not sure if there could be security concerns with these changes since this is in code related to login workflows.  Tagging @Jan-Soustruznik who was active/commenting on the earlier issue.