### PR TITLE
Make gcode easier to open in text editors on mac

### DIFF
--- a/src/platform/osx/Info.plist.in
+++ b/src/platform/osx/Info.plist.in
@@ -22,6 +22,28 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>@SLIC3R_BUILD_ID@</string>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>com.prusa3d.gcode</string>
+      <key>UTTypeDescription</key>
+      <string>G-code File</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.plain-text</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>gcode</string>
+        </array>
+        <key>public.mime-type</key>
+        <string>text/x-gcode</string>
+      </dict>
+    </dict>
+  </array>
   <key>CFBundleDocumentTypes</key>
   <array>
     <dict>
@@ -93,21 +115,18 @@
       <string>Alternate</string>
     </dict>
     <dict>
-      <key>CFBundleTypeExtensions</key>
-      <array>
-        <string>gcode</string>
-        <string>GCODE</string>
-      </array>
       <key>CFBundleTypeIconFile</key>
       <string>gcode.icns</string>
       <key>CFBundleTypeName</key>
       <string>GCODE</string>
       <key>CFBundleTypeRole</key>
       <string>Viewer</string>
-      <key>LISsAppleDefaultForType</key>
-      <true/>
       <key>LSHandlerRank</key>
       <string>Alternate</string>
+      <key>LSItemContentTypes</key>
+        <array>
+          <string>com.prusa3d.gcode</string>
+        </array>
     </dict>
     <dict>
       <key>CFBundleTypeExtensions</key>


### PR DESCRIPTION
This change updates how gcode files are registered with macOS. It creates a UTI for gcode that associates the .gcode file extension and inherits from the plain-text type. This means text editors will be suggested as applications that can open gcode files (on macOS) when right clicking and choosing "Open With".

Note that this still makes it so that Prusaslicer is registered as the default application for opening gcode files (by default).

I went to look into this because it was frustrating that whenever I want to open a gcode file in my editor it seems to take more steps than it should. This is because there was no connection to gcode being a text file to macOS. It treated it as something completely unique that couldn't be opened by anything other than Prusaslicer.