### PR TITLE
Fix segfault in --merge CLI command (#14548)

### DIFF
--- a/src/CLI/ProcessTransform.cpp
+++ b/src/CLI/ProcessTransform.cpp
@@ -48,7 +48,7 @@ bool process_transform(Data& cli, const DynamicPrintConfig& print_config, std::v
             for (ModelObject* o : model.objects)
                 m.add_object(*o);
         // Rearrange instances unless --dont-arrange is supplied
-        if (!transform.has("dont_arrange") && !transform.opt_bool("dont_arrange")) {
+        if (!transform.has("dont_arrange") || !transform.opt_bool("dont_arrange")) {
             m.add_default_instances();
             if (actions.has("slice"))
                 arrange_objects(m, bed, arrange_cfg);


### PR DESCRIPTION
## Summary                                                                                                                                      
   
Running `PrusaSlicer --merge model.stl` results in a segmentation fault. The root cause is an unsafe access to the `dont_arrange`  option - calling `transform.opt_bool("dont_arrange")` when the option hasn't been set causes the crash. 

## Changes

- Added safety check before accessing the `dont_arrange` option
  - _If the transform does not have `dont_arrange`, we'll skip checking the `dont_arrange` option since this causes crash_

## Testing

- ✅ `~/Projects/prusa-slicer/build/src/PrusaSlicer --merge /tmp/3DBenchy.stl /tmp/3DBenchy.stl --export-stl --output /tmp/merged.stl`, verify no crash occurs and output contains merged models which have been arranged
<img width="2048" height="1628" alt="merged-arrange stl" src="https://github.com/user-attachments/assets/ea7730f3-2e1a-4692-80cd-40496d5f83e2" />
#
- ✅ `~/Projects/prusa-slicer/build/src/PrusaSlicer --merge /tmp/3DBenchy.stl /tmp/3DBenchy.stl --export-stl --output /tmp/merged.stl --dont-arrange`, verify no crash occurs and output contains merged models which have **not** been arranged
<img width="2048" height="1628" alt="merged-dont-arrange stl" src="https://github.com/user-attachments/assets/e0b63cd4-d57c-4745-9659-5e510f03ed2b" />

## Issue

- https://github.com/prusa3d/PrusaSlicer/issues/14548