### PR TITLE
Added rendering of color changes in G-code thumbnails

### DIFF
--- a/src/libslic3r/GCode/ThumbnailData.hpp
+++ b/src/libslic3r/GCode/ThumbnailData.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "libslic3r/Point.hpp"
+#include "libslic3r/CustomGCode.hpp"
 
 namespace Slic3r {
 
@@ -34,6 +35,7 @@ struct ThumbnailsParams
 	bool 			parts_only;
 	bool 			show_bed;
 	bool 			transparent_background;
+	CustomGCode::Info color_changes;
 };
 
 typedef std::function<ThumbnailsList(const ThumbnailsParams&)> ThumbnailsGeneratorCallback;

--- a/src/slic3r/GUI/BackgroundSlicingProcess.cpp
+++ b/src/slic3r/GUI/BackgroundSlicingProcess.cpp
@@ -796,8 +796,11 @@ void BackgroundSlicingProcess::prepare_upload(PrintHostJob &upload_job)
 ThumbnailsList BackgroundSlicingProcess::render_thumbnails(const ThumbnailsParams &params)
 {
 	ThumbnailsList thumbnails;
-	if (m_thumbnail_cb)
-		this->execute_ui_task([this, &params, &thumbnails](){ thumbnails = m_thumbnail_cb(params); });
+	if (m_thumbnail_cb) {
+        ThumbnailsParams p = params;
+        p.color_changes = m_print->model().custom_gcode_per_print_z();
+		this->execute_ui_task([this, &p, &thumbnails](){ thumbnails = m_thumbnail_cb(p); });
+    }
 	return thumbnails;
 }
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5000,6 +5000,13 @@ void GLCanvas3D::_render_thumbnail_internal(ThumbnailData& thumbnail_data, const
         const Matrix3d view_normal_matrix = view_matrix.matrix().block(0, 0, 3, 3) * model_matrix.matrix().block(0, 0, 3, 3).inverse().transpose();
         shader->set_uniform("view_normal_matrix", view_normal_matrix);
 
+        std::vector<CustomGCode::Item> color_changes;
+        for (const auto& item : thumbnail_params.color_changes.gcodes) {
+            if (item.type == CustomGCode::ColorChange || item.type == CustomGCode::ToolChange)
+                color_changes.push_back(item);
+        }
+        std::sort(color_changes.begin(), color_changes.end());
+
         if (is_left_handed)
             glsafe(::glFrontFace(GL_CW));
 
@@ -5015,6 +5022,44 @@ void GLCanvas3D::_render_thumbnail_internal(ThumbnailData& thumbnail_data, const
             ts.request_update_render_data();
 
             ts.render(nullptr, model_matrix);
+        }
+        else if (!color_changes.empty()) {
+            GLShaderProgram* mm_shader = wxGetApp().get_shader("mm_gouraud");
+            if (mm_shader) {
+                mm_shader->start_using();
+                mm_shader->set_uniform("volume_world_matrix", vol->world_matrix());
+                mm_shader->set_uniform("volume_mirrored", is_left_handed);
+                mm_shader->set_uniform("clipping_plane", ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f));
+                mm_shader->set_uniform("view_model_matrix", view_matrix * model_matrix);
+                mm_shader->set_uniform("projection_matrix", projection_matrix);
+                mm_shader->set_uniform("view_normal_matrix", view_normal_matrix);
+
+                double last_z = -FLT_MAX;
+                ColorRGBA current_color = vol->color;
+
+                auto render_range = [&](double z_min, double z_max, const ColorRGBA& color) {
+                    mm_shader->set_uniform("z_range", std::array<float, 2>{(float)z_min, (float)z_max});
+                    mm_shader->set_uniform("uniform_color", color);
+                    vol->render();
+                };
+
+                glsafe(::glDepthFunc(GL_LEQUAL));
+                glsafe(::glEnable(GL_CLIP_PLANE0));
+                for (const auto& item : color_changes) {
+                    render_range(last_z, item.print_z, current_color);
+                    last_z = item.print_z;
+                    decode_color(item.color, current_color);
+                }
+                render_range(last_z, FLT_MAX, current_color);
+                glsafe(::glDisable(GL_CLIP_PLANE0));
+                glsafe(::glDepthFunc(GL_LESS));
+
+                mm_shader->stop_using();
+                shader->start_using(); // restore original shader for stop_using call below
+            }
+            else {
+                vol->render();
+            }
         }
         else
             vol->render();

--- a/src/slic3r/GUI/GLModel.cpp
+++ b/src/slic3r/GUI/GLModel.cpp
@@ -807,7 +807,8 @@ void GLModel::render(const std::pair<size_t, size_t>& range)
         }
     }
 
-    shader->set_uniform("uniform_color", data.color);
+    if (shader->get_name() != "mm_gouraud")
+        shader->set_uniform("uniform_color", data.color);
 
     glsafe(::glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_render_data.ibo_id));
     glsafe(::glDrawElements(mode, range.second - range.first, index_type, (const void*)(range.first * Geometry::index_stride_bytes(data))));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3727,10 +3727,12 @@ ThumbnailsList Plater::priv::generate_thumbnails(const ThumbnailsParams& params,
     s_multiple_beds.set_thumbnail_bed_idx(s_multiple_beds.get_active_bed());
     ScopeGuard guard([]() { s_multiple_beds.set_thumbnail_bed_idx(-1); });
     ThumbnailsList thumbnails;
-    for (const Vec2d& size : params.sizes) {
+    ThumbnailsParams p = params;
+    p.color_changes = q->model().custom_gcode_per_print_z();
+    for (const Vec2d& size : p.sizes) {
         thumbnails.push_back(ThumbnailData());
         Point isize(size); // round to ints
-        generate_thumbnail(thumbnails.back(), isize.x(), isize.y(), params, camera_type);
+        generate_thumbnail(thumbnails.back(), isize.x(), isize.y(), p, camera_type);
         if (!thumbnails.back().is_valid())
             thumbnails.pop_back();
     }


### PR DESCRIPTION
Currently, PrusaSlicer always renders G-code thumbnails in a single color. I have updated the rendering to consider color changes, so that the generated thumbnail represents the model as it was actually sliced. Then on the printer display you can see the preview with the colors you have set in the slicer.

| Original thumbnail | New color thumbnail |
|--------|--------|
| <img width="350" src="https://github.com/user-attachments/assets/1d787661-b2e8-4fee-91bf-3b5259a9b222" /> | <img width="350" src="https://github.com/user-attachments/assets/0c19cc41-dad6-45d8-935d-bc14473f9a68" /> |
| <img width="350" src="https://github.com/user-attachments/assets/ede2215e-6b61-4f98-b7f0-6cf34d98b1c0" /> | <img width="350" src="https://github.com/user-attachments/assets/dbc2a251-382e-4420-82f0-47e0f460e050" /> | 

I also tested with the new Colormix feature, and the thumbnails still work correctly.