### PR TITLE
Add libtool, libhidapi-dev to linux deps

### DIFF
--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -27,6 +27,7 @@ cmake \
 libglu1-mesa-dev \
 libgtk-3-dev \
 libdbus-1-dev \
+libtool \
 libwebkit2gtk-4.1-dev \
 texinfo
 ```

--- a/doc/How to build - Linux et al.md
+++ b/doc/How to build - Linux et al.md
@@ -27,6 +27,7 @@ cmake \
 libglu1-mesa-dev \
 libgtk-3-dev \
 libdbus-1-dev \
+libhidapi-dev \
 libtool \
 libwebkit2gtk-4.1-dev \
 texinfo


### PR DESCRIPTION
Fixes #15383 by adding `libtool` dependency to `apt install` list.
Also adds `libhidapi-dev` to fix the build of the main package.