### PR TITLE
Trim whitespace from printhost API keys to avoid Prusa-Link HTTP 415 error

### DIFF
--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -303,6 +303,7 @@ PhysicalPrinterDialog::PhysicalPrinterDialog(wxWindow* parent, wxString printer_
     update_full_printer_names();
 
     m_config = &m_printer.config;
+    boost::trim(m_config->opt_string("printhost_apikey"));
 
     m_optgroup = new ConfigOptionsGroup(this, _L("Print Host upload"), m_config);
     build_printhost_settings(m_optgroup);
@@ -599,6 +600,29 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
                     temp->SetValue(trimed_str);
 
                 TextCtrl* field = dynamic_cast<TextCtrl*>(printhost_field);
+                if (field)
+                    field->propagate_value();
+            }), temp->GetId());
+        }
+    }
+
+    Field* apikey_field = m_optgroup->get_field("printhost_apikey");
+    if (apikey_field)
+    {
+        text_ctrl* temp = dynamic_cast<text_ctrl*>(apikey_field->getWindow());
+        if (temp) {
+            temp->Bind(wxEVT_TEXT, ([apikey_field, temp](wxEvent& e)
+            {
+#ifndef __WXGTK__
+                e.Skip();
+                temp->GetToolTip()->Enable(true);
+#endif // __WXGTK__
+                std::string trimed_str, str = trimed_str = temp->GetValue().ToStdString();
+                boost::trim(trimed_str);
+                if (trimed_str != str)
+                    temp->SetValue(trimed_str);
+
+                TextCtrl* field = dynamic_cast<TextCtrl*>(apikey_field);
                 if (field)
                     field->propagate_value();
             }), temp->GetId());
@@ -965,6 +989,8 @@ void PhysicalPrinterDialog::OnOK(wxEvent& event)
 
     //update printer name, if it was changed
     m_printer.set_name(into_u8(printer_name));
+
+    boost::trim(m_printer.config.opt_string("printhost_apikey"));
 
     // save access data secretly
     if (!m_printer.config.opt_string("printhost_password").empty()) {

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -12,6 +12,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -164,7 +165,7 @@ std::string escape_path_by_element(const boost::filesystem::path& path)
 
 OctoPrint::OctoPrint(DynamicPrintConfig *config) :
     m_host(config->opt_string("print_host")),
-    m_apikey(config->opt_string("printhost_apikey")),
+    m_apikey(boost::trim_copy(config->opt_string("printhost_apikey"))),
     m_cafile(config->opt_string("printhost_cafile")),
     m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
 {}


### PR DESCRIPTION
## Summary

- Trim leading/trailing whitespace from `printhost_apikey` when loading, editing, and saving Physical Printer settings
- Trim API key in `OctoPrint` constructor before sending `X-Api-Key` headers (affects PrusaLink uploads)

## Problem

Copying the Prusa-Link API key into PrusaSlicer can include invisible trailing newline characters. Uploads then fail with a misleading `HTTP 415: Only G-Code for FDM printer can be uploaded` even though the G-code is valid. The web UI works because it uses digest auth instead of the API key.

## Related

Complements https://github.com/prusa3d/Prusa-Link/pull/1047 (server-side API key sanitization).

## Test plan

- [ ] Paste an API key with trailing newlines into Physical Printer settings; confirm they are stripped from the field
- [ ] Upload to Prusa-Link via Send to printer succeeds with a pasted key that previously failed
- [ ] Existing printers with clean API keys still upload normally