### PR TITLE
Add button to sort print order back-to-front

### DIFF
--- a/src/slic3r/GUI/ArrangeSettingsDialogImgui.cpp
+++ b/src/slic3r/GUI/ArrangeSettingsDialogImgui.cpp
@@ -143,12 +143,22 @@ void ArrangeSettingsDialogImgui::render(float pos_x, float pos_y, bool current_b
         ImGui::Separator();
     }
 
-
-    if (!current_bed && ImGuiPureWrap::button(_u8L("Arrange")) && m_on_arrange_btn) {
-        m_on_arrange_btn();
-    }
-    if (current_bed && ImGuiPureWrap::button(_u8L("Arrange bed")) && m_on_arrange_bed_btn) {
-        m_on_arrange_bed_btn();
+    if (!current_bed) {
+        if( ImGuiPureWrap::button(_u8L("Arrange")) && m_on_arrange_btn) {
+            m_on_arrange_btn();
+        }
+        ImGui::SameLine();
+        if( ImGuiPureWrap::button(_u8L("Sort Print Order"), _u8L("Sorts the print order based on how objects are arranged on the plate")) && m_on_sort_print_order_btn) {
+            m_on_sort_print_order_btn();
+        }
+    } else {
+        if (ImGuiPureWrap::button(_u8L("Arrange bed")) && m_on_arrange_bed_btn) {
+            m_on_arrange_bed_btn();
+        }
+        ImGui::SameLine();
+        if( ImGuiPureWrap::button(_u8L("Sort Bed Print Order"), _u8L("Sorts the bed print order based on how objects are arranged on the plate")) && m_on_sort_bed_print_order_btn) {
+            m_on_sort_bed_print_order_btn();
+        }
     }
 
     ImGuiPureWrap::end();

--- a/src/slic3r/GUI/ArrangeSettingsDialogImgui.hpp
+++ b/src/slic3r/GUI/ArrangeSettingsDialogImgui.hpp
@@ -18,6 +18,8 @@ class ArrangeSettingsDialogImgui: public arr2::ArrangeSettingsView {
 
     std::function<void()> m_on_arrange_btn;
     std::function<void()> m_on_arrange_bed_btn;
+    std::function<void()> m_on_sort_print_order_btn;
+    std::function<void()> m_on_sort_bed_print_order_btn;
     std::function<void()> m_on_reset_btn;
 
     std::function<bool()> m_show_xl_combo_predicate = [] { return true; };
@@ -40,6 +42,16 @@ public:
     void on_arrange_bed_btn(std::function<void()> on_arrangefn)
     {
         m_on_arrange_bed_btn = on_arrangefn;
+    }
+
+    void on_sort_print_order_btn(std::function<void()> on_sortfn)
+    {
+        m_on_sort_print_order_btn = on_sortfn;
+    }
+
+    void on_sort_bed_print_order_btn(std::function<void()> on_sortfn)
+    {
+        m_on_sort_bed_print_order_btn = on_sortfn;
     }
 
     void on_reset_btn(std::function<void()> on_resetfn)

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1351,6 +1351,21 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas *canvas, Bed3D &bed)
     m_arrange_settings_dialog.on_arrange_bed_btn([]{
         wxGetApp().plater()->arrange(true);
     });
+
+    // Simple back-to-front, left-to-right sorting
+    std::function<bool(const ModelObject*, const ModelObject*)> comp =
+        [](const ModelObject* a, const ModelObject* b) {
+            const auto& a_bb = a->bounding_box_exact();
+            const auto& b_bb = b->bounding_box_exact();
+            return (a_bb.max.y() != b_bb.max.y()) ? (a_bb.max.y() > b_bb.max.y())
+                                                  : (a_bb.max.x() < b_bb.max.x());
+        };
+    m_arrange_settings_dialog.on_sort_print_order_btn([comp]{
+        wxGetApp().obj_list()->sort_objects(comp, false);
+    });
+    m_arrange_settings_dialog.on_sort_bed_print_order_btn([comp]{
+        wxGetApp().obj_list()->sort_objects(comp, true);
+    });
 }
 
 GLCanvas3D::~GLCanvas3D()

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -2353,6 +2353,88 @@ void ObjectList::merge(bool to_multipart_object)
     }
 }
 
+void ObjectList::sort_objects(
+    std::function<bool(const ModelObject*, const ModelObject*)> cmp,
+    bool current_bed_only
+) {
+    if (!m_objects || m_objects->empty())
+        return;
+
+    const int selected_bed = current_bed_only ? s_multiple_beds.get_active_bed() : -1;
+
+    // Filter objects to sort by bed, deriving bed IDs from instances
+    std::vector<size_t> indices;
+    std::vector<int> bed_ids(m_objects->size(), -1);
+    const auto& inst_map = s_multiple_beds.get_inst_map();
+
+    for (size_t i = 0; i < m_objects->size(); ++i) {
+        const ModelObject* mo = (*m_objects)[i];
+        int object_bed = -1;
+        bool mixed_beds = false;
+
+        for (const ModelInstance* mi : mo->instances) {
+            int inst_bed = -1;
+            if (auto it = inst_map.find(mi->id()); it != inst_map.end())
+                inst_bed = it->second;
+
+            if (object_bed == -1) {
+                object_bed = inst_bed;
+            } else if (object_bed != inst_bed) {
+                mixed_beds = true;
+                break;
+            }
+        }
+
+        if (mixed_beds)
+            object_bed = -1;
+
+        bed_ids[i] = object_bed;
+
+        // If sorting only the active bed, skip objects not fully on it
+        if (selected_bed != -1 && object_bed != selected_bed)
+            continue;
+
+        indices.push_back(i);
+    }
+
+
+    if (indices.size() < 2)
+        return;
+
+    // Sort indices by bed ID first, then comp function
+    std::vector<size_t> sorted_indices = indices;
+    std::sort(sorted_indices.begin(), sorted_indices.end(),
+            [&cmp, &bed_ids, this](size_t a, size_t b) {
+                if (bed_ids[a] != bed_ids[b])
+                    return bed_ids[a] < bed_ids[b];
+                return cmp((*m_objects)[a], (*m_objects)[b]);
+            });
+
+    bool changed = false;
+    for (size_t i = 0; i < indices.size(); ++i) {
+        if ((*m_objects)[indices[i]] != (*m_objects)[sorted_indices[i]]) {
+            changed = true;
+            break;
+        }
+    }
+    if (!changed)
+        return;
+
+    take_snapshot(L("Sort objects"));
+
+    UnselectAll();
+
+    // Apply sorted order
+    std::vector<ModelObject*> temp;
+    for (size_t idx : sorted_indices)
+        temp.push_back((*m_objects)[idx]);
+    for (size_t i = 0; i < indices.size(); ++i)
+        (*m_objects)[indices[i]] = temp[i];
+
+    // Refresh the whole object list
+    update_after_undo_redo();
+}
+
 void ObjectList::layers_editing()
 {
     const Selection& selection = scene_selection();

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -273,6 +273,7 @@ public:
     void                del_info_item(const int obj_idx, InfoItemType type);
     void                split();
     void                merge(bool to_multipart_object);
+    void                sort_objects(std::function<bool(const ModelObject*, const ModelObject*)> sort_func, bool current_bed_only = false);
     void                layers_editing();
 
     wxDataViewItem      add_layer_root_item(const wxDataViewItem obj_item);


### PR DESCRIPTION
This adds a new button, "Sort Print Order" to the "Arrange Options" context menus. When clicked, this button will rearrange the order of the objects in the sidebar (which is also the print order) to match the layout of objects on the build plate, back-to-front then left-to-right.

For example, after Auto Arrange these objects will be printed in the order listed on the right:
<img width="1631" height="1124" alt="image" src="https://github.com/user-attachments/assets/c67446ff-32e6-4911-a862-c5a314468e3d" />


Click the new "Sort Print Order" button:
<img width="895" height="352" alt="image" src="https://github.com/user-attachments/assets/15d1b392-0128-4029-b07a-053baac147b9" />

and now the print order matches the lay out order:
<img width="1279" height="1071" alt="image" src="https://github.com/user-attachments/assets/58244112-6265-47b1-b0c2-dc15e1f2e16d" />

