### PR TITLE
[Feature] Top layer Fan controls

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3145,8 +3145,31 @@ std::string GCodeGenerator::extrude_infill_ranges(
     for (const InfillRange &infill_range : infill_ranges) {
         if (!infill_range.items.empty()) {
             this->m_config.apply(infill_range.region->config());
+
+            // Check if this infill range contains top solid infill, we should be able to piggy back of that to find
+            // "top" infill. This is how i saw fan speeds set above...so it should work fine.
+            //  is this a bit of a hack? maybe. does it work? sorta. but top solid infill is only the top most
+            // layer of the infill range. Need to check with Super slicer if this is how they do theirs.
+            bool has_top_layer = false;
+            for (const GCode::SmoothPath &path : infill_range.items) {
+                if (!path.empty() && path.front().path_attributes.role == ExtrusionRole::TopSolidInfill) {
+                    has_top_layer = true;
+                    break;
+                }
+            }
+
+            // Add top layer fan disable marker if this is a top layer
+            if (has_top_layer) {
+                gcode += ";_TOP_LAYER_FAN_START\n";
+            }
+
             for (const GCode::SmoothPath &path : infill_range.items) {
                 gcode += this->extrude_smooth_path(path, false, comment, -1.0);
+            }
+
+            // Add top layer fan restore marker
+            if (has_top_layer) {
+                gcode += ";_TOP_LAYER_FAN_END\n";
             }
         }
     }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -17,6 +17,7 @@
 ///|/ Copyright (c) 2013 Robert Giseburt
 ///|/ Copyright (c) 2012 Mark Hindess
 ///|/ Copyright (c) 2012 Henrik Brix Andersen @henrikbrixandersen
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -5,6 +5,7 @@
 ///|/ Copyright (c) Prusa Research 2016 - 2017 Vojtěch Bubník @bubnikv
 ///|/ Copyright (c) Slic3r 2013 - 2016 Alessandro Ranellucci @alranel
 ///|/ Copyright (c) 2016 Chow Loong Jin @hyperair
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1132,14 +1132,15 @@ std::string CoolingBuffer::apply_layer_cooldown(
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
     int  bridge_fan_speed   = 0;
-    bool top_layer_fan_disable = false; // using boolean value here, but will get from GUI later on
-    auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_layer_fan_disable](const int requested_fan_speed = -1) {
+    int top_fan_speed = 0;  // fan speed now a % based, similar to super slicer
+    auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_fan_speed](const int requested_fan_speed = -1) {
 #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         const int min_fan_speed            = EXTRUDER_CONFIG(min_fan_speed);
         // Is the fan speed ramp enabled?
         const int full_fan_speed_layer     = EXTRUDER_CONFIG(full_fan_speed_layer);
         int       disable_fan_first_layers = EXTRUDER_CONFIG(disable_fan_first_layers);
         int       fan_speed_new            = EXTRUDER_CONFIG(fan_always_on) ? min_fan_speed : 0;
+        int top_fan_speed = EXTRUDER_CONFIG(top_fan_speed) ? : 100; // the else should not be needed...but incase.
 
         struct FanSpeedRange
         {
@@ -1190,14 +1191,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
             bridge_fan_speed                     = 0;
             fan_speed_new                        = 0;
             requested_fan_speed_limits.max_speed = 0;
-        }
-
-        // Disable fan for top layers
-        if (top_layer_fan_disable) {
-            bridge_fan_control                   = false;
-            bridge_fan_speed                     = 0;
-            fan_speed_new                        = 0;
-            requested_fan_speed_limits.max_speed = 0;
+            top_fan_speed                        = 0;
         }
 
         requested_fan_speed_limits.min_speed = std::min(requested_fan_speed_limits.min_speed, requested_fan_speed_limits.max_speed);
@@ -1291,21 +1285,19 @@ std::string CoolingBuffer::apply_layer_cooldown(
         } else if (line->type & CoolingLine::TYPE_RESET_FAN_SPEED){
             change_extruder_set_fan();
         } else if (line->type & CoolingLine::TYPE_TOP_LAYER_FAN_START) {
-            top_layer_fan_disable = true;
-            // Disable the fan immediately
+           //set fan speed to top_fan_speed
             if (m_fan_speed != 0) {
-                m_fan_speed = 0;
+                m_fan_speed = top_fan_speed;
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, 0);
             }
         } else if (line->type & CoolingLine::TYPE_TOP_LAYER_FAN_END) {
-            top_layer_fan_disable = false;
             // Restore fan to calculated speed
             change_extruder_set_fan();
         } else if (line->type & CoolingLine::TYPE_BRIDGE_FAN_START) {
-            if (bridge_fan_control && !top_layer_fan_disable)
+            if (bridge_fan_control)
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, bridge_fan_speed);
         } else if (line->type & CoolingLine::TYPE_BRIDGE_FAN_END) {
-            if (bridge_fan_control && !top_layer_fan_disable)
+            if (bridge_fan_control)
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, m_fan_speed);
         } else if (line->type & CoolingLine::TYPE_EXTRUDE_END) {
             // Just remove this comment.

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -120,6 +120,9 @@ struct CoolingLine
         TYPE_RESET_FAN_SPEED    = 1 << 18,
         TYPE_INTERNAL_PERIMETER = 1 << 19,
         TYPE_FIRST_INTERNAL_PERIMETER = 1 << 20,
+        // Top layer fan disable
+        TYPE_TOP_LAYER_FAN_START = 1 << 21,
+        TYPE_TOP_LAYER_FAN_END   = 1 << 22,
     };
 
     CoolingLine(unsigned int type, size_t  line_start, size_t  line_end) :
@@ -837,6 +840,10 @@ std::vector<PerExtruderAdjustments> CoolingBuffer::parse_layer_gcode(const std::
             line.type = CoolingLine::TYPE_BRIDGE_FAN_START;
         } else if (boost::starts_with(sline, ";_BRIDGE_FAN_END")) {
             line.type = CoolingLine::TYPE_BRIDGE_FAN_END;
+        } else if (boost::starts_with(sline, ";_TOP_LAYER_FAN_START")) {
+            line.type = CoolingLine::TYPE_TOP_LAYER_FAN_START;
+        } else if (boost::starts_with(sline, ";_TOP_LAYER_FAN_END")) {
+            line.type = CoolingLine::TYPE_TOP_LAYER_FAN_END;
         } else if (boost::starts_with(sline, "G4 ")) {
             // Parse the wait time.
             line.type = CoolingLine::TYPE_G4;
@@ -1125,7 +1132,8 @@ std::string CoolingBuffer::apply_layer_cooldown(
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
     int  bridge_fan_speed   = 0;
-    auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed](const int requested_fan_speed = -1) {
+    bool top_layer_fan_disable = false;
+    auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_layer_fan_disable](const int requested_fan_speed = -1) {
 #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         const int min_fan_speed            = EXTRUDER_CONFIG(min_fan_speed);
         // Is the fan speed ramp enabled?
@@ -1178,6 +1186,14 @@ std::string CoolingBuffer::apply_layer_cooldown(
 #undef EXTRUDER_CONFIG
             bridge_fan_control = bridge_fan_speed > fan_speed_new;
         } else { // fan disabled
+            bridge_fan_control                   = false;
+            bridge_fan_speed                     = 0;
+            fan_speed_new                        = 0;
+            requested_fan_speed_limits.max_speed = 0;
+        }
+
+        // Disable fan for top layers
+        if (top_layer_fan_disable) {
             bridge_fan_control                   = false;
             bridge_fan_speed                     = 0;
             fan_speed_new                        = 0;
@@ -1274,11 +1290,22 @@ std::string CoolingBuffer::apply_layer_cooldown(
             change_extruder_set_fan(line->fan_speed);
         } else if (line->type & CoolingLine::TYPE_RESET_FAN_SPEED){
             change_extruder_set_fan();
+        } else if (line->type & CoolingLine::TYPE_TOP_LAYER_FAN_START) {
+            top_layer_fan_disable = true;
+            // Disable the fan immediately
+            if (m_fan_speed != 0) {
+                m_fan_speed = 0;
+                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, 0);
+            }
+        } else if (line->type & CoolingLine::TYPE_TOP_LAYER_FAN_END) {
+            top_layer_fan_disable = false;
+            // Restore fan to calculated speed
+            change_extruder_set_fan();
         } else if (line->type & CoolingLine::TYPE_BRIDGE_FAN_START) {
-            if (bridge_fan_control)
+            if (bridge_fan_control && !top_layer_fan_disable)
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, bridge_fan_speed);
         } else if (line->type & CoolingLine::TYPE_BRIDGE_FAN_END) {
-            if (bridge_fan_control)
+            if (bridge_fan_control && !top_layer_fan_disable)
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, m_fan_speed);
         } else if (line->type & CoolingLine::TYPE_EXTRUDE_END) {
             // Just remove this comment.

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1131,8 +1131,9 @@ std::string CoolingBuffer::apply_layer_cooldown(
     std::string new_gcode;
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
+    bool top_fan_control = false;
     int  bridge_fan_speed   = 0;
-    int top_fan_speed = 0;  // fan speed now a % based, similar to super slicer
+    int top_fan_speed = 100;  // fan speed now a % based, similar to super slicer
     auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_fan_speed](const int requested_fan_speed = -1) {
 #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         const int min_fan_speed            = EXTRUDER_CONFIG(min_fan_speed);
@@ -1288,7 +1289,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
            //set fan speed to top_fan_speed
             if (m_fan_speed != 0) {
                 m_fan_speed = top_fan_speed;
-                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, 0);
+                new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_config.gcode_comments, m_fan_speed);
             }
         } else if (line->type & CoolingLine::TYPE_TOP_LAYER_FAN_END) {
             // Restore fan to calculated speed

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1129,19 +1129,19 @@ std::string CoolingBuffer::apply_layer_cooldown(
     }
     // Second generate the adjusted G-code.
     std::string new_gcode;
+    #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
     bool top_fan_control = false;
     int  bridge_fan_speed   = 0;
-    int top_fan_speed = 100;  // fan speed now a % based, similar to super slicer
+    int top_fan_speed = EXTRUDER_CONFIG(top_fan_speed);  // fan speed now a % based, similar to super slicer
     auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_fan_speed](const int requested_fan_speed = -1) {
-#define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         const int min_fan_speed            = EXTRUDER_CONFIG(min_fan_speed);
         // Is the fan speed ramp enabled?
         const int full_fan_speed_layer     = EXTRUDER_CONFIG(full_fan_speed_layer);
         int       disable_fan_first_layers = EXTRUDER_CONFIG(disable_fan_first_layers);
         int       fan_speed_new            = EXTRUDER_CONFIG(fan_always_on) ? min_fan_speed : 0;
-        int top_fan_speed = EXTRUDER_CONFIG(top_fan_speed) ? : 100; // the else should not be needed...but incase.
+        int top_fan_speed                  = EXTRUDER_CONFIG(top_fan_speed) ? : 100; // the else should not be needed...but incase.
 
         struct FanSpeedRange
         {
@@ -1176,6 +1176,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
             }
 
             bridge_fan_speed = EXTRUDER_CONFIG(bridge_fan_speed);
+            top_fan_speed    = EXTRUDER_CONFIG(top_fan_speed);
             if (int(layer_id) >= disable_fan_first_layers && int(layer_id) + 1 < full_fan_speed_layer) {
                 // Ramp up the fan speed from disable_fan_first_layers to full_fan_speed_layer.
                 const float factor = float(int(layer_id + 1) - disable_fan_first_layers) / float(full_fan_speed_layer - disable_fan_first_layers);

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1133,7 +1133,6 @@ std::string CoolingBuffer::apply_layer_cooldown(
     #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
-    bool top_fan_control = false;
     int  bridge_fan_speed   = 0;
     int top_fan_speed = EXTRUDER_CONFIG(top_fan_speed);  // fan speed now a % based, similar to super slicer
     auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_fan_speed](const int requested_fan_speed = -1) {

--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -1132,7 +1132,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
     new_gcode.reserve(gcode.size() * 2);
     bool bridge_fan_control = false;
     int  bridge_fan_speed   = 0;
-    bool top_layer_fan_disable = false;
+    bool top_layer_fan_disable = false; // using boolean value here, but will get from GUI later on
     auto change_extruder_set_fan = [this, layer_id, layer_time, &new_gcode, &bridge_fan_control, &bridge_fan_speed, &top_layer_fan_disable](const int requested_fan_speed = -1) {
 #define EXTRUDER_CONFIG(OPT) m_config.OPT.get_at(m_current_extruder)
         const int min_fan_speed            = EXTRUDER_CONFIG(min_fan_speed);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -3,6 +3,7 @@
 ///|/ Copyright (c) 2021 Ilya @xorza
 ///|/ Copyright (c) 2019 John Drake @foxox
 ///|/ Copyright (c) 2018 Martin Loidl @LoidlM
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -522,7 +522,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_cooling_initial_speed", "filament_purge_multiplier", "filament_cooling_final_speed", "filament_ramming_parameters", "filament_minimal_purge_on_wipe_tower",
     "filament_multitool_ramming", "filament_multitool_ramming_volume", "filament_multitool_ramming_flow", 
     "temperature", "idle_temperature", "first_layer_temperature", "bed_temperature", "first_layer_bed_temperature", "fan_always_on", "cooling", "cooling_slowdown_logic",
-    "cooling_perimeter_transition_distance", "min_fan_speed",
+    "cooling_perimeter_transition_distance", "min_fan_speed", "top_fan_speed",
     "max_fan_speed", "bridge_fan_speed", "disable_fan_first_layers", "full_fan_speed_layer", "fan_below_layer_time", "slowdown_below_layer_time", "min_print_speed",
     "custom_parameters_filament", "start_filament_gcode", "end_filament_gcode", "enable_dynamic_fan_speeds", "chamber_temperature", "chamber_minimal_temperature",
     "overhang_fan_speed_0", "overhang_fan_speed_1", "overhang_fan_speed_2", "overhang_fan_speed_3",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -178,6 +178,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "custom_parameters_printer",
         "toolchange_gcode",
         "top_solid_infill_acceleration",
+        "top_fan_speed",
         "travel_acceleration",
         "travel_short_distance_acceleration",
         "thumbnails",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -17,6 +17,7 @@
 ///|/ Copyright (c) 2012 Henrik Brix Andersen @henrikbrixandersen
 ///|/ Copyright (c) 2012 Michael Moon
 ///|/ Copyright (c) 2011 Richard Goodwin
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1720,7 +1720,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->max = 100;
     def->mode = comExpert;
-    def->set_default_value(new ConfigOptionInts { 25 });
+    def->set_default_value(new ConfigOptionInts { 100 });
 
     def = this->add("fuzzy_skin", coEnum);
     def->label = L("Fuzzy Skin");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1711,6 +1711,16 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionInts { 0 });
 
+    // Pretty much from super slicer
+    def = this->add("top_fan_speed", coInts);
+    def->label = L("Top fan speed");
+    def->tooltip = L("This fan speed is enforced during top infill layers. Set to 0 to disable.");
+    def->sidetext = L("%");
+    def->min = 0;
+    def->max = 100;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionInts { 100 });
+
     def = this->add("fuzzy_skin", coEnum);
     def->label = L("Fuzzy Skin");
     def->category = L("Fuzzy Skin");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1719,7 +1719,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->max = 100;
     def->mode = comExpert;
-    def->set_default_value(new ConfigOptionInts { 100 });
+    def->set_default_value(new ConfigOptionInts { 25 });
 
     def = this->add("fuzzy_skin", coEnum);
     def->label = L("Fuzzy Skin");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -16,6 +16,7 @@
 ///|/ Copyright (c) 2016 Vanessa Ezekowitz @VanessaE
 ///|/ Copyright (c) 2015 Alexander Rössler @machinekoder
 ///|/ Copyright (c) 2014 Petr Ledvina @ledvinap
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -930,6 +930,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionInts,               bed_temperature))
     ((ConfigOptionFloat,              bridge_acceleration))
     ((ConfigOptionInts,               bridge_fan_speed))
+    ((ConfigOptionInts,               top_fan_speed))
     ((ConfigOptionBools,              enable_dynamic_fan_speeds))
     ((ConfigOptionInts,               overhang_fan_speed_0))
     ((ConfigOptionInts,               overhang_fan_speed_1))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -12,6 +12,7 @@
 ///|/ Copyright (c) Slic3r 2013 - 2015 Alessandro Ranellucci @alranel
 ///|/ Copyright (c) 2015 Maksim Derbasov @ntfshard
 ///|/ Copyright (c) 2015 Alexander Rössler @machinekoder
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -1,5 +1,6 @@
 ///|/ Copyright (c) Prusa Research 2017 - 2023 Oleksandra Iushchenko @YuSanka, Pavel Mikuš @Godrak, Lukáš Matěna @lukasmatena, Vojtěch Bubník @bubnikv
 ///|/ Copyright (c) 2021 Ilya @xorza
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -124,6 +124,8 @@ std::string PresetHints::maximum_volumetric_flow_description(const PresetBundle 
     const auto &support_material_extrusion_width    = *print_config.option<ConfigOptionFloatOrPercent>("support_material_extrusion_width");
     const auto &top_infill_extrusion_width          = *print_config.option<ConfigOptionFloatOrPercent>("top_infill_extrusion_width");
     const auto &first_layer_speed                   = *print_config.option<ConfigOptionFloatOrPercent>("first_layer_speed");
+    // TOP Fan speed is not yet supported.
+    //const auto &top_infill_fan_speed                = *print_config.option<ConfigOptionFloatOrPercent>("top_infill_fan_speed");
 
     // Index of an extruder assigned to a feature. If set to 0, an active extruder will be used for a multi-material print.
     // If different from idx_extruder, it will not be taken into account for this hint.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -14,6 +14,7 @@
 ///|/ Copyright (c) 2016 Chow Loong Jin @hyperair
 ///|/ Copyright (c) 2012 QuantumConcepts
 ///|/ Copyright (c) 2012 Henrik Brix Andersen @henrikbrixandersen
+///|/ Copyright (c) 2026 Nate Fonseka @nfons
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2270,6 +2270,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("bridge_fan_speed", category_path + "fan-settings");
         optgroup->append_single_option_line("disable_fan_first_layers", category_path + "fan-settings");
         optgroup->append_single_option_line("full_fan_speed_layer", category_path + "fan-settings");
+        //optgroup->append_single_option_line("top_fan_speed", category_path + "fan-settings");
 
         optgroup = page->new_optgroup(L("Dynamic fan speeds"), 25);
         optgroup->append_single_option_line("enable_dynamic_fan_speeds", category_path + "dynamic-fan-speeds");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2270,7 +2270,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("bridge_fan_speed", category_path + "fan-settings");
         optgroup->append_single_option_line("disable_fan_first_layers", category_path + "fan-settings");
         optgroup->append_single_option_line("full_fan_speed_layer", category_path + "fan-settings");
-        //optgroup->append_single_option_line("top_fan_speed", category_path + "fan-settings");
+        optgroup->append_single_option_line("top_fan_speed", category_path + "fan-settings");
 
         optgroup = page->new_optgroup(L("Dynamic fan speeds"), 25);
         optgroup->append_single_option_line("enable_dynamic_fan_speeds", category_path + "dynamic-fan-speeds");

--- a/tests/fff_print/test_cooling.cpp
+++ b/tests/fff_print/test_cooling.cpp
@@ -272,4 +272,107 @@ SCENARIO("Cooling integration tests", "[Cooling]") {
             // ok $external, '';
         }
     }
+
+    WHEN("top_fan_speed is applied") {
+        THEN("fan speed is reduced when entering top layer") {
+            config.set_deserialize_strict({
+                { "cooling",                   "1" },
+                { "fan_below_layer_time",      "60" },
+                { "slowdown_below_layer_time", "5" },
+                { "max_fan_speed",             "100" },
+                { "min_fan_speed",             "50" },
+                { "top_fan_speed",             "25" },
+                { "disable_fan_first_layers",  "0" }
+            });
+
+            GCodeGenerator gcodegen;
+            auto buffer = make_cooling_buffer(gcodegen, config);
+
+            std::string gcode_with_top_fan =
+                "G1 F3000;_EXTRUDE_SET_SPEED\n"
+                "G1 X50 E1\n"
+                ";_TOP_LAYER_FAN_START\n"
+                "G1 X100 E1\n"
+                ";_TOP_LAYER_FAN_END\n"
+                "G1 X150 E1\n";
+
+            std::string processed = buffer->process_layer(gcode_with_top_fan, 1, true);
+
+            // Should contain M106 commands for fan speed changes
+            bool has_fan_changes = processed.find("M106") != processed.npos;
+            REQUIRE(has_fan_changes);
+        }
+    }
+
+    WHEN("top_fan_speed respects fan disabled state") {
+        THEN("fan stays off when disabled in first layers") {
+            config.set_deserialize_strict({
+                { "cooling",                   "1" },
+                { "fan_below_layer_time",      "60" },
+                { "slowdown_below_layer_time", "5" },
+                { "max_fan_speed",             "100" },
+                { "top_fan_speed",             "25" },
+                { "disable_fan_first_layers",  "3" }
+            });
+
+            GCodeGenerator gcodegen;
+            auto buffer = make_cooling_buffer(gcodegen, config);
+
+            std::string gcode_with_top_fan =
+                "G1 F3000;_EXTRUDE_SET_SPEED\n"
+                ";_TOP_LAYER_FAN_START\n"
+                "G1 X50 E1\n"
+                ";_TOP_LAYER_FAN_END\n";
+
+            // Layer 0 should have fan disabled
+            std::string processed = buffer->process_layer(gcode_with_top_fan, 0, true);
+
+            // Should not contain M106 (fan on) when fan is disabled
+            bool fan_off = processed.find("M106") == processed.npos;
+            REQUIRE(fan_off);
+        }
+    }
+
+    // important, as we do not want to disable for 1 object, and then have a taller object also have disabled "top fan" at that layer
+    WHEN("top_fan_speed with multiple top fan sections") {
+        THEN("fan speed is toggled correctly for multiple sections") {
+            config.set_deserialize_strict({
+                { "cooling",                   "1" },
+                { "fan_below_layer_time",      "60" },
+                { "slowdown_below_layer_time", "5" },
+                { "max_fan_speed",             "100" },
+                { "min_fan_speed",             "50" },
+                { "top_fan_speed",             "30" },
+                { "disable_fan_first_layers",  "0" }
+            });
+
+            GCodeGenerator gcodegen;
+            auto buffer = make_cooling_buffer(gcodegen, config);
+
+            std::string gcode_with_multiple_sections =
+                "G1 F3000;_EXTRUDE_SET_SPEED\n"
+                "G1 X10 E1\n"
+                ";_TOP_LAYER_FAN_START\n"
+                "G1 X20 E1\n"
+                ";_TOP_LAYER_FAN_END\n"
+                "G1 X30 E1\n"
+                ";_TOP_LAYER_FAN_START\n"
+                "G1 X40 E1\n"
+                ";_TOP_LAYER_FAN_END\n"
+                "G1 X50 E1\n";
+
+            std::string processed = buffer->process_layer(gcode_with_multiple_sections, 1, true);
+
+            // Count M106 occurrences (should have multiple fan changes)
+            size_t m106_count = 0;
+            size_t pos = 0;
+            while ((pos = processed.find("M106", pos)) != std::string::npos) {
+                m106_count++;
+                pos += 4;
+            }
+
+            // Should have at least 2 fan changes (entering and exiting top sections)
+            REQUIRE(m106_count >= 2);
+        }
+    }
 }


### PR DESCRIPTION
Closes #942 

For certain prints, especially when layer height is large (0.3mm > ) and infils are low, it is better to have no part cooling as the fan will often leave scarring on the top layer see: https://forum.prusa3d.com/forum/original-prusa-i3-mk2-5s-mk2-5-hardware-firmware-and-software-help/part-cooling-on-top-infill-layer-is-causing-ripples/?language=it


Super slicer (@supermerill ) had this feature for a while now, and it essentially eliminates issues like above.. and this is my attempt to replicate it in the latest pursa slicer.

**What it does**

Adds a config to Filament > Fan Settings that will modify fan speed on top layers:

<img width="697" height="229" alt="image" src="https://github.com/user-attachments/assets/8a3be437-00c7-4026-9786-b3e56358c849" />

<img width="973" height="458" alt="image" src="https://github.com/user-attachments/assets/7cda7aa7-8ec1-494b-9fc8-5339421ce954" />

