### PR TITLE
Fix missing include when building on OpenBSD

### DIFF
--- a/bundled_deps/avrdude/avrdude/libavrdude.h
+++ b/bundled_deps/avrdude/avrdude/libavrdude.h
@@ -950,6 +950,8 @@ int read_config_builtin();
 // Header file for alloca()
 #if defined(WIN32NATIVE)
 #  include <malloc.h>
+#elif defined(__OpenBSD__)
+#  include <stdlib.h>
 #else
 #  include <alloca.h>
 #endif


### PR DESCRIPTION
On OpenBSD, alloca() is defined in stdlib.h. Hence, it needs to be included when building on that platform.