### PR TITLE
fix: Address nesting regression in auto arrange after 2.9.0

### DIFF
--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -2436,10 +2436,7 @@ Polygons project_mesh(
     std::vector<Polygons> top, bottom;
     std::vector<float>    zs { -1e10, 1e10 };
     slice_mesh_slabs(mesh, zs, trafo, &top, &bottom, throw_on_cancel);
-
-    // We typically perform a union operation on a lot of overlapping polygons, which can be slow in some cases.
-    // To address this, we use parallel reduction, which can be significantly faster in such cases.
-    return union_(union_parallel_reduce(top.front()), union_parallel_reduce(bottom.back()));
+    return union_(top.front(), bottom.back());
 }
 
 void cut_mesh(const indexed_triangle_set &mesh, float z, indexed_triangle_set *upper, indexed_triangle_set *lower, bool triangulate_caps)


### PR DESCRIPTION
Reverts calling union_parallel_reduce() in project_mesh(), going back
to union_(top, bottom).

The parallel reduction splits polygons into chunks and merges them
pairwise. The problem is that _clipper() uses pftNonZero throughout, so
when partial results containing holes get merged, pftNonZero fills them
in. By the time all chunks are combined the holes are gone.

This matters because project_mesh() feeds the 2D footprint to the NFP
arrange engine, which finds valid nesting positions by looking for
clockwise hole polygons after the union. No holes means no nesting
positions, so objects that should fit inside concave regions get placed
beside them instead.

Parallelizing this correctly would need union_ to use pftEvenOdd, which
has broader implications and should be tackled separately.

Closes #14202
