### PR TITLE
Fix pause_print_gcode for Snapmaker machines

### DIFF
--- a/resources/profiles/Snapmaker.ini
+++ b/resources/profiles/Snapmaker.ini
@@ -3279,7 +3279,7 @@ filament_colour = #383737
 
 [printer:*fdm_common*]
 gcode_flavor = marlin2
-pause_gcode = M600 ;pause print
+pause_print_gcode = M600 ;pause print
 nozzle_type = hardened_steel
 use_relative_e_distances = 1
 silent_mode = 0


### PR DESCRIPTION
The M600 is correct for all Marlin based Snapmaker machines, however, it appears this key is incorrect as it isn't used anywhere else in the codebase.