### PR TITLE
Add meshseal cross-platform mesh-repair backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,13 @@ if(WIN32)
     endif()
 endif()
 
+# meshseal — option declaration only here; the FetchContent call moves
+# below add_subdirectory(bundled_deps) so PrusaSlicer's own `miniz`
+# target exists before meshseal runs. meshseal v0.1.2+ guards its
+# bundled-dep fetches with `if(NOT TARGET <name>)` and links against
+# the host's miniz instead.
+option(SLIC3R_MESHSEAL "Build with meshseal mesh-repair backend" ON)
+
 if (APPLE)
     message("OS X SDK Path: ${CMAKE_OSX_SYSROOT}")
     if (CMAKE_OSX_DEPLOYMENT_TARGET)
@@ -611,6 +618,33 @@ endfunction()
 
 add_subdirectory(build-utils)
 add_subdirectory(bundled_deps)
+
+# meshseal cross-platform mesh-repair backend.
+# Placed AFTER bundled_deps so PrusaSlicer's bundled `miniz` target
+# already exists; meshseal's `if(NOT TARGET miniz)` guard (v0.1.2+) then
+# skips its own miniz fetch and links against the host one.
+if (SLIC3R_MESHSEAL)
+    include(FetchContent)
+    FetchContent_Declare(meshseal
+        URL      https://github.com/jkavalik/meshseal/archive/refs/tags/v0.1.3.tar.gz
+        URL_HASH SHA256=5bca8b9051a21c6895284cba2cce130127a6bebfa5945af3c35c714efa0e6b4c
+    )
+    # Build meshseal as STATIC so it links into libslic3r_gui directly.
+    # SHARED was tried first but PrusaSlicer's bundled_deps/miniz is built
+    # without -fPIC (its CMake doesn't set POSITION_INDEPENDENT_CODE), so
+    # the static miniz archive can't be linked into a shared library on
+    # Linux. STATIC sidesteps the issue: meshseal becomes a static archive,
+    # libslic3r_gui pulls it in, the host's miniz is shared across both.
+    set(MESHSEAL_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(MESHSEAL_BUILD_CLI    OFF CACHE BOOL "" FORCE)
+    set(MESHSEAL_BUILD_TESTS  OFF CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(meshseal)
+    add_definitions(-DHAS_MESHSEAL)
+    message("Building with meshseal cross-platform mesh-repair backend")
+else()
+    message("Building without meshseal mesh-repair backend (SLIC3R_MESHSEAL=OFF)")
+endif()
+
 # libslic3r, PrusaSlicer GUI and the PrusaSlicer executable.
 add_subdirectory(src)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT PrusaSlicer_app_console)

--- a/deps/+Meshseal/Meshseal.cmake
+++ b/deps/+Meshseal/Meshseal.cmake
@@ -1,0 +1,24 @@
+# Meshseal — NOT currently used by the deps/ flow.
+#
+# The deps/ infrastructure (add_cmake_project + ExternalProject_Add)
+# requires that each dep installs into destdir/usr/local via CMake
+# install() rules. meshseal v0.1.x does not yet ship install rules
+# (planned for v0.1.2 — exporting the meshseal target via
+# install(TARGETS ... EXPORT meshsealTargets) + meshsealConfig.cmake).
+#
+# Until then, meshseal is fetched as an in-tree subproject from the
+# top-level PrusaSlicer CMakeLists.txt — see SLIC3R_MESHSEAL there.
+# This file is a placeholder so the future move into deps/ is one
+# concentrated change rather than scattered edits.
+
+# When meshseal v0.1.2 ships with install() rules, replace the above
+# with the real recipe:
+#
+# add_cmake_project(Meshseal
+#     URL      https://github.com/jkavalik/meshseal/archive/refs/tags/v0.1.2.tar.gz
+#     URL_HASH SHA256=...
+#     CMAKE_ARGS
+#         -DMESHSEAL_BUILD_SHARED=ON
+#         -DMESHSEAL_BUILD_TESTS=OFF
+#         -DMESHSEAL_BUILD_CLI=OFF
+# )

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -356,6 +356,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/Http.hpp
     Utils/FixModelByWin10.cpp
     Utils/FixModelByWin10.hpp
+    Utils/FixModelByMeshseal.cpp
+    Utils/FixModelByMeshseal.hpp
     Utils/Jwt.cpp
     Utils/Jwt.hpp
     Utils/Moonraker.cpp
@@ -470,6 +472,14 @@ target_link_libraries(
     fastfloat
     boost_headeronly
 )
+
+if (SLIC3R_MESHSEAL)
+    # meshseal is a shared library (MESHSEAL_BUILD_SHARED=ON) fetched via
+    # FetchContent at top level (CMakeLists.txt). Link conditionally so a
+    # build with -DSLIC3R_MESHSEAL=OFF still compiles (FixModelByMeshseal
+    # then becomes a no-op stub via the HAS_MESHSEAL gate in its header).
+    target_link_libraries(libslic3r_gui PUBLIC meshseal)
+endif ()
 
 if (MSVC)
     target_link_libraries(libslic3r_gui PUBLIC Setupapi.lib)

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include "slic3r/Utils/FixModelByWin10.hpp"
+#include "slic3r/Utils/FixModelByMeshseal.hpp"
 #ifdef __APPLE__
 #include "wx/dcclient.h"
 #include "slic3r/Utils/MacDarkMode.hpp"
@@ -876,9 +877,22 @@ wxMenuItem* MenuFactory::append_menu_item_fix_through_winsdk(wxMenu* menu)
         return nullptr;
     wxMenuItem* menu_item = append_menu_item(menu, wxID_ANY, _L("Fix by Windows repair algorithm"), "",
         [](wxCommandEvent&) { obj_list()->fix_through_winsdk(); }, "", menu,
-        []() {return plater()->can_fix_through_winsdk(); }, m_parent);
+        []() { return plater()->can_fix_through_winsdk(); }, m_parent);
 
     return menu_item;
+}
+
+wxMenuItem* MenuFactory::append_menu_item_fix_through_meshseal(wxMenu* menu)
+{
+#ifdef HAS_MESHSEAL
+    wxMenuItem* menu_item = append_menu_item(menu, wxID_ANY, _L("Fix by meshseal"), "",
+        [](wxCommandEvent&) { obj_list()->fix_through_meshseal(); }, "", menu,
+        []() { return plater()->can_fix_through_meshseal(); }, m_parent);
+    return menu_item;
+#else
+    (void)menu;
+    return nullptr;
+#endif
 }
 
 wxMenuItem* MenuFactory::append_menu_item_simplify(wxMenu* menu)
@@ -1199,6 +1213,7 @@ void MenuFactory::create_common_object_menu(wxMenu* menu)
     append_menu_item_scale_selection_to_fit_print_volume(menu);
 
     append_menu_item_fix_through_winsdk(menu);
+    append_menu_item_fix_through_meshseal(menu);
     append_menu_item_simplify(menu);
     append_menu_items_mirror(menu);
 
@@ -1248,6 +1263,7 @@ void MenuFactory::create_part_menu()
     append_menu_item_replace_with_stl(menu);
     append_menu_item_export_stl(menu);
     append_menu_item_fix_through_winsdk(menu);
+    append_menu_item_fix_through_meshseal(menu);
     append_menu_item_simplify(menu);
 
     append_menu_item(menu, wxID_ANY, _L("Split"), _L("Split the selected object into individual parts"),
@@ -1264,6 +1280,7 @@ void MenuFactory::create_text_part_menu()
     append_menu_item_edit_text(menu);
     append_menu_item_delete(menu);
     append_menu_item_fix_through_winsdk(menu);
+    append_menu_item_fix_through_meshseal(menu);
     append_menu_item_simplify(menu);
 
     append_immutable_part_menu_items(menu);
@@ -1276,6 +1293,7 @@ void MenuFactory::create_svg_part_menu()
     append_menu_item_edit_svg(menu);
     append_menu_item_delete(menu);
     append_menu_item_fix_through_winsdk(menu);
+    append_menu_item_fix_through_meshseal(menu);
     append_menu_item_simplify(menu);
 
     append_immutable_part_menu_items(menu);
@@ -1389,6 +1407,7 @@ wxMenu* MenuFactory::multi_selection_menu()
     wxMenu* menu = new MenuWithSeparators();
 
     append_menu_item_fix_through_winsdk(menu);
+    append_menu_item_fix_through_meshseal(menu);
     append_menu_item_reload_from_disk(menu);
     append_menu_items_convert_unit(menu);
     if (obj_list()->can_merge_to_multipart_object())

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -133,6 +133,7 @@ private:
     void        append_menu_item_invalidate_cut_info(wxMenu *menu);
     void        append_menu_items_osx(wxMenu* menu);
     wxMenuItem* append_menu_item_fix_through_winsdk(wxMenu* menu);
+    wxMenuItem* append_menu_item_fix_through_meshseal(wxMenu* menu);
     wxMenuItem* append_menu_item_simplify(wxMenu* menu);
     void        append_menu_item_export_stl(wxMenu* menu);
     void        append_menu_item_reload_from_disk(wxMenu* menu);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -44,6 +44,7 @@
 #include <wx/bookctrl.h> // IWYU pragma: keep
 
 #include "slic3r/Utils/FixModelByWin10.hpp"
+#include "slic3r/Utils/FixModelByMeshseal.hpp"
 
 #ifdef __WXMSW__
 #include "wx/uiaction.h"
@@ -4746,6 +4747,61 @@ void ObjectList::fix_through_winsdk()
     // Show info notification
     wxString msg = MenuFactory::get_repaire_result_message(succes_models, failed_models);
     plater->get_notification_manager()->push_notification(NotificationType::RepairFinished, NotificationManager::NotificationLevel::PrintInfoShortNotificationLevel, into_u8(msg));
+}
+
+void ObjectList::fix_through_meshseal()
+{
+    if (!wxGetApp().plater()->canvas3D()->get_gizmos_manager().check_gizmos_closed_except(GLGizmosManager::Undefined))
+        return;
+
+    std::vector<int> obj_idxs, vol_idxs;
+    get_selection_indexes(obj_idxs, vol_idxs);
+    if (obj_idxs.empty()) return;
+
+    auto plater = wxGetApp().plater();
+    Plater::TakeSnapshot snapshot(plater, _L("Fix by meshseal"));
+
+    wxProgressDialog progress_dlg(_L("Repairing by meshseal"), "", 100,
+        find_toplevel_parent(plater),
+        wxPD_AUTO_HIDE | wxPD_APP_MODAL | wxPD_CAN_ABORT);
+
+    std::vector<std::string> succes_models;
+    std::vector<std::pair<std::string, std::string>> failed_models;
+
+    auto do_fix = [&](int obj_idx, int vol_idx) {
+        const std::string name = vol_idx < 0
+            ? object(obj_idx)->name
+            : object(obj_idx)->volumes[vol_idx]->name;
+        plater->clear_before_change_mesh(obj_idx,
+            _u8L("Custom supports, seams, fuzzy skin and multimaterial painting "
+                 "were removed after repairing the mesh."));
+        std::string res;
+        wxString msg = _L("Repairing model") + ": " + from_u8(name) + "\n";
+        if (!fix_model_by_meshseal_gui(*object(obj_idx), vol_idx, progress_dlg, msg, res))
+            return false;
+        plater->changed_mesh(obj_idx);
+        if (res.empty()) succes_models.push_back(name);
+        else             failed_models.push_back({ name, res });
+        update_item_error_icon(obj_idx, vol_idx);
+        update_info_items(obj_idx);
+        return true;
+    };
+
+    if (vol_idxs.empty()) {
+        for (int obj_idx : obj_idxs)
+            if (!do_fix(obj_idx, -1)) break;
+    } else {
+        int obj_idx = obj_idxs.front();
+        for (int vol_idx : vol_idxs)
+            if (!do_fix(obj_idx, vol_idx)) break;
+    }
+    progress_dlg.Update(100, "");
+
+    wxString msg = MenuFactory::get_repaire_result_message(succes_models, failed_models);
+    plater->get_notification_manager()->push_notification(
+        NotificationType::RepairFinished,
+        NotificationManager::NotificationLevel::PrintInfoShortNotificationLevel,
+        into_u8(msg));
 }
 
 void ObjectList::simplify()

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -388,6 +388,7 @@ public:
     void split_instances();
     void rename_item();
     void fix_through_winsdk();
+    void fix_through_meshseal();
     void simplify();
     void update_item_error_icon(const int obj_idx, int vol_idx) const ;
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -617,6 +617,7 @@ struct Plater::priv
     bool can_arrange() const;
     bool can_layers_editing() const;
     bool can_fix_through_winsdk() const;
+    bool can_fix_through_meshseal() const;
     bool can_simplify() const;
     bool can_set_instance_to_object() const;
     bool can_mirror() const;
@@ -4054,6 +4055,15 @@ bool Plater::priv::can_fix_through_winsdk() const
             return true;
     return false;
 #endif // FIX_THROUGH_WINSDK_ALWAYS
+}
+
+bool Plater::priv::can_fix_through_meshseal() const
+{
+    // Same selection / error-count gate as the WinSDK path. meshseal is
+    // available on all platforms, so no platform check needed; the
+    // HAS_MESHSEAL guard in the called code path handles the
+    // build-time opt-out.
+    return can_fix_through_winsdk();
 }
 
 bool Plater::priv::can_simplify() const
@@ -7749,6 +7759,7 @@ bool Plater::can_increase_instances() const { return p->can_increase_instances()
 bool Plater::can_decrease_instances(int obj_idx/* = -1*/) const { return p->can_decrease_instances(obj_idx); }
 bool Plater::can_set_instance_to_object() const { return p->can_set_instance_to_object(); }
 bool Plater::can_fix_through_winsdk() const { return p->can_fix_through_winsdk(); }
+bool Plater::can_fix_through_meshseal() const { return p->can_fix_through_meshseal(); }
 bool Plater::can_simplify() const { return p->can_simplify(); }
 bool Plater::can_split_to_objects() const { return p->can_split_to_objects(); }
 bool Plater::can_split_to_volumes() const { return p->can_split_to_volumes(); }

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -335,6 +335,7 @@ public:
     bool can_decrease_instances(int obj_idx = -1) const;
     bool can_set_instance_to_object() const;
     bool can_fix_through_winsdk() const;
+    bool can_fix_through_meshseal() const;
     bool can_simplify() const;
     bool can_split_to_objects() const;
     bool can_split_to_volumes() const;

--- a/src/slic3r/Utils/FixModelByMeshseal.cpp
+++ b/src/slic3r/Utils/FixModelByMeshseal.cpp
@@ -1,0 +1,248 @@
+///|/ meshseal integration into PrusaSlicer.
+///|/ Released under AGPLv3+ (PrusaSlicer); meshseal itself is MIT.
+///|/
+#ifdef HAS_MESHSEAL
+
+#include "FixModelByMeshseal.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <exception>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <boost/thread.hpp>
+
+#include "libslic3r/Model.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "../GUI/I18N.hpp"
+
+#include <wx/progdlg.h>
+
+#include <meshseal/meshseal.h>
+
+namespace Slic3r {
+
+bool is_meshseal_available()
+{
+    // meshseal has no runtime probe — if HAS_MESHSEAL is defined the
+    // library was linked in at build time. Always available.
+    return true;
+}
+
+namespace {
+
+// ITS (float, int) -> meshseal::Mesh (double, uint32_t).
+// Both layouts are flat triangle soup: vertex array + index array.
+// O(V + F) conversion, no metadata involved.
+static meshseal::Mesh its_to_meshseal(const indexed_triangle_set& its)
+{
+    meshseal::Mesh m;
+    m.vertices.reserve(its.vertices.size());
+    for (const auto& v : its.vertices)
+        m.vertices.push_back({ double(v.x()), double(v.y()), double(v.z()) });
+    m.faces.reserve(its.indices.size());
+    for (const auto& t : its.indices)
+        m.faces.push_back({ uint32_t(t[0]), uint32_t(t[1]), uint32_t(t[2]) });
+    return m;
+}
+
+// meshseal::Mesh (double, uint32_t) -> ITS (float, int).
+static indexed_triangle_set meshseal_to_its(const meshseal::Mesh& m)
+{
+    indexed_triangle_set out;
+    out.vertices.reserve(m.vertices.size());
+    for (const auto& v : m.vertices)
+        out.vertices.emplace_back(float(v[0]), float(v[1]), float(v[2]));
+    out.indices.reserve(m.faces.size());
+    for (const auto& f : m.faces)
+        out.indices.emplace_back(int(f[0]), int(f[1]), int(f[2]));
+    return out;
+}
+
+// Sentinel thrown from inside the worker when the user clicks Cancel.
+class RepairCanceledException : public std::exception {
+public:
+    const char* what() const noexcept override { return "Model repair canceled"; }
+};
+
+// Repair one ModelVolume in place. Throws Slic3r::RuntimeError on failure,
+// RepairCanceledException on user cancellation. The progress callback bridges
+// meshseal's per-stage events to the GUI dialog.
+template <typename ProgressFn, typename CancelFn>
+static void fix_one_volume_in_memory(ModelVolume&    vol,
+                                     ProgressFn      on_progress,
+                                     CancelFn        throw_on_cancel)
+{
+    on_progress(L("Preparing mesh"), 5);
+
+    const TriangleMesh& tm  = vol.mesh();
+    const indexed_triangle_set& its = tm.its;
+    if (its.vertices.empty() || its.indices.empty()) {
+        throw Slic3r::RuntimeError("Volume mesh is empty");
+    }
+
+    meshseal::Mesh input = its_to_meshseal(its);
+
+    throw_on_cancel();
+    on_progress(L("Repairing mesh"), 15);
+
+    meshseal::RepairOptions opts;
+    // Wire meshseal's per-stage event stream into the GUI progress dialog
+    // and cancellation check. Returning false from the callback raises
+    // RepairCanceledException inside meshseal::repair(), which propagates
+    // out through std::exception (caught below).
+    std::atomic<bool> cancel_requested{false};
+    opts.on_progress = [&](const meshseal::ProgressEvent& ev) -> bool {
+        // Bridge meshseal's stage names to a localized GUI message.
+        // Percentage is a soft estimate: 15..85 mapped against a heuristic
+        // budget. meshseal does not know the total work in advance (pipeline
+        // branches on input characteristics), so we cap below 90 and let
+        // the final "Loading" step take it the rest of the way.
+        const int pct = std::min(85, 15 + int(ev.elapsed_ms / 40.0));
+        on_progress(ev.stage_name.c_str(), pct);
+        // Note: we cannot throw from the callback (meshseal stays plain-C++
+        // exception-safe); returning false is the documented cancel path.
+        return !cancel_requested.load();
+    };
+    // Pre-call cancellation check; cancel_requested is wired to the
+    // shared `canceled` atomic via throw_on_cancel below.
+    try {
+        throw_on_cancel();
+    } catch (...) {
+        cancel_requested.store(true);
+        throw;
+    }
+
+    meshseal::RepairResult result;
+    try {
+        result = meshseal::repair(input, opts);
+    } catch (const std::exception& e) {
+        throw Slic3r::RuntimeError(std::string("meshseal::repair threw: ") + e.what());
+    }
+
+    throw_on_cancel();
+
+    if (result.partial_failure) {
+        // Look for an explicit "canceled" marker in the notes.
+        for (const auto& note : result.notes) {
+            if (note.find("canceled") != std::string::npos)
+                throw RepairCanceledException();
+        }
+        // Otherwise partial_failure means the pipeline ran but couldn't
+        // produce a strictly-clean output. Adopt the result anyway — it's
+        // still likely closer to clean than the input. The user can decide
+        // whether to re-run.
+    }
+
+    if (result.mesh.vertices.empty() || result.mesh.faces.empty()) {
+        throw Slic3r::RuntimeError(
+            "meshseal returned an empty mesh (input was unrepairable)");
+    }
+
+    on_progress(L("Loading repaired mesh"), 90);
+
+    indexed_triangle_set repaired = meshseal_to_its(result.mesh);
+    vol.set_mesh(TriangleMesh(std::move(repaired)));
+    vol.calculate_convex_hull();
+    vol.set_new_unique_id();
+}
+
+} // anonymous namespace
+
+bool fix_model_by_meshseal_gui(ModelObject&        model_object,
+                               int                 volume_idx,
+                               wxProgressDialog&   progress_dialog,
+                               const wxString&     msg_header,
+                               std::string&        fix_result)
+{
+    std::mutex                      mtx;
+    std::condition_variable         condition;
+    struct Progress {
+        std::string                 message;
+        int                         percent = 0;
+        bool                        updated = false;
+    } progress;
+    std::atomic<bool>               canceled{false};
+    std::atomic<bool>               finished{false};
+
+    std::vector<ModelVolume*> volumes;
+    if (volume_idx == -1)
+        volumes = model_object.volumes;
+    else
+        volumes.push_back(model_object.volumes[volume_idx]);
+
+    bool   success = false;
+    size_t ivolume = 0;
+
+    auto on_progress = [&](const char* msg, unsigned prcnt) {
+        std::unique_lock<std::mutex> lock(mtx);
+        progress.message = msg;
+        progress.percent = int((float(prcnt) + float(ivolume) * 100.f) / float(volumes.size()));
+        progress.updated = true;
+        condition.notify_all();
+    };
+    auto throw_on_cancel = [&]() {
+        if (canceled) throw RepairCanceledException();
+    };
+
+    // Worker thread keeps the GUI responsive (progress_dialog polled on
+    // the main thread). meshseal itself is single-threaded; the worker
+    // exists for UX, not parallelism.
+    auto worker = boost::thread([&]() {
+        try {
+            for (; ivolume < volumes.size(); ++ivolume) {
+                fix_one_volume_in_memory(*volumes[ivolume],
+                                         on_progress,
+                                         throw_on_cancel);
+            }
+            model_object.invalidate_bounding_box();
+            on_progress(L("Model repair finished"), 100);
+            success  = true;
+            finished = true;
+        } catch (const RepairCanceledException&) {
+            canceled = true;
+            finished = true;
+            on_progress(L("Model repair canceled"), 100);
+        } catch (const std::exception& ex) {
+            success  = false;
+            finished = true;
+            // Stash the message into progress so the main thread sees it.
+            std::unique_lock<std::mutex> lock(mtx);
+            progress.message = ex.what();
+            progress.percent = 100;
+            progress.updated = true;
+            condition.notify_all();
+        }
+    });
+
+    while (!finished) {
+        std::unique_lock<std::mutex> lock(mtx);
+        condition.wait_for(lock, std::chrono::milliseconds(250),
+                           [&progress] { return progress.updated; });
+        // Decrease by 1 to keep the dialog open until we explicitly close.
+        if (!progress_dialog.Update(std::max(0, progress.percent - 1),
+                                    msg_header + _(progress.message)))
+            canceled = true;
+        else
+            progress_dialog.Fit();
+        progress.updated = false;
+    }
+
+    if (canceled) {
+        // Nothing to show — caller looks at the return value.
+    } else if (success) {
+        fix_result.clear();
+    } else {
+        fix_result = progress.message;
+    }
+    worker.join();
+    return !canceled;
+}
+
+} // namespace Slic3r
+
+#endif /* HAS_MESHSEAL */

--- a/src/slic3r/Utils/FixModelByMeshseal.hpp
+++ b/src/slic3r/Utils/FixModelByMeshseal.hpp
@@ -1,0 +1,51 @@
+///|/ meshseal integration into PrusaSlicer.
+///|/ Released under AGPLv3+ (PrusaSlicer); meshseal itself is MIT.
+///|/
+#ifndef slic3r_GUI_Utils_FixModelByMeshseal_hpp_
+#define slic3r_GUI_Utils_FixModelByMeshseal_hpp_
+
+#include <string>
+
+class wxProgressDialog;
+class wxString;
+
+namespace Slic3r {
+
+class ModelObject;
+
+#ifdef HAS_MESHSEAL
+
+// Cross-platform mesh repair backend backed by libmeshseal
+// (https://github.com/jkavalik/meshseal).
+//
+// Mirrors the public surface of FixModelByWin10.hpp so the GUI can pick
+// between backends at the call site. Difference vs the WinSDK backend:
+// - Cross-platform (Windows, macOS, Linux).
+// - In-memory ITS <-> meshseal::Mesh conversion (no temp 3MF round-trip).
+// - Single worker thread; progress + cooperative cancellation via the
+//   meshseal RepairOptions::on_progress callback.
+
+extern bool is_meshseal_available();
+
+// Returns FALSE if fixing was canceled by the user.
+// `fix_result` is empty on success; on failure contains an error message.
+extern bool fix_model_by_meshseal_gui(ModelObject&                model_object,
+                                      int                         volume_idx,
+                                      wxProgressDialog&           progress_dialog,
+                                      const wxString&             msg_header,
+                                      std::string&                fix_result);
+
+#else /* HAS_MESHSEAL */
+
+inline bool is_meshseal_available() { return false; }
+inline bool fix_model_by_meshseal_gui(ModelObject&,
+                                      int,
+                                      wxProgressDialog&,
+                                      const wxString&,
+                                      std::string&) { return false; }
+
+#endif /* HAS_MESHSEAL */
+
+} // namespace Slic3r
+
+#endif /* slic3r_GUI_Utils_FixModelByMeshseal_hpp_ */


### PR DESCRIPTION
**Add meshseal: a cross-platform mesh-repair backend**

Adds an optional second repair backend that works on **Windows, Linux, and macOS** — unlike the existing "Fix by Windows repair algorithm", which is Windows-only. Exposed as a right-click **"Fix by meshseal"** menu item; the existing Windows path is untouched.

meshseal ([[jkavalik/meshseal](https://github.com/jkavalik/meshseal)](https://github.com/jkavalik/meshseal)) is an MIT-licensed C++17 mesh-repair library (compatible with PrusaSlicer's AGPL). It reads the volume's mesh in memory and returns a watertight 2-manifold solid, prioritising preservation of the original geometry.

**Build integration**
- `CMakeLists.txt`: `SLIC3R_MESHSEAL` option (default ON). FetchContent pulls a pinned tag + SHA (`v0.1.3`) and builds meshseal **static**, linked into `libslic3r_gui`. Declared after `bundled_deps` so meshseal yields to PrusaSlicer's bundled `miniz` instead of colliding. No new system dependencies.
- `HAS_MESHSEAL` gates all new code, so `-DSLIC3R_MESHSEAL=OFF` compiles cleanly to no-op stubs.

**Code**
- `src/slic3r/Utils/FixModelByMeshseal.{hpp,cpp}` — worker-thread wrapper bridging meshseal's progress/cancel callback to the GUI progress dialog. In-memory `indexed_triangle_set` ↔ `meshseal::Mesh` conversion (no temp-3MF round-trip).
- `Plater`, `GUI_ObjectList`, `GUI_Factories` — `can_fix_through_meshseal()`, `fix_through_meshseal()`, and `append_menu_item_fix_through_meshseal()` wired at the 5 menu sites parallel to the Windows path.
- `deps/+Meshseal/Meshseal.cmake` — placeholder documenting a future migration to the `deps/` flow.

**Scope / follow-ups**
- The two auto-fix call sites (`GLGizmoCut`, `GUI_ObjectManipulation`) remain Windows-SDK-only for now; they can route through meshseal in a follow-up once the menu path has had wider exposure.

**Validation**
- Builds + links on Linux (GCC, WSLg); "Fix by meshseal" exercised interactively across a defective-model corpus. meshseal itself ships cross-platform CI (Windows/Linux/macOS) and a 670-assertion test suite.

**Disclosure:** meshseal is AI-authored ("vibe coded") — human-directed and validated empirically against its test corpus and real-world batches rather than hand-audited line by line. Noted here for transparency to maintainers.
