### PR TITLE
Minor spelling/wording change in font error message

### DIFF
--- a/resources/localization/PrusaSlicer.pot
+++ b/resources/localization/PrusaSlicer.pot
@@ -10179,8 +10179,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, possible-boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/be/PrusaSlicer_be.po
+++ b/resources/localization/be/PrusaSlicer_be.po
@@ -11468,8 +11468,8 @@ msgstr "Заблакаваць вярчэнне тэксту пры руху т�
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Не атрымалася загрузіць сапраўды такі ж шрыфт (\"%1%\").\n"
 "Выбраны падобны (\"%2%\").\n"

--- a/resources/localization/ca/PrusaSlicer_ca.po
+++ b/resources/localization/ca/PrusaSlicer_ca.po
@@ -11428,8 +11428,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "No es pot carregar exactament el mateix tipus de lletra(\"%1%\"), "
 "L'aplicació ha seleccionat un de similar(\"%2%\"). Heu d'especificar el "

--- a/resources/localization/cs/PrusaSlicer_cs.po
+++ b/resources/localization/cs/PrusaSlicer_cs.po
@@ -10103,8 +10103,8 @@ msgstr "Uzamknout natočení textu při pohybu textu po povrchu objektu."
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Nelze načíst přesně stejné písmo(\"%1%\"). Aplikace vybrala podobné "
 "písmo(\"%2%\"). Musíte zadat písmo pro povolení editace textu."

--- a/resources/localization/de/PrusaSlicer_de.po
+++ b/resources/localization/de/PrusaSlicer_de.po
@@ -10369,8 +10369,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Kann nicht genau dieselbe Schriftart (\"%1%\") laden. Die Anwendung hat eine "
 "ähnliche Schriftart ausgewählt (\"%2%\"). Sie müssen die Schriftart angeben, "

--- a/resources/localization/en/PrusaSlicer_en.po
+++ b/resources/localization/en/PrusaSlicer_en.po
@@ -10240,8 +10240,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/es/PrusaSlicer_es.po
+++ b/resources/localization/es/PrusaSlicer_es.po
@@ -10320,8 +10320,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "No se puede cargar exactamente la misma fuente(\"%1%\"). La aplicación "
 "seleccionó una similar(\"%2%\"). Debes especificar la fuente para habilitar "

--- a/resources/localization/fi/PrusaSlicer_fi.po
+++ b/resources/localization/fi/PrusaSlicer_fi.po
@@ -10414,8 +10414,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/fr/PrusaSlicer_fr.po
+++ b/resources/localization/fr/PrusaSlicer_fr.po
@@ -10386,8 +10386,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Impossible de charger exactement la même police (\"%1%\"). L'application en "
 "a sélectionné une similaire (\"%2%\"). Vous devez spécifier la police pour "

--- a/resources/localization/hu/PrusaSlicer_hu.po
+++ b/resources/localization/hu/PrusaSlicer_hu.po
@@ -11107,8 +11107,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/it/PrusaSlicer_it.po
+++ b/resources/localization/it/PrusaSlicer_it.po
@@ -10339,8 +10339,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Non è possibile caricare esattamente lo stesso font(\"%1%\"). L'applicazione "
 "ne ha selezionato uno simile(\"%2%\"). È necessario specificare il font per "

--- a/resources/localization/ja/PrusaSlicer_ja.po
+++ b/resources/localization/ja/PrusaSlicer_ja.po
@@ -10039,8 +10039,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "全く同じフォント(\"%1%\")を読み込むことができません。アプリケーションは似たよ"
 "うなもの(\"%2%\")を選択しました。編集テキストを有効にするには、フォントを指定"

--- a/resources/localization/ko/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko/PrusaSlicer_ko_KR.po
@@ -10631,8 +10631,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/ko_KR/PrusaSlicer_ko.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko.po
@@ -10706,8 +10706,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
+++ b/resources/localization/ko_KR/PrusaSlicer_ko_KR.po
@@ -10706,8 +10706,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/nl/PrusaSlicer_nl.po
+++ b/resources/localization/nl/PrusaSlicer_nl.po
@@ -11085,8 +11085,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/pl/PrusaSlicer_pl.po
+++ b/resources/localization/pl/PrusaSlicer_pl.po
@@ -10211,8 +10211,8 @@ msgstr "Zablokuj obrót tekstu podczas przesuwania go po powierzchni obiektu."
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Nie można załadować dokładnie tej samej czcionki (\"%1%\"). Aplikacja "
 "wybrała podobną (\"%2%\"). Musisz określić czcionkę dla umożliwienia edycji "

--- a/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
+++ b/resources/localization/pt_BR/PrusaSlicer_pt_BR.po
@@ -11135,8 +11135,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/ru/PrusaSlicer_ru.po
+++ b/resources/localization/ru/PrusaSlicer_ru.po
@@ -11811,8 +11811,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Т.к. не удалось загрузить тот же шрифт (\"%1%\"), приложение выбрало похожий "
 "шрифт (\"%2%\"). Выберите шрифт для включения редактирования текста."

--- a/resources/localization/sl/PrusaSlicer.po
+++ b/resources/localization/sl/PrusaSlicer.po
@@ -10244,8 +10244,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/resources/localization/tr/PrusaSlicer_tr.po
+++ b/resources/localization/tr/PrusaSlicer_tr.po
@@ -11152,8 +11152,8 @@ msgstr "Metni kameraya bakacak şekilde ayarla"
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Tam olarak aynı fontu yüklenemiyor (\"%1%\"), uygulama benzer bir yazı tipi "
 "seçti (\"%2%\"). Metni düzenlemeyi etkinleştirmek için yazı tipi belirtmeniz "

--- a/resources/localization/uk/PrusaSlicer_uk.po
+++ b/resources/localization/uk/PrusaSlicer_uk.po
@@ -11882,8 +11882,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "Оскільки не вдалося завантажити той самий шрифт (\"%1%\"), програма вибере "
 "схожий шрифт (\"%2%\"). Виберіть шрифт для ввімкнення редагування тексту."

--- a/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
+++ b/resources/localization/zh_CN/PrusaSlicer_zh_CN.po
@@ -10673,8 +10673,8 @@ msgstr "沿对象曲面移动文本时，锁定文本的旋转。"
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 "不能加载完全相同的字体(\"%1%\")。应用程序选择了一种类似的字体（\"%2%\"）。你"
 "必须为启用编辑文本指定字体。"

--- a/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
+++ b/resources/localization/zh_TW/PrusaSlicer_zh_TW.po
@@ -10643,8 +10643,8 @@ msgstr ""
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3407
 #, boost-format
 msgid ""
-"Can't load exactly same font(\"%1%\"). Aplication selected a similar "
-"one(\"%2%\"). You have to specify font for enable edit text."
+"Can't load exactly same font(\"%1%\"). Application selected a similar "
+"one(\"%2%\"). You have to select a font to enable editing text."
 msgstr ""
 
 #: src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp:3817

--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -3405,8 +3405,8 @@ void GLGizmoEmboss::create_notification_not_valid_font(
     const std::string &face_name = face_name_opt.value_or(face_name_by_wx.value_or(es.path));
     std::string text =
         GUI::format(_L("Can't load exactly same font(\"%1%\"). "
-                       "Aplication selected a similar one(\"%2%\"). "
-                       "You have to specify font for enable edit text."),
+                       "Application selected a similar one(\"%2%\"). "
+                       "You have to specify font to enable editing text."),
                     face_name_3mf, face_name);
     create_notification_not_valid_font(text);
 }


### PR DESCRIPTION
Fix typo. Make message read better in English.