### PR TITLE
chore(docs): missing libtool dep

### DIFF
--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -28,7 +28,8 @@ libglu1-mesa-dev \
 libgtk-3-dev \
 libdbus-1-dev \
 libwebkit2gtk-4.1-dev \
-texinfo
+texinfo \
+libtool
 ```
 The names of the packages may be different on different distros.
 

--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -29,7 +29,8 @@ libgtk-3-dev \
 libdbus-1-dev \
 libwebkit2gtk-4.1-dev \
 texinfo \
-libtool
+libtool \
+librust-hidapi-sys-dev
 ```
 The names of the packages may be different on different distros.
 


### PR DESCRIPTION
Building on Debian 13, missing libtool during `make` in `deps` build