### PR TITLE
Skip finding binary location when SLIC3R_FHS is enabled

### DIFF
--- a/src/CLI/Setup.cpp
+++ b/src/CLI/Setup.cpp
@@ -272,9 +272,11 @@ static bool setup_common()
     }
 #endif
 
+#ifndef SLIC3R_FHS
     // See Invoking prusa-slicer from $PATH environment variable crashes #5542
     // boost::filesystem::path path_to_binary = boost::filesystem::system_complete(argv[0]);
     boost::filesystem::path path_to_binary = boost::dll::program_location();
+#endif
 
     // Path from the Slic3r binary to its resources.
 #ifdef __APPLE__


### PR DESCRIPTION
The path_to_binary variable is not used when SLIC3R_FHS is enabled, so this its declaration can be skipped.

This eliminates an unnecessary call to `boost::dll::program_location()`.