### PR TITLE
Add advanced fuzzy skin features ported from OrcaSlicer

### DIFF
--- a/cmake/modules/Findlibnoise.cmake
+++ b/cmake/modules/Findlibnoise.cmake
@@ -1,0 +1,72 @@
+#///////////////////////////////////////////////////////////////////////////
+#//-------------------------------------------------------------------------
+#//
+#// Description:
+#//      cmake module for finding libnoise installation
+#//      Used for advanced fuzzy skin noise patterns (Perlin, Billow, etc.)
+#//
+#//      following variables are defined:
+#//      libnoise_FOUND         - whether libnoise was found
+#//      libnoise_INCLUDE_DIR   - libnoise header directory
+#//      libnoise_LIBRARY       - libnoise library file
+#//
+#//      Example usage:
+#//          find_package(libnoise REQUIRED)
+#//          target_link_libraries(myapp libnoise::libnoise)
+#//
+#//-------------------------------------------------------------------------
+
+set(libnoise_FOUND FALSE)
+set(libnoise_ERROR_REASON "")
+
+# Try to find the header
+find_path(libnoise_INCLUDE_DIR
+    NAMES libnoise/noise.h
+    PATH_SUFFIXES include
+)
+
+# Try to find the library
+find_library(libnoise_LIBRARY
+    NAMES libnoise_static libnoise noise
+    PATH_SUFFIXES lib lib64
+)
+
+# Check if we found everything
+if(libnoise_INCLUDE_DIR AND libnoise_LIBRARY)
+    set(libnoise_FOUND TRUE)
+else()
+    if(NOT libnoise_INCLUDE_DIR)
+        set(libnoise_ERROR_REASON "${libnoise_ERROR_REASON} Cannot find libnoise header 'libnoise/noise.h'.")
+    endif()
+    if(NOT libnoise_LIBRARY)
+        set(libnoise_ERROR_REASON "${libnoise_ERROR_REASON} Cannot find libnoise library.")
+    endif()
+endif()
+
+# Make variables changeable
+mark_as_advanced(
+    libnoise_INCLUDE_DIR
+    libnoise_LIBRARY
+)
+
+# Report result and create imported target
+if(libnoise_FOUND)
+    message(STATUS "Found libnoise: ${libnoise_LIBRARY}")
+    message(STATUS "Using libnoise include directory: ${libnoise_INCLUDE_DIR}")
+
+    if(NOT TARGET libnoise::libnoise)
+        add_library(libnoise::libnoise STATIC IMPORTED)
+        set_target_properties(libnoise::libnoise PROPERTIES
+            IMPORTED_LOCATION "${libnoise_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${libnoise_INCLUDE_DIR}"
+        )
+    endif()
+else()
+    if(libnoise_FIND_REQUIRED)
+        message(FATAL_ERROR "Unable to find required libnoise installation:${libnoise_ERROR_REASON}")
+    else()
+        if(NOT libnoise_FIND_QUIETLY)
+            message(STATUS "libnoise was not found:${libnoise_ERROR_REASON}")
+        endif()
+    endif()
+endif()

--- a/deps/+libnoise/libnoise.cmake
+++ b/deps/+libnoise/libnoise.cmake
@@ -1,0 +1,10 @@
+# libnoise - Coherent noise generation library
+# Used for advanced fuzzy skin noise patterns (Perlin, Billow, RidgedMulti, Voronoi)
+# Source: OrcaSlicer's fork of libnoise 1.0 (LGPL-2.1+)
+
+add_cmake_project(libnoise
+    URL "https://github.com/SoftFever/Orca-deps-libnoise/archive/refs/tags/1.0.zip"
+    URL_HASH SHA256=96ffd6cc47898dd8147aab53d7d1b1911b507d9dbaecd5613ca2649468afd8b6
+    CMAKE_ARGS
+        -DBUILD_SHARED_LIBS=OFF
+)

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -612,6 +612,7 @@ target_include_directories(libslic3r PUBLIC ${EXPAT_INCLUDE_DIRS})
 
 find_package(JPEG REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(libnoise REQUIRED)
 
 target_link_libraries(libslic3r PRIVATE
     libnest2d
@@ -632,6 +633,7 @@ target_link_libraries(libslic3r PRIVATE
     fastfloat
     int128
     nlohmann_json::nlohmann_json
+    libnoise::libnoise
 )
 target_link_libraries(libslic3r PUBLIC
     Eigen3::Eigen

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -1,4 +1,6 @@
 #include <random>
+#include <memory>
+#include <cmath>
 
 #include "libslic3r/Algorithm/LineSegmentation/LineSegmentation.hpp"
 #include "libslic3r/Arachne/utils/ExtrusionJunction.hpp"
@@ -7,6 +9,8 @@
 #include "libslic3r/Point.hpp"
 #include "libslic3r/Polygon.hpp"
 #include "libslic3r/PrintConfig.hpp"
+
+#include <libnoise/noise.h>
 
 #include "FuzzySkin.hpp"
 
@@ -24,11 +28,79 @@ static double random_value()
     return dist(gen);
 }
 
-void fuzzy_polyline(Points &poly, const bool closed, const double fuzzy_skin_thickness, const double fuzzy_skin_point_distance)
+// Adapter to use random_value() as a noise::module::Module
+class UniformNoise : public noise::module::Module {
+public:
+    UniformNoise() : Module(0) {}
+
+    int GetSourceModuleCount() const override { return 0; }
+
+    double GetValue(double /*x*/, double /*y*/, double /*z*/) const override {
+        // Return value in range [-1, 1] to match libnoise convention
+        return random_value() * 2.0 - 1.0;
+    }
+};
+
+// Factory function to create noise module based on config
+static std::unique_ptr<noise::module::Module> get_noise_module(const PrintRegionConfig &config)
 {
+    const NoiseType noise_type = config.fuzzy_skin_noise_type.value;
+    const double    scale      = config.fuzzy_skin_scale.value;
+    const int       octaves    = config.fuzzy_skin_octaves.value;
+    const double    persistence = config.fuzzy_skin_persistence.value;
+
+    switch (noise_type) {
+    case NoiseType::Perlin: {
+        auto module = std::make_unique<noise::module::Perlin>();
+        module->SetFrequency(1.0 / scale);
+        module->SetOctaveCount(octaves);
+        module->SetPersistence(persistence);
+        return module;
+    }
+    case NoiseType::Billow: {
+        auto module = std::make_unique<noise::module::Billow>();
+        module->SetFrequency(1.0 / scale);
+        module->SetOctaveCount(octaves);
+        module->SetPersistence(persistence);
+        return module;
+    }
+    case NoiseType::RidgedMulti: {
+        auto module = std::make_unique<noise::module::RidgedMulti>();
+        module->SetFrequency(1.0 / scale);
+        module->SetOctaveCount(octaves);
+        return module;
+    }
+    case NoiseType::Voronoi: {
+        auto module = std::make_unique<noise::module::Voronoi>();
+        module->SetFrequency(1.0 / scale);
+        module->EnableDistance(true);
+        return module;
+    }
+    case NoiseType::Classic:
+    default:
+        return std::make_unique<UniformNoise>();
+    }
+}
+
+// Get noise value at a point, returning value in range [-1, 1]
+static double get_noise_value(const noise::module::Module &noise_module, double x, double y, double z)
+{
+    double value = noise_module.GetValue(x, y, z);
+    // Clamp to [-1, 1] as some noise types can exceed this range
+    return std::clamp(value, -1.0, 1.0);
+}
+
+// Internal implementation for fuzzy polyline with noise support
+static void fuzzy_polyline_impl(Points &poly, const bool closed, coordf_t slice_z, const PrintRegionConfig &config)
+{
+    const double fuzzy_skin_thickness      = scaled<double>(config.fuzzy_skin_thickness.value);
+    const double fuzzy_skin_point_distance = scaled<double>(config.fuzzy_skin_point_dist.value);
+
     const double min_dist_between_points = fuzzy_skin_point_distance * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
     const double range_random_point_dist = fuzzy_skin_point_distance / 2.;
     double       dist_left_over          = random_value() * (min_dist_between_points / 2.); // the distance to be traversed on the line before making the first new point
+
+    auto noise_module = get_noise_module(config);
 
     Points out;
     out.reserve(poly.size());
@@ -43,7 +115,13 @@ void fuzzy_polyline(Points &poly, const bool closed, const double fuzzy_skin_thi
         double p0p1_size = p0p1.norm();
         double p0pa_dist = dist_left_over;
         for (; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + random_value() * range_random_point_dist) {
-            double r = random_value() * (fuzzy_skin_thickness * 2.) - fuzzy_skin_thickness;
+            // Calculate position along the line
+            Vec2d point_pos = p0->cast<double>() + p0p1 * (p0pa_dist / p0p1_size);
+
+            // Get noise value at this position
+            double noise_val = get_noise_value(*noise_module, unscale<double>(point_pos.x()), unscale<double>(point_pos.y()), slice_z);
+            double r = noise_val * fuzzy_skin_thickness;
+
             out.emplace_back(*p0 + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * r).cast<coord_t>());
         }
 
@@ -66,16 +144,23 @@ void fuzzy_polyline(Points &poly, const bool closed, const double fuzzy_skin_thi
     }
 }
 
-void fuzzy_polygon(Polygon &polygon, double fuzzy_skin_thickness, double fuzzy_skin_point_distance)
+void fuzzy_polygon(Polygon &polygon, coordf_t slice_z, const PrintRegionConfig &config)
 {
-    fuzzy_polyline(polygon.points, true, fuzzy_skin_thickness, fuzzy_skin_point_distance);
+    fuzzy_polyline_impl(polygon.points, true, slice_z, config);
 }
 
-void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, const double fuzzy_skin_thickness, const double fuzzy_skin_point_distance)
+void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, coordf_t slice_z, const PrintRegionConfig &config)
 {
+    const FuzzySkinMode mode = config.fuzzy_skin_mode.value;
+
+    const double fuzzy_skin_thickness      = scaled<double>(config.fuzzy_skin_thickness.value);
+    const double fuzzy_skin_point_distance = scaled<double>(config.fuzzy_skin_point_dist.value);
+
     const double min_dist_between_points = fuzzy_skin_point_distance * 3. / 4.; // hardcoded: the point distance may vary between 3/4 and 5/4 the supplied value
     const double range_random_point_dist = fuzzy_skin_point_distance / 2.;
     double       dist_left_over          = random_value() * (min_dist_between_points / 2.); // the distance to be traversed on the line before making the first new point
+
+    auto noise_module = get_noise_module(config);
 
     Arachne::ExtrusionJunction *p0 = &ext_lines.front();
     Arachne::ExtrusionJunctions out;
@@ -92,8 +177,29 @@ void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, const double fuzzy_
         double p0p1_size = p0p1.norm();
         double p0pa_dist = dist_left_over;
         for (; p0pa_dist < p0p1_size; p0pa_dist += min_dist_between_points + random_value() * range_random_point_dist) {
-            double r = random_value() * (fuzzy_skin_thickness * 2.) - fuzzy_skin_thickness;
-            out.emplace_back(p0->p + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * r).cast<coord_t>(), p1.w, p1.perimeter_index);
+            // Calculate position along the line
+            Vec2d point_pos = p0->p.cast<double>() + p0p1 * (p0pa_dist / p0p1_size);
+
+            // Get noise value at this position
+            double noise_val = get_noise_value(*noise_module, unscale<double>(point_pos.x()), unscale<double>(point_pos.y()), slice_z);
+
+            // Calculate displacement
+            double displacement = 0.0;
+            if (mode == FuzzySkinMode::Displacement || mode == FuzzySkinMode::Combined) {
+                displacement = noise_val * fuzzy_skin_thickness;
+            }
+
+            // Calculate width variation
+            coord_t new_width = p1.w;
+            if (mode == FuzzySkinMode::Extrusion || mode == FuzzySkinMode::Combined) {
+                // Vary width by up to ±thickness (as a fraction of original width)
+                double width_factor = 1.0 + noise_val * (fuzzy_skin_thickness / std::max(1.0, static_cast<double>(p1.w)));
+                width_factor = std::clamp(width_factor, 0.5, 1.5); // Clamp to reasonable range
+                new_width = static_cast<coord_t>(p1.w * width_factor);
+            }
+
+            Point new_point = p0->p + (p0p1 * (p0pa_dist / p0p1_size) + perp(p0p1).cast<double>().normalized() * displacement).cast<coord_t>();
+            out.emplace_back(new_point, new_width, p1.perimeter_index);
         }
 
         dist_left_over = p0pa_dist - p0p1_size;
@@ -124,24 +230,38 @@ bool should_fuzzify(const PrintRegionConfig &config, const size_t layer_idx, con
 {
     const FuzzySkinType fuzzy_skin_type = config.fuzzy_skin.value;
 
-    if (fuzzy_skin_type == FuzzySkinType::None || layer_idx <= 0) {
+    if (fuzzy_skin_type == FuzzySkinType::None) {
         return false;
     }
 
+    // Check first layer option
+    if (layer_idx == 0 && !config.fuzzy_skin_first_layer.value) {
+        return false;
+    }
+
+    // AllWalls: fuzzify all perimeters (internal and external)
+    if (fuzzy_skin_type == FuzzySkinType::AllWalls) {
+        return true;
+    }
+
+    // External: only outermost perimeter (perimeter_idx == 0) and only contours
     const bool fuzzify_contours = perimeter_idx == 0;
-    const bool fuzzify_holes    = fuzzify_contours && fuzzy_skin_type == FuzzySkinType::All;
+
+    // All: outermost perimeter for both contours and holes
+    const bool fuzzify_holes = fuzzify_contours && fuzzy_skin_type == FuzzySkinType::All;
 
     return is_contour ? fuzzify_contours : fuzzify_holes;
 }
 
-Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions, const size_t layer_idx, const size_t perimeter_idx, const bool is_contour)
+Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions,
+                         const size_t layer_idx, coordf_t slice_z, const size_t perimeter_idx, const bool is_contour)
 {
     using namespace Slic3r::Algorithm::LineSegmentation;
 
-    auto apply_fuzzy_skin_on_polygon = [&layer_idx, &perimeter_idx, &is_contour](const Polygon &polygon, const PrintRegionConfig &config) -> Polygon {
+    auto apply_fuzzy_skin_on_polygon = [&layer_idx, &slice_z, &perimeter_idx, &is_contour](const Polygon &polygon, const PrintRegionConfig &config) -> Polygon {
         if (should_fuzzify(config, layer_idx, perimeter_idx, is_contour)) {
             Polygon fuzzified_polygon = polygon;
-            fuzzy_polygon(fuzzified_polygon, scaled<double>(config.fuzzy_skin_thickness.value), scaled<double>(config.fuzzy_skin_point_dist.value));
+            fuzzy_polygon(fuzzified_polygon, slice_z, config);
 
             return fuzzified_polygon;
         } else {
@@ -163,7 +283,7 @@ Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_c
     for (PolylineRegionSegment &segment : segments) {
         const PrintRegionConfig &config = segment.config;
         if (should_fuzzify(config, layer_idx, perimeter_idx, is_contour)) {
-            fuzzy_polyline(segment.polyline.points, false, scaled<double>(config.fuzzy_skin_thickness.value), scaled<double>(config.fuzzy_skin_point_dist.value));
+            fuzzy_polyline_impl(segment.polyline.points, false, slice_z, config);
         }
 
         assert(!segment.polyline.empty());
@@ -186,7 +306,9 @@ Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_c
     return fuzzified_polygon;
 }
 
-Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions, const size_t layer_idx, const size_t perimeter_idx, const bool is_contour)
+Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion, const PrintRegionConfig &base_config,
+                                        const PerimeterRegions &perimeter_regions, const size_t layer_idx, coordf_t slice_z,
+                                        const size_t perimeter_idx, const bool is_contour)
 {
     using namespace Slic3r::Algorithm::LineSegmentation;
     using namespace Slic3r::Arachne;
@@ -194,7 +316,7 @@ Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion,
     if (perimeter_regions.empty()) {
         if (should_fuzzify(base_config, layer_idx, perimeter_idx, is_contour)) {
             ExtrusionLine fuzzified_extrusion = extrusion;
-            fuzzy_extrusion_line(fuzzified_extrusion, scaled<double>(base_config.fuzzy_skin_thickness.value), scaled<double>(base_config.fuzzy_skin_point_dist.value));
+            fuzzy_extrusion_line(fuzzified_extrusion, slice_z, base_config);
 
             return fuzzified_extrusion;
         } else {
@@ -208,7 +330,7 @@ Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion,
     for (ExtrusionRegionSegment &segment : segments) {
         const PrintRegionConfig &config = segment.config;
         if (should_fuzzify(config, layer_idx, perimeter_idx, is_contour)) {
-            fuzzy_extrusion_line(segment.extrusion, scaled<double>(config.fuzzy_skin_thickness.value), scaled<double>(config.fuzzy_skin_point_dist.value));
+            fuzzy_extrusion_line(segment.extrusion, slice_z, config);
         }
 
         assert(!segment.extrusion.empty());

--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.hpp
@@ -1,25 +1,34 @@
 #ifndef libslic3r_FuzzySkin_hpp_
 #define libslic3r_FuzzySkin_hpp_
 
+#include "libslic3r/libslic3r.h"
+#include "libslic3r/Polygon.hpp"
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/PerimeterGenerator.hpp"
+
 namespace Slic3r::Arachne {
 struct ExtrusionLine;
 } // namespace Slic3r::Arachne
 
-namespace Slic3r::PerimeterGenerator {
-struct Parameters;
-} // namespace Slic3r::PerimeterGenerator
-
 namespace Slic3r::Feature::FuzzySkin {
 
-void fuzzy_polygon(Polygon &polygon, double fuzzy_skin_thickness, double fuzzy_skin_point_distance);
+// Apply fuzzy skin displacement to a polygon
+void fuzzy_polygon(Polygon &polygon, coordf_t slice_z, const PrintRegionConfig &config);
 
-void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, double fuzzy_skin_thickness, double fuzzy_skin_point_dist);
+// Apply fuzzy skin to an extrusion line (supports displacement, extrusion width, or combined modes)
+void fuzzy_extrusion_line(Arachne::ExtrusionLine &ext_lines, coordf_t slice_z, const PrintRegionConfig &config);
 
+// Determine if fuzzy skin should be applied based on config, layer, perimeter index, and contour type
 bool should_fuzzify(const PrintRegionConfig &config, size_t layer_idx, size_t perimeter_idx, bool is_contour);
 
-Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions, size_t layer_idx, size_t perimeter_idx, bool is_contour);
+// Apply fuzzy skin to a polygon with region-aware processing
+Polygon apply_fuzzy_skin(const Polygon &polygon, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions,
+                         size_t layer_idx, coordf_t slice_z, size_t perimeter_idx, bool is_contour);
 
-Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion, const PrintRegionConfig &base_config, const PerimeterRegions &perimeter_regions, size_t layer_idx, size_t perimeter_idx, bool is_contour);
+// Apply fuzzy skin to an extrusion line with region-aware processing
+Arachne::ExtrusionLine apply_fuzzy_skin(const Arachne::ExtrusionLine &extrusion, const PrintRegionConfig &base_config,
+                                        const PerimeterRegions &perimeter_regions, size_t layer_idx, coordf_t slice_z,
+                                        size_t perimeter_idx, bool is_contour);
 
 } // namespace Slic3r::Feature::FuzzySkin
 

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -118,6 +118,7 @@ void LayerRegion::make_perimeters(
     PerimeterGenerator::Parameters params(
         this->layer()->height,
         int(this->layer()->id()),
+        this->layer()->slice_z,
         this->flow(frPerimeter),
         this->flow(frExternalPerimeter),
         this->bridging_flow(frPerimeter),

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -225,7 +225,7 @@ static ExtrusionEntityCollection traverse_loops_classic(const PerimeterGenerator
         }
 
         // Apply fuzzy skin if it is enabled for at least some part of the polygon.
-        const Polygon polygon = apply_fuzzy_skin(loop.polygon, params.config, params.perimeter_regions, params.layer_id, loop.depth, loop.is_contour);
+        const Polygon polygon = apply_fuzzy_skin(loop.polygon, params.config, params.perimeter_regions, params.layer_id, params.slice_z, loop.depth, loop.is_contour);
 
         ExtrusionPaths paths;
         if (params.config.overhangs && params.layer_id > params.object_config.raft_layers &&
@@ -434,7 +434,7 @@ static ExtrusionEntityCollection traverse_extrusions(const PerimeterGenerator::P
         ExtrusionRole role_overhang = role_normal | ExtrusionRoleModifier::Bridge;
 
         // Apply fuzzy skin if it is enabled for at least some part of the ExtrusionLine.
-        extrusion = apply_fuzzy_skin(extrusion, params.config, params.perimeter_regions, params.layer_id, pg_extrusion.extrusion.inset_idx, !pg_extrusion.extrusion.is_closed || pg_extrusion.is_contour());
+        extrusion = apply_fuzzy_skin(extrusion, params.config, params.perimeter_regions, params.layer_id, params.slice_z, pg_extrusion.extrusion.inset_idx, !pg_extrusion.extrusion.is_closed || pg_extrusion.is_contour());
 
         ExtrusionPaths paths;
         // detect overhanging/bridging perimeters
@@ -1553,9 +1553,15 @@ PerimeterRegion::PerimeterRegion(const LayerRegion &layer_region) : region(&laye
 
 bool PerimeterRegion::has_compatible_perimeter_regions(const PrintRegionConfig &config, const PrintRegionConfig &other_config)
 {
-    return config.fuzzy_skin            == other_config.fuzzy_skin &&
-           config.fuzzy_skin_thickness  == other_config.fuzzy_skin_thickness &&
-           config.fuzzy_skin_point_dist == other_config.fuzzy_skin_point_dist;
+    return config.fuzzy_skin              == other_config.fuzzy_skin &&
+           config.fuzzy_skin_thickness    == other_config.fuzzy_skin_thickness &&
+           config.fuzzy_skin_point_dist   == other_config.fuzzy_skin_point_dist &&
+           config.fuzzy_skin_first_layer  == other_config.fuzzy_skin_first_layer &&
+           config.fuzzy_skin_mode         == other_config.fuzzy_skin_mode &&
+           config.fuzzy_skin_noise_type   == other_config.fuzzy_skin_noise_type &&
+           config.fuzzy_skin_scale        == other_config.fuzzy_skin_scale &&
+           config.fuzzy_skin_octaves      == other_config.fuzzy_skin_octaves &&
+           config.fuzzy_skin_persistence  == other_config.fuzzy_skin_persistence;
 }
 
 void PerimeterRegion::merge_compatible_perimeter_regions(PerimeterRegions &perimeter_regions)

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -48,10 +48,11 @@ using PerimeterRegions = std::vector<PerimeterRegion>;
 
 namespace Slic3r::PerimeterGenerator {
 
-struct Parameters {    
+struct Parameters {
     Parameters(
         double                      layer_height,
         int                         layer_id,
+        coordf_t                    slice_z,
         Flow                        perimeter_flow,
         Flow                        ext_perimeter_flow,
         Flow                        overhang_flow,
@@ -60,21 +61,22 @@ struct Parameters {
         const PrintObjectConfig    &object_config,
         const PrintConfig          &print_config,
         const PerimeterRegions     &perimeter_regions,
-        const bool                  spiral_vase) :   
+        const bool                  spiral_vase) :
             layer_height(layer_height),
             layer_id(layer_id),
-            perimeter_flow(perimeter_flow), 
+            slice_z(slice_z),
+            perimeter_flow(perimeter_flow),
             ext_perimeter_flow(ext_perimeter_flow),
-            overhang_flow(overhang_flow), 
+            overhang_flow(overhang_flow),
             solid_infill_flow(solid_infill_flow),
-            config(config), 
-            object_config(object_config), 
+            config(config),
+            object_config(object_config),
             print_config(print_config),
             perimeter_regions(perimeter_regions),
             spiral_vase(spiral_vase),
             scaled_resolution(scaled<double>(print_config.gcode_resolution.value)),
             mm3_per_mm(perimeter_flow.mm3_per_mm()),
-            ext_mm3_per_mm(ext_perimeter_flow.mm3_per_mm()), 
+            ext_mm3_per_mm(ext_perimeter_flow.mm3_per_mm()),
             mm3_per_mm_overhang(overhang_flow.mm3_per_mm())
         {
         }
@@ -82,6 +84,7 @@ struct Parameters {
     // Input parameters
     double                       layer_height;
     int                          layer_id;
+    coordf_t                     slice_z;
     Flow                         perimeter_flow;
     Flow                         ext_perimeter_flow;
     Flow                         overhang_flow;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -481,6 +481,7 @@ static std::vector<std::string> s_Preset_print_options {
     "ironing", "ironing_type", "ironing_flowrate", "ironing_speed", "ironing_spacing",
     "max_print_speed", "max_volumetric_speed", "avoid_crossing_perimeters_max_detour",
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_dist",
+    "fuzzy_skin_first_layer", "fuzzy_skin_mode", "fuzzy_skin_noise_type", "fuzzy_skin_scale", "fuzzy_skin_octaves", "fuzzy_skin_persistence",
     "max_volumetric_extrusion_rate_slope_positive", "max_volumetric_extrusion_rate_slope_negative",
     "perimeter_speed", "small_perimeter_speed", "external_perimeter_speed", "infill_speed", "solid_infill_speed",
     "enable_dynamic_overhang_speeds", "overhang_speed_0", "overhang_speed_1", "overhang_speed_2", "overhang_speed_3",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -123,9 +123,26 @@ CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(AuthorizationType)
 static const t_config_enum_values s_keys_map_FuzzySkinType {
     { "none",           int(FuzzySkinType::None) },
     { "external",       int(FuzzySkinType::External) },
-    { "all",            int(FuzzySkinType::All) }
+    { "all",            int(FuzzySkinType::All) },
+    { "allwalls",       int(FuzzySkinType::AllWalls) }
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinType)
+
+static const t_config_enum_values s_keys_map_FuzzySkinMode {
+    { "displacement",   int(FuzzySkinMode::Displacement) },
+    { "extrusion",      int(FuzzySkinMode::Extrusion) },
+    { "combined",       int(FuzzySkinMode::Combined) }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(FuzzySkinMode)
+
+static const t_config_enum_values s_keys_map_NoiseType {
+    { "classic",        int(NoiseType::Classic) },
+    { "perlin",         int(NoiseType::Perlin) },
+    { "billow",         int(NoiseType::Billow) },
+    { "ridgedmulti",    int(NoiseType::RidgedMulti) },
+    { "voronoi",        int(NoiseType::Voronoi) }
+};
+CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(NoiseType)
 
 static const t_config_enum_values s_keys_map_InfillPattern {
     { "rectilinear",        ipRectilinear },
@@ -1718,7 +1735,8 @@ void PrintConfigDef::init_fff_params()
     def->set_enum<FuzzySkinType>({
         { "none",       L("None") },
         { "external",   L("Outside walls") },
-        { "all",        L("All walls") }
+        { "all",        L("Outside walls and holes") },
+        { "allwalls",   L("All walls (including internal)") }
     });
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionEnum<FuzzySkinType>(FuzzySkinType::None));
@@ -1742,6 +1760,75 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.8));
+
+    def = this->add("fuzzy_skin_first_layer", coBool);
+    def->label = L("Apply fuzzy skin to first layer");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Apply fuzzy skin effect to the first layer. By default, the first layer is not fuzzified "
+                     "to improve bed adhesion.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("fuzzy_skin_mode", coEnum);
+    def->label = L("Fuzzy skin mode");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Displacement mode offsets points perpendicular to the wall (classic behavior). "
+                     "Extrusion mode varies the extrusion width (requires Arachne). "
+                     "Combined mode applies both displacement and extrusion variation.");
+    def->set_enum<FuzzySkinMode>({
+        { "displacement",   L("Displacement") },
+        { "extrusion",      L("Extrusion width") },
+        { "combined",       L("Combined") }
+    });
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionEnum<FuzzySkinMode>(FuzzySkinMode::Displacement));
+
+    def = this->add("fuzzy_skin_noise_type", coEnum);
+    def->label = L("Noise type");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Type of noise pattern to use. Classic uses random noise (original behavior). "
+                     "Perlin creates smooth, natural-looking patterns. Billow creates cloud-like billowy patterns. "
+                     "RidgedMulti creates sharp ridge patterns. Voronoi creates cell-like patterns.");
+    def->set_enum<NoiseType>({
+        { "classic",        L("Classic (random)") },
+        { "perlin",         L("Perlin") },
+        { "billow",         L("Billow") },
+        { "ridgedmulti",    L("Ridged multifractal") },
+        { "voronoi",        L("Voronoi") }
+    });
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionEnum<NoiseType>(NoiseType::Classic));
+
+    def = this->add("fuzzy_skin_scale", coFloat);
+    def->label = L("Noise scale");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Scale of the noise pattern. Larger values create larger features. "
+                     "Only applies to non-classic noise types.");
+    def->sidetext = L("mm");
+    def->min = 0.1;
+    def->max = 500;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1.0));
+
+    def = this->add("fuzzy_skin_octaves", coInt);
+    def->label = L("Noise octaves");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Number of octaves of noise to combine. More octaves add finer detail. "
+                     "Only applies to Perlin, Billow, and RidgedMulti noise types.");
+    def->min = 1;
+    def->max = 10;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(4));
+
+    def = this->add("fuzzy_skin_persistence", coFloat);
+    def->label = L("Noise persistence");
+    def->category = L("Fuzzy Skin");
+    def->tooltip = L("Controls how quickly the amplitude of each octave decreases. "
+                     "Higher values create rougher patterns. Only applies to Perlin and Billow noise types.");
+    def->min = 0.01;
+    def->max = 1.0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0.5));
 
     def = this->add("gap_fill_enabled", coBool);
     def->label = L("Fill gaps");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -99,6 +99,21 @@ enum class FuzzySkinType {
     None,
     External,
     All,
+    AllWalls,
+};
+
+enum class FuzzySkinMode {
+    Displacement,
+    Extrusion,
+    Combined,
+};
+
+enum class NoiseType {
+    Classic,
+    Perlin,
+    Billow,
+    RidgedMulti,
+    Voronoi,
 };
 
 enum InfillPattern : int {
@@ -256,6 +271,8 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(MachineLimitsUsage)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(PrintHostType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(AuthorizationType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(FuzzySkinType)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(FuzzySkinMode)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(NoiseType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(InfillPattern)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(IroningType)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(SlicingMode)
@@ -728,6 +745,12 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<FuzzySkinType>,  fuzzy_skin))
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_dist))
+    ((ConfigOptionBool,                 fuzzy_skin_first_layer))
+    ((ConfigOptionEnum<FuzzySkinMode>,  fuzzy_skin_mode))
+    ((ConfigOptionEnum<NoiseType>,      fuzzy_skin_noise_type))
+    ((ConfigOptionFloat,                fuzzy_skin_scale))
+    ((ConfigOptionInt,                  fuzzy_skin_octaves))
+    ((ConfigOptionFloat,                fuzzy_skin_persistence))
     ((ConfigOptionBool,                 gap_fill_enabled))
     ((ConfigOptionFloat,                gap_fill_speed))
     ((ConfigOptionFloatOrPercent,       infill_anchor))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -9,6 +9,7 @@
 #include "format.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/PrintConfig.hpp"
 #include "MsgDialog.hpp"
 
 #include <string>
@@ -278,6 +279,31 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
             apply(config, &(*new_config));
         }
     }
+
+    // Check fuzzy skin mode compatibility with perimeter generator
+    // Extrusion and Combined modes require Arachne perimeter generator
+    FuzzySkinMode fuzzy_skin_mode = config->opt_enum<FuzzySkinMode>("fuzzy_skin_mode");
+    FuzzySkinType fuzzy_skin_type = config->opt_enum<FuzzySkinType>("fuzzy_skin");
+    bool have_arachne = config->opt_enum<PerimeterGeneratorType>("perimeter_generator") == PerimeterGeneratorType::Arachne;
+
+    if (fuzzy_skin_type != FuzzySkinType::None &&
+        fuzzy_skin_mode != FuzzySkinMode::Displacement &&
+        !have_arachne) {
+        wxString msg_text = _(L("Fuzzy skin modes 'Extrusion width' and 'Combined' require the Arachne perimeter generator "
+                                "to vary extrusion widths. The Classic perimeter generator does not support variable width extrusions."));
+        if (is_global_config)
+            msg_text += "\n\n" + _(L("Shall I enable Arachne perimeter generator?"));
+        MessageDialog dialog(m_msg_dlg_parent, msg_text, _(L("Fuzzy Skin")),
+                               wxICON_WARNING | (is_global_config ? wxYES | wxNO : wxOK));
+        DynamicPrintConfig new_conf = *config;
+        auto answer = dialog.ShowModal();
+        if (!is_global_config || answer == wxID_YES) {
+            new_conf.set_key_value("perimeter_generator", new ConfigOptionEnum<PerimeterGeneratorType>(PerimeterGeneratorType::Arachne));
+        } else {
+            new_conf.set_key_value("fuzzy_skin_mode", new ConfigOptionEnum<FuzzySkinMode>(FuzzySkinMode::Displacement));
+        }
+        apply(config, &new_conf);
+    }
 }
 
 void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
@@ -431,6 +457,27 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_non_zero_mmu_segmented_region_max_width = !use_beam_interlocking && config->opt_float("mmu_segmented_region_max_width") > 0.;
     toggle_field("mmu_segmented_region_interlocking_depth", have_non_zero_mmu_segmented_region_max_width);
+
+    // Fuzzy skin visibility toggles
+    bool has_fuzzy_skin = config->opt_enum<FuzzySkinType>("fuzzy_skin") != FuzzySkinType::None;
+    toggle_field("fuzzy_skin_thickness", has_fuzzy_skin);
+    toggle_field("fuzzy_skin_point_dist", has_fuzzy_skin);
+    toggle_field("fuzzy_skin_first_layer", has_fuzzy_skin);
+    toggle_field("fuzzy_skin_mode", has_fuzzy_skin);
+    toggle_field("fuzzy_skin_noise_type", has_fuzzy_skin);
+
+    // Noise-specific parameters
+    NoiseType noise_type = config->opt_enum<NoiseType>("fuzzy_skin_noise_type");
+    bool is_non_classic_noise = has_fuzzy_skin && noise_type != NoiseType::Classic;
+    toggle_field("fuzzy_skin_scale", is_non_classic_noise);
+
+    // Octaves: Perlin, Billow, RidgedMulti (not Voronoi or Classic)
+    bool has_octaves = is_non_classic_noise && noise_type != NoiseType::Voronoi;
+    toggle_field("fuzzy_skin_octaves", has_octaves);
+
+    // Persistence: only Perlin and Billow
+    bool has_persistence = is_non_classic_noise && (noise_type == NoiseType::Perlin || noise_type == NoiseType::Billow);
+    toggle_field("fuzzy_skin_persistence", has_persistence);
 }
 
 void ConfigManipulation::toggle_print_sla_options(DynamicPrintConfig* config)

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1497,6 +1497,12 @@ void TabPrint::build()
         optgroup->append_single_option_line("fuzzy_skin", category_path + "fuzzy-skin-type");
         optgroup->append_single_option_line("fuzzy_skin_thickness", category_path + "fuzzy-skin-thickness");
         optgroup->append_single_option_line("fuzzy_skin_point_dist", category_path + "fuzzy-skin-point-distance");
+        optgroup->append_single_option_line("fuzzy_skin_first_layer", category_path + "fuzzy-skin-first-layer");
+        optgroup->append_single_option_line("fuzzy_skin_mode", category_path + "fuzzy-skin-mode");
+        optgroup->append_single_option_line("fuzzy_skin_noise_type", category_path + "fuzzy-skin-noise-type");
+        optgroup->append_single_option_line("fuzzy_skin_scale", category_path + "fuzzy-skin-scale");
+        optgroup->append_single_option_line("fuzzy_skin_octaves", category_path + "fuzzy-skin-octaves");
+        optgroup->append_single_option_line("fuzzy_skin_persistence", category_path + "fuzzy-skin-persistence");
 
         optgroup = page->new_optgroup(L("Only one perimeter"));
         category_path = "layers-and-perimeters_1748/#";

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(${_TEST_NAME}_tests
 	test_support_material.cpp
 	test_thin_walls.cpp
 	test_trianglemesh.cpp
+	test_fuzzy_skin.cpp
 	)
 target_link_libraries(${_TEST_NAME}_tests test_common slic3r-arrange-wrapper)
 set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")

--- a/tests/fff_print/test_fuzzy_skin.cpp
+++ b/tests/fff_print/test_fuzzy_skin.cpp
@@ -1,0 +1,498 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "libslic3r/PrintConfig.hpp"
+#include "libslic3r/Polygon.hpp"
+#include "libslic3r/Feature/FuzzySkin/FuzzySkin.hpp"
+#include "libslic3r/Arachne/utils/ExtrusionLine.hpp"
+
+#include "test_data.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Feature::FuzzySkin;
+
+// Helper to create a simple square polygon
+static Polygon make_square(coord_t size)
+{
+    return Polygon({
+        Point(0, 0),
+        Point(size, 0),
+        Point(size, size),
+        Point(0, size)
+    });
+}
+
+// Helper to create a config with specific fuzzy skin settings
+static PrintRegionConfig make_fuzzy_config(
+    FuzzySkinType type = FuzzySkinType::External,
+    FuzzySkinMode mode = FuzzySkinMode::Displacement,
+    NoiseType noise_type = NoiseType::Classic,
+    double thickness = 0.3,
+    double point_dist = 0.8,
+    bool first_layer = false,
+    double scale = 1.0,
+    int octaves = 4,
+    double persistence = 0.5)
+{
+    PrintRegionConfig config;
+    config.fuzzy_skin.value = type;
+    config.fuzzy_skin_mode.value = mode;
+    config.fuzzy_skin_noise_type.value = noise_type;
+    config.fuzzy_skin_thickness.value = thickness;
+    config.fuzzy_skin_point_dist.value = point_dist;
+    config.fuzzy_skin_first_layer.value = first_layer;
+    config.fuzzy_skin_scale.value = scale;
+    config.fuzzy_skin_octaves.value = octaves;
+    config.fuzzy_skin_persistence.value = persistence;
+    return config;
+}
+
+SCENARIO("should_fuzzify logic", "[FuzzySkin]")
+{
+    GIVEN("FuzzySkinType::None") {
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::None);
+
+        THEN("never fuzzifies") {
+            REQUIRE_FALSE(should_fuzzify(config, 0, 0, true));
+            REQUIRE_FALSE(should_fuzzify(config, 1, 0, true));
+            REQUIRE_FALSE(should_fuzzify(config, 1, 0, false));
+            REQUIRE_FALSE(should_fuzzify(config, 1, 1, true));
+        }
+    }
+
+    GIVEN("FuzzySkinType::External") {
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::External);
+
+        THEN("fuzzifies only outermost contours, not first layer") {
+            // Layer 0 (first layer) - should not fuzzify by default
+            REQUIRE_FALSE(should_fuzzify(config, 0, 0, true));
+
+            // Layer 1+, perimeter 0, contour - should fuzzify
+            REQUIRE(should_fuzzify(config, 1, 0, true));
+
+            // Layer 1+, perimeter 0, hole - should NOT fuzzify (External mode)
+            REQUIRE_FALSE(should_fuzzify(config, 1, 0, false));
+
+            // Layer 1+, inner perimeters - should NOT fuzzify
+            REQUIRE_FALSE(should_fuzzify(config, 1, 1, true));
+            REQUIRE_FALSE(should_fuzzify(config, 1, 2, true));
+        }
+    }
+
+    GIVEN("FuzzySkinType::All") {
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::All);
+
+        THEN("fuzzifies outermost perimeters including holes, not first layer") {
+            // Layer 0 (first layer) - should not fuzzify by default
+            REQUIRE_FALSE(should_fuzzify(config, 0, 0, true));
+
+            // Layer 1+, perimeter 0, contour - should fuzzify
+            REQUIRE(should_fuzzify(config, 1, 0, true));
+
+            // Layer 1+, perimeter 0, hole - should fuzzify (All mode)
+            REQUIRE(should_fuzzify(config, 1, 0, false));
+
+            // Layer 1+, inner perimeters - should NOT fuzzify
+            REQUIRE_FALSE(should_fuzzify(config, 1, 1, true));
+        }
+    }
+
+    GIVEN("FuzzySkinType::AllWalls") {
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::AllWalls);
+
+        THEN("fuzzifies all perimeters on all walls, not first layer") {
+            // Layer 0 (first layer) - should not fuzzify by default
+            REQUIRE_FALSE(should_fuzzify(config, 0, 0, true));
+            REQUIRE_FALSE(should_fuzzify(config, 0, 1, true));
+
+            // Layer 1+, all perimeters - should fuzzify
+            REQUIRE(should_fuzzify(config, 1, 0, true));
+            REQUIRE(should_fuzzify(config, 1, 0, false));
+            REQUIRE(should_fuzzify(config, 1, 1, true));
+            REQUIRE(should_fuzzify(config, 1, 2, true));
+            REQUIRE(should_fuzzify(config, 1, 5, false));
+        }
+    }
+
+    GIVEN("fuzzy_skin_first_layer enabled") {
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::External);
+        config.fuzzy_skin_first_layer.value = true;
+
+        THEN("first layer is also fuzzified") {
+            REQUIRE(should_fuzzify(config, 0, 0, true));
+            REQUIRE(should_fuzzify(config, 1, 0, true));
+        }
+    }
+}
+
+SCENARIO("fuzzy_polygon basic behavior", "[FuzzySkin]")
+{
+    GIVEN("a square polygon") {
+        Polygon square = make_square(scaled<coord_t>(10.0)); // 10mm square
+        size_t original_point_count = square.points.size();
+
+        WHEN("fuzzy skin is applied with Classic noise") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::Classic,
+                0.3,  // thickness
+                0.8   // point_dist
+            );
+
+            Polygon fuzzified = square;
+            fuzzy_polygon(fuzzified, 1.0, config);
+
+            THEN("polygon has more points than original") {
+                REQUIRE(fuzzified.points.size() > original_point_count);
+            }
+
+            THEN("polygon is still valid (at least 3 points)") {
+                REQUIRE(fuzzified.points.size() >= 3);
+            }
+        }
+
+        WHEN("fuzzy skin is applied with Perlin noise") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::Perlin,
+                0.3,  // thickness
+                0.8,  // point_dist
+                false,
+                2.0,  // scale
+                4,    // octaves
+                0.5   // persistence
+            );
+
+            Polygon fuzzified = square;
+            fuzzy_polygon(fuzzified, 1.0, config);
+
+            THEN("polygon has more points than original") {
+                REQUIRE(fuzzified.points.size() > original_point_count);
+            }
+        }
+
+        WHEN("fuzzy skin is applied with Billow noise") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::Billow
+            );
+
+            Polygon fuzzified = square;
+            fuzzy_polygon(fuzzified, 1.0, config);
+
+            THEN("polygon has more points than original") {
+                REQUIRE(fuzzified.points.size() > original_point_count);
+            }
+        }
+
+        WHEN("fuzzy skin is applied with RidgedMulti noise") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::RidgedMulti
+            );
+
+            Polygon fuzzified = square;
+            fuzzy_polygon(fuzzified, 1.0, config);
+
+            THEN("polygon has more points than original") {
+                REQUIRE(fuzzified.points.size() > original_point_count);
+            }
+        }
+
+        WHEN("fuzzy skin is applied with Voronoi noise") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::Voronoi
+            );
+
+            Polygon fuzzified = square;
+            fuzzy_polygon(fuzzified, 1.0, config);
+
+            THEN("polygon has more points than original") {
+                REQUIRE(fuzzified.points.size() > original_point_count);
+            }
+        }
+    }
+}
+
+SCENARIO("fuzzy_extrusion_line modes", "[FuzzySkin]")
+{
+    GIVEN("a simple extrusion line") {
+        Arachne::ExtrusionLine ext_line(0, false, false);
+        coord_t base_width = scaled<coord_t>(0.4);
+
+        // Create a line with 4 points forming a square path
+        ext_line.junctions.emplace_back(Point(0, 0), base_width, 0);
+        ext_line.junctions.emplace_back(Point(scaled<coord_t>(10.0), 0), base_width, 0);
+        ext_line.junctions.emplace_back(Point(scaled<coord_t>(10.0), scaled<coord_t>(10.0)), base_width, 0);
+        ext_line.junctions.emplace_back(Point(0, scaled<coord_t>(10.0)), base_width, 0);
+
+        size_t original_count = ext_line.junctions.size();
+
+        WHEN("Displacement mode is used") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Displacement,
+                NoiseType::Classic
+            );
+
+            Arachne::ExtrusionLine fuzzified = ext_line;
+            fuzzy_extrusion_line(fuzzified, 1.0, config);
+
+            THEN("extrusion line has more junctions") {
+                REQUIRE(fuzzified.junctions.size() > original_count);
+            }
+
+            THEN("junction widths remain unchanged") {
+                // In displacement mode, widths should stay close to original
+                for (const auto &junction : fuzzified.junctions) {
+                    // Allow small tolerance for rounding
+                    REQUIRE(junction.w == base_width);
+                }
+            }
+        }
+
+        WHEN("Extrusion mode is used") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Extrusion,
+                NoiseType::Classic
+            );
+
+            Arachne::ExtrusionLine fuzzified = ext_line;
+            fuzzy_extrusion_line(fuzzified, 1.0, config);
+
+            THEN("extrusion line has more junctions") {
+                REQUIRE(fuzzified.junctions.size() > original_count);
+            }
+
+            THEN("junction widths vary") {
+                bool has_width_variation = false;
+                for (const auto &junction : fuzzified.junctions) {
+                    if (junction.w != base_width) {
+                        has_width_variation = true;
+                        break;
+                    }
+                }
+                REQUIRE(has_width_variation);
+            }
+        }
+
+        WHEN("Combined mode is used") {
+            PrintRegionConfig config = make_fuzzy_config(
+                FuzzySkinType::External,
+                FuzzySkinMode::Combined,
+                NoiseType::Classic
+            );
+
+            Arachne::ExtrusionLine fuzzified = ext_line;
+            fuzzy_extrusion_line(fuzzified, 1.0, config);
+
+            THEN("extrusion line has more junctions") {
+                REQUIRE(fuzzified.junctions.size() > original_count);
+            }
+
+            THEN("junction widths vary (combined has both displacement and width variation)") {
+                bool has_width_variation = false;
+                for (const auto &junction : fuzzified.junctions) {
+                    if (junction.w != base_width) {
+                        has_width_variation = true;
+                        break;
+                    }
+                }
+                REQUIRE(has_width_variation);
+            }
+        }
+    }
+}
+
+SCENARIO("Coherent noise produces consistent patterns", "[FuzzySkin]")
+{
+    GIVEN("the same polygon fuzzified twice at the same Z height with Perlin noise") {
+        Polygon square1 = make_square(scaled<coord_t>(10.0));
+        Polygon square2 = make_square(scaled<coord_t>(10.0));
+
+        PrintRegionConfig config = make_fuzzy_config(
+            FuzzySkinType::External,
+            FuzzySkinMode::Displacement,
+            NoiseType::Perlin,
+            0.3,  // thickness
+            0.8,  // point_dist
+            false,
+            2.0   // scale
+        );
+
+        // Note: Due to the random point spacing, the exact points won't match,
+        // but the noise values at the same coordinates should be the same.
+        // This test verifies that the noise module is being used correctly.
+
+        fuzzy_polygon(square1, 1.0, config);
+        fuzzy_polygon(square2, 1.0, config);
+
+        THEN("both polygons have been modified") {
+            REQUIRE(square1.points.size() > 4);
+            REQUIRE(square2.points.size() > 4);
+        }
+    }
+
+    GIVEN("polygons at different Z heights with coherent noise") {
+        PrintRegionConfig config = make_fuzzy_config(
+            FuzzySkinType::External,
+            FuzzySkinMode::Displacement,
+            NoiseType::Perlin,
+            0.3,
+            0.8,
+            false,
+            2.0
+        );
+
+        Polygon square_z1 = make_square(scaled<coord_t>(10.0));
+        Polygon square_z2 = make_square(scaled<coord_t>(10.0));
+
+        fuzzy_polygon(square_z1, 1.0, config);  // Z = 1.0
+        fuzzy_polygon(square_z2, 2.0, config);  // Z = 2.0
+
+        THEN("both are valid polygons") {
+            REQUIRE(square_z1.points.size() >= 3);
+            REQUIRE(square_z2.points.size() >= 3);
+        }
+    }
+}
+
+SCENARIO("apply_fuzzy_skin with empty perimeter regions", "[FuzzySkin]")
+{
+    GIVEN("a polygon with empty perimeter regions") {
+        Polygon square = make_square(scaled<coord_t>(10.0));
+        PerimeterRegions empty_regions;
+
+        PrintRegionConfig config = make_fuzzy_config(FuzzySkinType::External);
+
+        WHEN("should_fuzzify returns true") {
+            Polygon result = apply_fuzzy_skin(square, config, empty_regions, 1, 1.0, 0, true);
+
+            THEN("polygon is fuzzified") {
+                REQUIRE(result.points.size() > square.points.size());
+            }
+        }
+
+        WHEN("should_fuzzify returns false (inner perimeter)") {
+            Polygon result = apply_fuzzy_skin(square, config, empty_regions, 1, 1.0, 1, true);
+
+            THEN("polygon is unchanged") {
+                REQUIRE(result.points.size() == square.points.size());
+            }
+        }
+    }
+}
+
+SCENARIO("Full slice with fuzzy skin enabled", "[FuzzySkin][Integration]")
+{
+    GIVEN("A cube with fuzzy skin external") {
+        auto config = Slic3r::DynamicPrintConfig::full_print_config_with({
+            { "fuzzy_skin",             "external" },
+            { "fuzzy_skin_thickness",   0.3 },
+            { "fuzzy_skin_point_dist",  0.8 },
+            { "perimeters",             2 },
+            { "layer_height",           0.2 },
+            { "first_layer_height",     0.2 },
+            { "fill_density",           0 },
+            { "top_solid_layers",       0 },
+            { "bottom_solid_layers",    1 }
+        });
+
+        std::string gcode = Slic3r::Test::slice({ Slic3r::Test::TestMesh::cube_20x20x20 }, config);
+
+        THEN("G-code is generated successfully") {
+            REQUIRE(!gcode.empty());
+        }
+    }
+
+    GIVEN("A cube with fuzzy skin all") {
+        auto config = Slic3r::DynamicPrintConfig::full_print_config_with({
+            { "fuzzy_skin",             "all" },
+            { "fuzzy_skin_thickness",   0.3 },
+            { "fuzzy_skin_point_dist",  0.8 },
+            { "perimeters",             2 },
+            { "layer_height",           0.2 },
+            { "first_layer_height",     0.2 },
+            { "fill_density",           0 },
+            { "top_solid_layers",       0 },
+            { "bottom_solid_layers",    1 }
+        });
+
+        std::string gcode = Slic3r::Test::slice({ Slic3r::Test::TestMesh::cube_20x20x20 }, config);
+
+        THEN("G-code is generated successfully") {
+            REQUIRE(!gcode.empty());
+        }
+    }
+
+    GIVEN("A cube with fuzzy skin allwalls") {
+        auto config = Slic3r::DynamicPrintConfig::full_print_config_with({
+            { "fuzzy_skin",             "allwalls" },
+            { "fuzzy_skin_thickness",   0.3 },
+            { "fuzzy_skin_point_dist",  0.8 },
+            { "perimeters",             3 },
+            { "layer_height",           0.2 },
+            { "first_layer_height",     0.2 },
+            { "fill_density",           0 },
+            { "top_solid_layers",       0 },
+            { "bottom_solid_layers",    1 }
+        });
+
+        std::string gcode = Slic3r::Test::slice({ Slic3r::Test::TestMesh::cube_20x20x20 }, config);
+
+        THEN("G-code is generated successfully") {
+            REQUIRE(!gcode.empty());
+        }
+    }
+
+    GIVEN("A cube with Perlin noise fuzzy skin") {
+        auto config = Slic3r::DynamicPrintConfig::full_print_config_with({
+            { "fuzzy_skin",             "external" },
+            { "fuzzy_skin_noise_type",  "perlin" },
+            { "fuzzy_skin_thickness",   0.3 },
+            { "fuzzy_skin_point_dist",  0.8 },
+            { "fuzzy_skin_scale",       2.0 },
+            { "fuzzy_skin_octaves",     4 },
+            { "fuzzy_skin_persistence", 0.5 },
+            { "perimeters",             2 },
+            { "layer_height",           0.2 },
+            { "first_layer_height",     0.2 },
+            { "fill_density",           0 },
+            { "top_solid_layers",       0 },
+            { "bottom_solid_layers",    1 }
+        });
+
+        std::string gcode = Slic3r::Test::slice({ Slic3r::Test::TestMesh::cube_20x20x20 }, config);
+
+        THEN("G-code is generated successfully") {
+            REQUIRE(!gcode.empty());
+        }
+    }
+
+    GIVEN("A cube with first layer fuzzy skin enabled") {
+        auto config = Slic3r::DynamicPrintConfig::full_print_config_with({
+            { "fuzzy_skin",             "external" },
+            { "fuzzy_skin_first_layer", true },
+            { "fuzzy_skin_thickness",   0.3 },
+            { "fuzzy_skin_point_dist",  0.8 },
+            { "perimeters",             2 },
+            { "layer_height",           0.2 },
+            { "first_layer_height",     0.2 },
+            { "fill_density",           0 },
+            { "top_solid_layers",       0 },
+            { "bottom_solid_layers",    1 }
+        });
+
+        std::string gcode = Slic3r::Test::slice({ Slic3r::Test::TestMesh::cube_20x20x20 }, config);
+
+        THEN("G-code is generated successfully") {
+            REQUIRE(!gcode.empty());
+        }
+    }
+}

--- a/tests/fff_print/test_perimeters.cpp
+++ b/tests/fff_print/test_perimeters.cpp
@@ -50,6 +50,7 @@ SCENARIO("Perimeter nesting", "[Perimeters]")
         PerimeterGenerator::Parameters perimeter_generator_params(
             1., // layer height
             -1, // layer ID
+            0., // slice_z
             flow, flow, flow, flow,
             static_cast<const PrintRegionConfig&>(config),
             static_cast<const PrintObjectConfig&>(config),


### PR DESCRIPTION


Port OrcaSlicer's enhanced fuzzy skin implementation adding:

New noise types:

    Perlin: smooth, natural-looking patterns
    Billow: cloud-like billowy patterns
    RidgedMulti: sharp ridge patterns
    Voronoi: cell-like patterns
    Classic: original random behavior (default)

New modes:

    Displacement: offset points perpendicular to wall (original)
    Extrusion: vary extrusion width (requires Arachne)
    Combined: both displacement and width variation

New options:

    AllWalls fuzzy skin type: fuzzify internal perimeters too
    First-layer toggle: control bed adhesion vs aesthetics
    Noise scale, octaves, persistence parameters

Implementation:

    Vendor libnoise library via deps/ system (LGPL-2.1+)
    Add slice_z to PerimeterGenerator for 3D noise sampling
    GUI shows/hides options based on relevance
    Arachne compatibility check for width-varying modes

<img width="525" height="270" alt="Screenshot 2026-02-09 at 11 30 30 AM" src="https://github.com/user-attachments/assets/5afd0fec-3d6b-45ae-a019-d41187352c41" />
<img width="1133" height="815" alt="Screenshot 2026-02-09 at 11 32 42 AM" src="https://github.com/user-attachments/assets/7b3a02fc-8ec4-440f-972b-a16fab0407e0" />
