### PR TITLE
Fix project not marked dirty when changing per-extruder filament

### DIFF
--- a/src/slic3r/GUI/ProjectDirtyStateManager.cpp
+++ b/src/slic3r/GUI/ProjectDirtyStateManager.cpp
@@ -40,6 +40,13 @@ void ProjectDirtyStateManager::update_from_presets()
         auto type = preset_collection->type();
         m_presets_dirty |= (has_project && !m_initial_presets[type].empty() && m_initial_presets[type] != preset_collection->get_selected_preset_name()) || preset_collection->saved_is_dirty();
     }
+
+    // check for per-extruder filament selection changes
+    m_filament_presets_dirty = false;
+    const auto& efs = app.preset_bundle->extruders_filaments;
+    for (size_t i = 0; i < std::min(efs.size(), m_initial_filament_presets.size()); ++i)
+        m_filament_presets_dirty |= efs[i].get_selected_preset_name() != m_initial_filament_presets[i];
+
     m_project_config_dirty = m_initial_project_config != app.preset_bundle->project_config;
     app.mainframe->update_title();
 }
@@ -61,6 +68,7 @@ void ProjectDirtyStateManager::reset_after_save()
     this->reset_initial_presets();
     m_plater_dirty  = false;
     m_presets_dirty = false;
+    m_filament_presets_dirty = false;
     m_project_config_dirty = false;
     m_custom_gcode_per_print_z_dirty = false;
     wxGetApp().mainframe->update_title();
@@ -72,6 +80,10 @@ void ProjectDirtyStateManager::reset_initial_presets()
     GUI_App &app = wxGetApp();
     for (const PresetCollection *preset_collection : app.get_active_preset_collections())
         m_initial_presets[preset_collection->type()] = preset_collection->get_selected_preset_name();
+    m_initial_filament_presets.clear();
+    for (const auto& ef : app.preset_bundle->extruders_filaments)
+        m_initial_filament_presets.push_back(ef.get_selected_preset_name());
+
     m_initial_project_config = app.preset_bundle->project_config;
     m_initial_custom_gcode_per_print_z = app.model().custom_gcode_per_print_z();
 }

--- a/src/slic3r/GUI/ProjectDirtyStateManager.hpp
+++ b/src/slic3r/GUI/ProjectDirtyStateManager.hpp
@@ -20,7 +20,7 @@ public:
     void reset_after_save();
     void reset_initial_presets();
 
-    bool is_dirty() const { return m_plater_dirty || m_project_config_dirty || m_presets_dirty || m_custom_gcode_per_print_z_dirty; }
+    bool is_dirty() const { return m_plater_dirty || m_project_config_dirty || m_presets_dirty || m_filament_presets_dirty || m_custom_gcode_per_print_z_dirty; }
     bool is_presets_dirty() const { return m_presets_dirty; }
 
 #if ENABLE_PROJECT_DIRTY_STATE_DEBUG_WINDOW
@@ -34,10 +34,14 @@ private:
     bool                                        m_presets_dirty { false };
     // Is the project config dirty?
     bool                                        m_project_config_dirty { false };
+    // Have per-extruder filament selections changed?
+    bool                                        m_filament_presets_dirty { false };
     // Is the custom_gcode_per_print_z dirty?
     bool                                        m_custom_gcode_per_print_z_dirty { false };
     // Keeps track of preset names selected at the time of last project save.
     std::array<std::string, Preset::TYPE_COUNT> m_initial_presets;
+    // Keeps track of per-extruder filament preset names at the time of last project save.
+    std::vector<std::string>                    m_initial_filament_presets;
     DynamicPrintConfig                          m_initial_project_config;
     CustomGCode::Info                           m_initial_custom_gcode_per_print_z;
 };

--- a/src/slic3r/GUI/Sidebar.cpp
+++ b/src/slic3r/GUI/Sidebar.cpp
@@ -789,9 +789,11 @@ void Sidebar::on_select_preset(wxCommandEvent& evt)
             const std::string& old_name = wxGetApp().preset_bundle->filaments.get_edited_preset().name;
                                           wxGetApp().preset_bundle->set_filament_preset(idx, old_name);
         }
-        else
+        else {
             // Synchronize config.ini with the current selections.
             wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
+            m_plater->update_project_dirty_from_presets();
+        }
         combo->update();
     }
     else if (select_preset) {


### PR DESCRIPTION
I have encountered a bug in PrusaSlicer 2.9.4 where changing the filament profile preset, using the sidebar, of a non-active extruder for my Prusa XL T5 does not result in the project being considered dirty/eligible for saving. Modifying the selection via the Filaments tab, or modifying the selection of the "active"/primary extruder, does however result in the expected behavior. This PR adds tracking to the filament selections to improve dirty state detection and correct the bug.

## Technical Changes

ProjectDirtyStateManager only tracked the main PresetCollection's selected filament, which corresponds to the filament tab's active extruder. Changing a filament for any other extruder via the sidebar updated ExtruderFilaments but never triggered update_project_dirty_from_presets(), and even if it had, the dirty check had no visibility into per-extruder selections.

Added m_filament_presets_dirty (separate from m_presets_dirty to avoid broadening its semantics for the close-dialog preset-save gate) and m_initial_filament_presets to track per-extruder filament preset names across save/reset cycles. This triggers the dirty check from the sidebar's else branch, which handles both non-active extruder changes and successful active extruder changes.

For select_present cases which return true, this technically results in a double call to update_project_dirty_from_presets which I have initially ignored to minimize the code changes as the redundant call cost is limited.