### PR TITLE
Fix #14449: persist download path regardless of URL registration state

### DIFF
--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1698,7 +1698,7 @@ bool PageDownloader::on_finish_downloader() const
 bool DownloaderUtils::Worker::perform_registration_linux = false;
 #endif // __linux__
 
-bool DownloaderUtils::Worker::perform_download_register(const std::string& path)
+bool DownloaderUtils::Worker::validate_and_save_download_path(const std::string& path)
 {
     boost::filesystem::path aux_dest (path);
     boost::system::error_code ec;
@@ -1709,12 +1709,18 @@ bool DownloaderUtils::Worker::perform_download_register(const std::string& path)
     if (chosen_dest.empty() || !boost::filesystem::is_directory(chosen_dest, ec) || ec) {
         std::string err_msg = GUI::format("%1%\n\n%2%",_L("Chosen directory for downloads does not exist.") ,chosen_dest.string());
         BOOST_LOG_TRIVIAL(error) << err_msg;
-        show_error(/*m_parent*/ nullptr, err_msg);
+        if (downloader_checked) {
+            // Error if checked
+            show_error(/*m_parent*/ nullptr, err_msg);
+        } else {
+            // Warn if unchecked
+            show_info(/*m_parent*/ nullptr, err_msg);
+        }
         return false;
     }
     BOOST_LOG_TRIVIAL(info) << "Downloader registration: Directory for downloads: " << chosen_dest.string();
     wxGetApp().app_config->set("url_downloader_dest", chosen_dest.string());
-    return perform_url_register();
+    return true;
 }
 bool DownloaderUtils::Worker::perform_url_register()
 {
@@ -1775,24 +1781,20 @@ bool DownloaderUtils::Worker::on_finish() {
     AppConfig* app_config = wxGetApp().app_config;
     bool ac_value = app_config->get_bool("downloader_url_registered");
     BOOST_LOG_TRIVIAL(debug) << "PageDownloader::on_finish_downloader ac_value " << ac_value << " downloader_checked " << downloader_checked;
-    if (ac_value && downloader_checked) {
-        // already registered but we need to do it again
-        if (!perform_download_register(GUI::into_u8(path_name())))
-            return false;
-        app_config->set("downloader_url_registered", "1");
-    } else if (!ac_value && downloader_checked) {
-        // register
-        if (!perform_download_register(GUI::into_u8(path_name())))
-            return false;
-        app_config->set("downloader_url_registered", "1");
-    } else if (ac_value && !downloader_checked) {
-        // deregister, downloads are banned now  
+    // Always validate and save path
+    bool valid_path = validate_and_save_download_path(GUI::into_u8(path_name()));
+
+    if (downloader_checked) {
+        if (valid_path && perform_url_register()) {
+            app_config->set("downloader_url_registered", "1");
+            return true;
+        }
+        return false;
+    } else if (ac_value) {
+        // deregister, downloads are banned now
         deregister();
         app_config->set("downloader_url_registered", "0");
-    } /*else if (!ac_value && !downloader_checked) {
-        // not registered and we dont want to do it
-        // do not deregister as other instance might be registered
-    } */
+    }
     return true;
 }
 

--- a/src/slic3r/GUI/ConfigWizard.hpp
+++ b/src/slic3r/GUI/ConfigWizard.hpp
@@ -48,7 +48,7 @@ namespace DownloaderUtils {
         void set_path_name(const std::string& name);
 
         bool on_finish();
-        static bool perform_download_register(const std::string& path);
+        bool validate_and_save_download_path(const std::string& path);
         static bool perform_url_register();
 #ifdef __linux__
         static bool perform_registration_linux;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3429,7 +3429,10 @@ void GUI_App::show_downloader_registration_dialog()
         , true, wxYES_NO);
     if (msg.ShowModal() == wxID_YES) {
         auto downloader_worker = new DownloaderUtils::Worker(nullptr);
-        downloader_worker->perform_download_register(app_config->get("url_downloader_dest"));
+        if (downloader_worker->validate_and_save_download_path(app_config->get("url_downloader_dest"))) {
+            downloader_worker->perform_url_register();
+            app_config->set("downloader_url_registered", "1");
+        }
 #if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
         if (DownloaderUtils::Worker::perform_registration_linux)
             DesktopIntegrationDialog::perform_downloader_desktop_integration();


### PR DESCRIPTION
Fixes #14449 (SPE-2752).

### Problem
The Download path (`url_downloader_dest`) set in **Preferences > Other** was not persisted when the downloader URL-registration checkbox was disabled - the edit was silently discarded and the field showed the previously stored value again on reopen (the default Downloads folder if nothing had been saved before).

### Root cause
Saving the path was a side effect of `perform_download_register()`, which `on_finish()` only called in its "checked" branches. With registration off, none of those branches ran, so the edited path was silently dropped.

### Change
- Split `perform_download_register()` into `validate_and_save_download_path()`  (validate + save only) and the existing `perform_url_register()`.
- Call validation/save **unconditionally** in `on_finish()`, so the path persists regardless of the registration checkbox. URL registration still happens only when the box is checked and the path is valid.
- Invalid paths are reported as an **error** when the box is checked (blocks closing) and as a non-blocking **info notice** when unchecked. An invalid path is never written, so a bad entry can't clobber the stored value.

### Testing
- Unchecked + valid path → persists across restart (the reported bug). ✅
- Unchecked + invalid path → info notice, dialog closes, stored path unchanged. ✅
- Checked + invalid path → error, dialog stays open. ✅

Co-Authored-By: Claude Code <noreply@anthropic.com>

~ Supported and reviewed by Opus 4.7 -- But code was written and reviewed by hand.