### PR TITLE
Add 'extruder_clearance_offset' setting

### DIFF
--- a/src/libslic3r/ArrangeHelper.cpp
+++ b/src/libslic3r/ArrangeHelper.cpp
@@ -115,10 +115,13 @@ static Sequential::PrinterGeometry get_printer_geometry(const ConfigBase& config
 			// Fallback to primitive model using radius and height.
 			coord_t r = scaled(std::max(0.1, config.opt_float("extruder_clearance_radius")));
 			coord_t h = scaled(std::max(0.1, config.opt_float("extruder_clearance_height")));
+			const ConfigOptionPoints* extruder_offset = config.option<ConfigOptionPoints>("extruder_clearance_offset");
+			coord_t offset_x = scaled(extruder_offset->values[0].x());
+			coord_t offset_y = scaled(extruder_offset->values[0].y());
 			double bed_x = bv.bounding_volume2d().size().x();
 			double bed_y = bv.bounding_volume2d().size().y();
 			slices.push_back(ExtruderSlice{ 0, CONVEX, { { {  -5000000,   -5000000 }, {   5000000,   -5000000 }, {   5000000,   5000000 }, {  -5000000,   5000000 } } } });
-			slices.push_back(ExtruderSlice{ 1000000, BOX, { { {  -r, -r }, { r, -r }, {   r,   r }, {  -r,  r } } } });
+			slices.push_back(ExtruderSlice{ 1000000, BOX, { { {  -r + offset_x, -r + offset_y }, { r + offset_x, -r + offset_y }, { r + offset_x, r + offset_y }, { -r + offset_x, r + offset_y } } } });
 			slices.push_back(ExtruderSlice{ h, BOX, { { { -scaled(bed_x),  -r }, { scaled(bed_x),  -r }, { scaled(bed_x), r }, { -scaled(bed_x), r}}} });
 		}
 	}

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -560,7 +560,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "max_print_height", "default_print_profile", "inherits",
     "remaining_times", "silent_mode",
     "machine_limits_usage", "thumbnails", "thumbnails_format",
-    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height"
+    "nozzle_high_flow", "extruder_clearance_radius", "extruder_clearance_height", "extruder_clearance_offset"
 };
 
 static std::vector<std::string> s_Preset_sla_print_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -112,6 +112,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "extrusion_axis",
         "extruder_clearance_height",
         "extruder_clearance_radius",
+        "extruder_clearance_offset",
         "extruder_colour",
         "extruder_offset",
         "extrusion_multiplier",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1175,6 +1175,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloat(20));
 
+    def = this->add("extruder_clearance_offset", coPoints);
+    def->label = L("Offset");
+    def->tooltip = L("Only used when 'Print Settings -> Complete individual objects' is active. This defines the X/Y shift"
+                     "of the nozzle tip relative to the center of the Clearance Radius cylinder. Use this if your nozzle"
+                     "is not centered within your extruder assembly to ensure the collision-free zone is positioned correctly.\n"
+                    "The value is ignored for most Prusa printers, which include a more detailed extruder model.");
+    def->sidetext = L("mm");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionPoints { Vec2d(0,0) });
+
     def = this->add("extruder_colour", coStrings);
     def->label = L("Extruder Color");
     def->tooltip = L("This is only used in the Slic3r interface as a visual help.");
@@ -5621,6 +5631,11 @@ std::string validate(const FullPrintConfig &cfg)
         return "Invalid value for --extruder-clearance-radius";
     if (cfg.extruder_clearance_height <= 0)
         return "Invalid value for --extruder-clearance-height";
+
+    coord_t offset_x = cfg.extruder_offset.values[0].x();
+    coord_t offset_y = cfg.extruder_offset.values[0].y();
+    if ((offset_x * offset_x + offset_y * offset_y) > (cfg.extruder_clearance_radius * cfg.extruder_clearance_radius))
+        return "Invalid value for --extruder-clearance-offset (offset must be within clearance radius)";
 
     // --extrusion-multiplier
     for (double em : cfg.extrusion_multiplier.values)

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -949,6 +949,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,              external_perimeter_acceleration))
     ((ConfigOptionFloat,              extruder_clearance_height))
     ((ConfigOptionFloat,              extruder_clearance_radius))
+    ((ConfigOptionPoints,             extruder_clearance_offset))
     ((ConfigOptionStrings,            extruder_colour))
     ((ConfigOptionPoints,             extruder_offset))
     ((ConfigOptionBools,              fan_always_on))

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -170,17 +170,20 @@ std::pair<std::optional<std::unique_ptr<GLModel>>, bool> GLCanvas3D::get_current
     static std::string last_printer_notes;
     static double old_r = 0.;
     static double old_h = 0.;
+    static Vec2d old_offset;
     static bool old_seq = false;
 
     std::string printer_notes = m_config->opt_string("printer_notes");
     double r = m_config->opt_float("extruder_clearance_radius");
     double h = m_config->opt_float("extruder_clearance_height");
+    const Vec2d offset = m_config->option<ConfigOptionPoints>("extruder_clearance_offset")->values[0];
     bool seq = m_config->opt_bool("complete_objects");
 
-    if (last_printer_notes != printer_notes ||  r != old_r || h != old_h || seq != old_seq) {
+    if (last_printer_notes != printer_notes ||  r != old_r || h != old_h || seq != old_seq || offset != old_offset) {
         last_printer_notes = printer_notes;
         old_r = r;
         old_h = h;
+        old_offset = offset;
         old_seq = seq;
 
         out.second = (printer_notes.find("PRINTER_MODEL_HT90") != std::string::npos);
@@ -211,13 +214,19 @@ std::pair<std::optional<std::unique_ptr<GLModel>>, bool> GLCanvas3D::get_current
         if (*(out.first) == nullptr && seq) {
             // Generic sequential extruder model.
             double gantry_height = 10;
-            auto mesh = its_make_cylinder(r, h + gantry_height - 0.001);
+            double nozzle_height = 3;
+            double nozzle_radius = std::min(2.0, r / 2);
             double d = 3 * wxGetApp().plater()->build_volume().bounding_volume2d().size().x();
-            auto mesh2 = its_make_cube(d,2*r, gantry_height);
-            its_translate(mesh2, Vec3f(-d/2, -r, h));
-            its_merge(mesh, mesh2);
+            auto gantry_mesh = its_make_cube(d,2*r, gantry_height);
+            auto toolhead_mesh = its_make_cylinder(r, h + gantry_height - 0.001);
+            its_translate(gantry_mesh, Vec3f(-d/2, -r, h));
+            its_merge(gantry_mesh, toolhead_mesh);
+
+            auto nozzle_mesh = its_make_cylinder(nozzle_radius, nozzle_height - 0.001);
+            its_translate(gantry_mesh, Vec3f(offset.x(),offset.y(), 0));
+            its_merge(nozzle_mesh, gantry_mesh);
             std::unique_ptr<GLModel> m = std::make_unique<GLModel>();
-            m->init_from(mesh);
+            m->init_from(nozzle_mesh);
             out.first = std::make_optional(std::move(m));
         }
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -630,8 +630,8 @@ Plater::priv::priv(Plater* q, MainFrame* main_frame)
     : q(q)
     , main_frame(main_frame)
     , config(Slic3r::DynamicPrintConfig::new_from_defaults_keys({
-        "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "extruder_clearance_height", "skirts", "skirt_distance",
-        "brim_width", "brim_separation", "brim_type", "variable_layer_height", "nozzle_diameter", "single_extruder_multi_material",
+        "bed_shape", "bed_custom_texture", "bed_custom_model", "complete_objects", "duplicate_distance", "extruder_clearance_radius", "extruder_clearance_height", "extruder_clearance_offset",
+        "skirts", "skirt_distance", "brim_width", "brim_separation", "brim_type", "variable_layer_height", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_width", "wipe_tower_brim_width", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "wipe_tower_extruder",
         "extruder_colour", "filament_colour", "material_colour", "max_print_height", "printer_model", "printer_notes", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2878,6 +2878,8 @@ void TabPrinter::build_fff()
         optgroup = page->new_optgroup(L("Sequential printing limits"));
         optgroup->append_single_option_line("extruder_clearance_radius");
         optgroup->append_single_option_line("extruder_clearance_height");
+        optgroup->append_single_option_line("extruder_clearance_offset");
+
 
     const int gcode_field_height = 15; // 150
     const int notes_field_height = 25; // 250


### PR DESCRIPTION
This adds a new option, extruder_clearance_offset, to the Sequential Printing Limits configuration settings. This setting allows offsetting the nozzle on the generic clearance model. 
<img width="737" height="214" alt="image" src="https://github.com/user-attachments/assets/e9d6428b-5971-4f3a-9086-c899b2b78906" />


This is useful for extruders where the nozzle is near the edge of the toolhead, for example:
<img width="1627" height="1288" alt="image" src="https://github.com/user-attachments/assets/44ce8473-1d99-4e20-b79d-1885fe1aad46" />

Since the clearance radius must be the maximum distance between the nozzle and the edge, if the nozzle is at the edge then the clearance radius must be set to nearly double the real value. By offsetting the nozzle, the radius of the generic printer model can be set to much smaller while still maintaining accurate clearance. A visual representation of the nozzle position was added to the model to visualize the offset position:
<img width="1796" height="1499" alt="image" src="https://github.com/user-attachments/assets/271a130b-8da8-4b95-89cb-9bcf9fcc2526" />



