### PR TITLE
Add an optional local import server for receiving model files from browser-based CAD Packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(SLIC3R_MSVC_COMPILE_PARALLEL "Compile on Visual Studio in parallel" 1)
 option(SLIC3R_ASAN              "Enable ASan on Clang and GCC" 0)
 option(SLIC3R_UBSAN             "Enable UBSan on Clang and GCC" 0)
 option(SLIC3R_ENABLE_FORMAT_STEP "Enable compilation of STEP file support" ON)
+option(SLIC3R_LOCAL_IMPORT_SERVER "Enable an optional, off-by-default loopback HTTP endpoint to receive model files from external tools" ON)
 option(SLIC3R_LOG_TO_FILE       "Enable logging into file")
 option(SLIC3R_REPO_URL          "Preset repo URL")
 
@@ -111,6 +112,10 @@ endif ()
 
 if (SLIC3R_OPENGL_ES)
     add_definitions(-DSLIC3R_OPENGL_ES)
+endif()
+
+if (SLIC3R_LOCAL_IMPORT_SERVER)
+    add_definitions(-DSLIC3R_LOCAL_IMPORT_SERVER)
 endif()
 
 if(SLIC3R_DESKTOP_INTEGRATION)

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -92,6 +92,27 @@ void AppConfig::set_defaults()
         if (get("export_sources_full_pathnames").empty())
             set("export_sources_full_pathnames", "0");
 
+        // Optional loopback HTTP endpoint for receiving model files from external
+        // tools (e.g. a browser CAD app). Off by default; loopback only.
+        if (get("enable_local_import_server").empty())
+            set("enable_local_import_server", "0");
+        // When enabled, callers must present a matching "X-Prusa-Token" header. A
+        // random key is generated into local_import_token on first enable.
+        if (get("local_import_require_key").empty())
+            set("local_import_require_key", "0");
+        // Loopback bind address. Defaults to 127.0.0.1. A dedicated address from
+        // the 127.0.0.0/8 block (e.g. to avoid colliding with other tools on a
+        // shared port) is allowed, but on macOS/Windows it must first be assigned
+        // to the loopback interface (PrusaSlicer never does this itself).
+        if (get("local_import_bind_address").empty())
+            set("local_import_bind_address", "127.0.0.1");
+        if (get("local_import_server_port").empty())
+            set("local_import_server_port", "8126");
+        if (get("local_import_allowed_origin").empty())
+            set("local_import_allowed_origin", "");
+        if (get("local_import_token").empty())
+            set("local_import_token", "");
+
 #ifdef _WIN32
         if (get("associate_3mf").empty())
             set("associate_3mf", "0");

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -354,6 +354,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/AppUpdater.hpp
     Utils/Http.cpp
     Utils/Http.hpp
+    Utils/LocalImportServer.cpp
+    Utils/LocalImportServer.hpp
     Utils/FixModelByWin10.cpp
     Utils/FixModelByWin10.hpp
     Utils/Jwt.cpp

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -903,11 +903,7 @@ void GUI_App::start_local_import_server_if_enabled()
     if (app_config->get_bool("local_import_require_key")) {
         std::string token = app_config->get("local_import_token");
         if (token.empty()) {
-            std::random_device rd;
-            static const char hexd[] = "0123456789abcdef";
-            token.reserve(32);
-            for (int i = 0; i < 32; ++i)
-                token.push_back(hexd[rd() & 0xF]);
+            token = LocalImportServer::generate_token();
             app_config->set("local_import_token", token);
             BOOST_LOG_TRIVIAL(info)
                 << "Local import server: generated an access key (see local_import_token in PrusaSlicer.ini).";

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -29,6 +29,7 @@
 #include <iterator>
 #include <exception>
 #include <cstdlib>
+#include <random>
 #include <regex>
 #include <string_view>
 #include <boost/nowide/fstream.hpp>
@@ -92,6 +93,9 @@
 #include "Mouse3DController.hpp"
 #include "RemovableDriveManager.hpp"
 #include "InstanceCheck.hpp" // IWYU pragma: keep
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+#include "Utils/LocalImportServer.hpp"
+#endif
 #include "NotificationManager.hpp"
 #include "UnsavedChangesDialog.hpp"
 #include "SavePresetDialog.hpp"
@@ -869,7 +873,68 @@ void GUI_App::post_init()
     // Sets window property to mainframe so other instances can indentify it.
     OtherInstanceMessageHandler::init_windows_properties(mainframe, m_instance_hash_int);
 #endif //WIN32
+
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+    // Optional loopback endpoint that receives model files from external tools.
+    if (is_editor())
+        start_local_import_server_if_enabled();
+#endif
 }
+
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+void GUI_App::start_local_import_server_if_enabled()
+{
+    // Stop any existing instance first so this can also act as "apply changes".
+    m_local_import_server.reset();
+
+    if (app_config == nullptr || ! app_config->get_bool("enable_local_import_server"))
+        return;
+
+    LocalImportServer::Config cfg;
+    if (const std::string addr = app_config->get("local_import_bind_address"); ! addr.empty())
+        cfg.bind_address = addr;
+    const int port = atoi(app_config->get("local_import_server_port").c_str());
+    if (port > 0 && port < 65536)
+        cfg.port = static_cast<uint16_t>(port);
+    cfg.allowed_origin = app_config->get("local_import_allowed_origin");
+
+    // Optional access-key gate. When the user asks to require a key, generate and
+    // persist a random one on first enable so it is secure without manual setup.
+    if (app_config->get_bool("local_import_require_key")) {
+        std::string token = app_config->get("local_import_token");
+        if (token.empty()) {
+            std::random_device rd;
+            static const char hexd[] = "0123456789abcdef";
+            token.reserve(32);
+            for (int i = 0; i < 32; ++i)
+                token.push_back(hexd[rd() & 0xF]);
+            app_config->set("local_import_token", token);
+            BOOST_LOG_TRIVIAL(info)
+                << "Local import server: generated an access key (see local_import_token in PrusaSlicer.ini).";
+        }
+        cfg.token = token;
+    }
+
+    m_local_import_server = std::make_unique<LocalImportServer>(std::move(cfg),
+        [](boost::filesystem::path path) {
+            // Invoked on the server thread; marshal onto the GUI thread and reuse
+            // the existing "open these files" path.
+            wxGetApp().CallAfter([path]() {
+                GUI_App& app = wxGetApp();
+                if (Plater* pl = app.plater()) {
+                    if (app.mainframe)
+                        app.mainframe->Raise();
+                    pl->load_files(std::vector<boost::filesystem::path>{ path }, true, false, false);
+                }
+            });
+        });
+
+    if (! m_local_import_server->start()) {
+        BOOST_LOG_TRIVIAL(error) << "Could not start the local import server (port in use?).";
+        m_local_import_server.reset();
+    }
+}
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 
 IMPLEMENT_APP(GUI_App)
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -94,7 +94,7 @@
 #include "RemovableDriveManager.hpp"
 #include "InstanceCheck.hpp" // IWYU pragma: keep
 #ifdef SLIC3R_LOCAL_IMPORT_SERVER
-#include "Utils/LocalImportServer.hpp"
+#include "../Utils/LocalImportServer.hpp"
 #endif
 #include "NotificationManager.hpp"
 #include "UnsavedChangesDialog.hpp"

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -48,6 +48,9 @@ namespace GUI{
 
 class RemovableDriveManager;
 class OtherInstanceMessageHandler;
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+class LocalImportServer;
+#endif
 class MainFrame;
 class Sidebar;
 class ObjectManipulation;
@@ -190,7 +193,10 @@ private:
     std::unique_ptr<AppUpdater>                     m_app_updater;
     std::unique_ptr<wxSingleInstanceChecker>        m_single_instance_checker;
     std::unique_ptr<Downloader>                     m_downloader;
-    
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+    std::unique_ptr<LocalImportServer>              m_local_import_server;
+#endif
+
     std::string m_instance_hash_string;
 	size_t m_instance_hash_int;
 
@@ -372,6 +378,11 @@ public:
 	OtherInstanceMessageHandler* other_instance_message_handler() { return m_other_instance_message_handler.get(); }
     wxSingleInstanceChecker* single_instance_checker() {return m_single_instance_checker.get();}
 
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+	// (Re)start or stop the optional loopback model-import server to match the
+	// current AppConfig settings. Safe to call repeatedly.
+	void        start_local_import_server_if_enabled();
+#endif
 	void        init_single_instance_checker(const std::string &name, const std::string &path);
 	void        set_instance_hash (const size_t hash) { m_instance_hash_int = hash; m_instance_hash_string = std::to_string(hash); }
     std::string get_instance_hash_string ()           { return m_instance_hash_string; }

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -315,6 +315,23 @@ void PreferencesDialog::build()
 				"Examples of such issues are floating object parts, unsupported extrusions and low bed adhesion."),
 			app_config->get_bool("alert_when_supports_needed"));
 
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+		append_bool_option(m_optgroup_general, "enable_local_import_server",
+			L("Enable local import server"),
+			L("If enabled, PrusaSlicer listens on a loopback HTTP port (127.0.0.1) so external "
+			  "tools - such as a browser CAD app - can send model files directly into the open window. "
+			  "Bound to localhost only and off by default. Advanced options (port, allowed origin) "
+			  "are stored in PrusaSlicer.ini."),
+			app_config->get_bool("enable_local_import_server"));
+
+		append_bool_option(m_optgroup_general, "local_import_require_key",
+			L("Require an access key for the local import server"),
+			L("If enabled, the local import server only accepts requests that present a matching "
+			  "access key. A random key is generated the first time you enable this; copy it from "
+			  "local_import_token in PrusaSlicer.ini into the tool that sends files."),
+			app_config->get_bool("local_import_require_key"));
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
+
 
 		m_optgroup_general->append_separator();
 
@@ -808,6 +825,13 @@ void PreferencesDialog::accept(wxEvent&)
 
 	for (std::map<std::string, std::string>::iterator it = m_values.begin(); it != m_values.end(); ++it)
 		app_config->set(it->first, it->second);
+
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+	if (m_values.count("enable_local_import_server") || m_values.count("local_import_require_key")
+	    || m_values.count("local_import_server_port") || m_values.count("local_import_allowed_origin")
+	    || m_values.count("local_import_token"))
+		wxGetApp().start_local_import_server_if_enabled();
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 
 	if (wxGetApp().is_editor()) {
 		wxGetApp().set_label_clr_sys(m_sys_colour->GetColour());

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -315,23 +315,6 @@ void PreferencesDialog::build()
 				"Examples of such issues are floating object parts, unsupported extrusions and low bed adhesion."),
 			app_config->get_bool("alert_when_supports_needed"));
 
-#ifdef SLIC3R_LOCAL_IMPORT_SERVER
-		append_bool_option(m_optgroup_general, "enable_local_import_server",
-			L("Enable local import server"),
-			L("If enabled, PrusaSlicer listens on a loopback HTTP port (127.0.0.1:8126) so external "
-			  "tools - such as a browser CAD app - can send model files directly into the open window. "
-			  "Bound to localhost only and off by default. Advanced options (port, allowed origin) "
-			  "are stored in PrusaSlicer.ini."),
-			app_config->get_bool("enable_local_import_server"));
-
-		append_bool_option(m_optgroup_general, "local_import_require_key",
-			L("Require an access key for the local import server"),
-			L("If enabled, the local import server only accepts requests that present a matching "
-			  "access key. A random key is generated the first time you enable this; copy it from "
-			  "local_import_token in PrusaSlicer.ini into the tool that sends files."),
-			app_config->get_bool("local_import_require_key"));
-#endif // SLIC3R_LOCAL_IMPORT_SERVER
-
 
 		m_optgroup_general->append_separator();
 
@@ -660,6 +643,23 @@ void PreferencesDialog::build()
 			L("Allow downloads from supported websites (e.g. Printables.com)"),
 			L("If enabled, PrusaSlicer can download and open files from supported websites"),
 			app_config->get_bool("downloader_url_registered"));
+
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+		append_bool_option(m_optgroup_other, "enable_local_import_server",
+			L("Enable local import server"),
+			L("If enabled, PrusaSlicer listens on a loopback HTTP port (127.0.0.1:8126) so external "
+			  "tools - such as a browser CAD app - can send model files directly into the open window. "
+			  "Bound to localhost only and off by default. Advanced options (port, allowed origin) "
+			  "are stored in PrusaSlicer.ini."),
+			app_config->get_bool("enable_local_import_server"));
+
+		append_bool_option(m_optgroup_other, "local_import_require_key",
+			L("Require an access key for the local import server"),
+			L("If enabled, the local import server only accepts requests that present a matching "
+			  "access key. A random key is generated the first time you enable this; copy it from "
+			  "local_import_token in PrusaSlicer.ini into the tool that sends files."),
+			app_config->get_bool("local_import_require_key"));
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 
 		activate_options_tab(m_optgroup_other);
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -21,6 +21,12 @@
 #include "GLCanvas3D.hpp"
 #include "ConfigWizard.hpp"
 #include "Search.hpp"
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+#include "../Utils/LocalImportServer.hpp"
+#include <wx/hyperlink.h>
+// wxTheClipboard / wxTextDataObject / wxButton / wxStaticText come from the
+// precompiled header (<wx/wx.h>), as in AboutDialog.cpp.
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 
 #include "Widgets/SpinInput.hpp"
 
@@ -605,6 +611,11 @@ void PreferencesDialog::build()
 		m_optgroup_other = create_options_tab(_L("Other"), tabs);
 		m_optgroup_other->on_change = [this](t_config_option_key opt_key, boost::any value) {
 
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+			if (opt_key == "local_import_require_key")
+				update_local_import_token_widget(boost::any_cast<bool>(value));
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
+
 			if (auto it = m_values.find(opt_key); it != m_values.end() && opt_key != "url_downloader_dest") {
 				m_values.erase(it); // we shouldn't change value, if some of those parameters were selected, and then deselected
 				return;
@@ -663,6 +674,11 @@ void PreferencesDialog::build()
 
 		activate_options_tab(m_optgroup_other);
 
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+		// Added before the download-path sizer so the access-key row sits directly
+		// below the "Require an access key" checkbox (the last option line).
+		create_local_import_token_widget();
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 		create_downloader_path_sizer();
 		create_settings_font_widget();
 
@@ -1202,6 +1218,91 @@ void PreferencesDialog::create_downloader_path_sizer()
 
 	append_preferences_option_to_searcher(m_optgroup_other, opt_key, title);
 }
+
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+void PreferencesDialog::create_local_import_token_widget()
+{
+	wxWindow* parent = m_optgroup_other->parent();
+	auto app_config = get_app_config();
+
+	const std::string token = app_config->get("local_import_token");
+
+	auto* sizer = new wxBoxSizer(wxHORIZONTAL);
+
+	auto* label = new wxStaticText(parent, wxID_ANY, _L("Access key") + ":");
+	m_local_import_token_link = new wxHyperlinkCtrl(parent, wxID_ANY, wxString::FromUTF8(token.c_str()), wxEmptyString);
+	m_local_import_token_link->SetToolTip(_L("Click to copy the access key to the clipboard"));
+	// Keep the key readable after it has been clicked (don't turn "visited" purple).
+	m_local_import_token_link->SetVisitedColour(m_local_import_token_link->GetNormalColour());
+	m_local_import_token_link->SetHoverColour(m_local_import_token_link->GetNormalColour());
+	auto* regen_btn = new wxButton(parent, wxID_ANY, _L("Regenerate"));
+	regen_btn->SetToolTip(_L("Generate a new random access key"));
+	m_local_import_token_status = new wxStaticText(parent, wxID_ANY, wxEmptyString);
+
+	// Indent to line up with the download-path row, which is offset by its blinker icon.
+	sizer->AddSpacer(int(1.6 * em_unit()) + 2);
+	sizer->Add(label,                     0, wxALIGN_CENTER_VERTICAL | wxRIGHT, em_unit());
+	sizer->Add(m_local_import_token_link, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 2 * em_unit());
+	sizer->Add(regen_btn,                 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, em_unit());
+	sizer->Add(m_local_import_token_status, 0, wxALIGN_CENTER_VERTICAL);
+
+	m_local_import_token_sizer = sizer;
+	m_optgroup_other->sizer->Add(sizer, 0, wxEXPAND | wxTOP, em_unit());
+
+	auto copy_token = [this]() {
+		const wxString tok = m_local_import_token_link->GetLabel();
+		if (!tok.IsEmpty() && wxTheClipboard->Open()) {
+			wxTheClipboard->SetData(new wxTextDataObject(tok));
+			wxTheClipboard->Close();
+			if (m_local_import_token_status) {
+				m_local_import_token_status->SetLabel(_L("Copied to clipboard"));
+				m_local_import_token_sizer->Layout();
+			}
+		}
+	};
+
+	// Click the key text -> copy to clipboard (the hyperlink supplies the hover cursor).
+	m_local_import_token_link->Bind(wxEVT_HYPERLINK, [copy_token](wxHyperlinkEvent&) { copy_token(); });
+
+	regen_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+		const std::string t = LocalImportServer::generate_token();
+		m_values["local_import_token"] = t;
+		m_local_import_token_link->SetLabel(wxString::FromUTF8(t.c_str()));
+		if (m_local_import_token_status) {
+			m_local_import_token_status->SetLabel(_L("Token regenerated"));
+			m_local_import_token_sizer->Layout();
+		}
+	});
+
+	update_local_import_token_widget(app_config->get_bool("local_import_require_key"));
+}
+
+void PreferencesDialog::update_local_import_token_widget(bool require_key)
+{
+	if (!m_local_import_token_sizer)
+		return;
+
+	if (require_key) {
+		// Make sure a key exists so it can be displayed/copied.
+		std::string token;
+		if (auto it = m_values.find("local_import_token"); it != m_values.end())
+			token = it->second;
+		else
+			token = get_app_config()->get("local_import_token");
+		if (token.empty()) {
+			token = LocalImportServer::generate_token();
+			m_values["local_import_token"] = token;
+		}
+		if (m_local_import_token_link)
+			m_local_import_token_link->SetLabel(wxString::FromUTF8(token.c_str()));
+	}
+	if (m_local_import_token_status)
+		m_local_import_token_status->SetLabel(wxEmptyString);
+
+	m_optgroup_other->sizer->Show(m_local_import_token_sizer, require_key, true);
+	m_optgroup_other->parent()->Layout();
+}
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 
 void PreferencesDialog::init_highlighter(const t_config_option_key& opt_key)
 {

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -318,7 +318,7 @@ void PreferencesDialog::build()
 #ifdef SLIC3R_LOCAL_IMPORT_SERVER
 		append_bool_option(m_optgroup_general, "enable_local_import_server",
 			L("Enable local import server"),
-			L("If enabled, PrusaSlicer listens on a loopback HTTP port (127.0.0.1) so external "
+			L("If enabled, PrusaSlicer listens on a loopback HTTP port (127.0.0.1:8126) so external "
 			  "tools - such as a browser CAD app - can send model files directly into the open window. "
 			  "Bound to localhost only and off by default. Advanced options (port, allowed origin) "
 			  "are stored in PrusaSlicer.ini."),

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -23,6 +23,8 @@ class wxColourPickerCtrl;
 class wxBookCtrlBase;
 class wxSlider;
 class wxRadioButton;
+class wxStaticText;
+class wxHyperlinkCtrl;
 
 namespace Slic3r {
 
@@ -69,6 +71,12 @@ class PreferencesDialog : public DPIDialog
 
 	DownloaderUtils::Worker*			downloader { nullptr };
 
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+	wxSizer*							m_local_import_token_sizer  { nullptr };
+	wxHyperlinkCtrl*					m_local_import_token_link   { nullptr };
+	wxStaticText*						m_local_import_token_status { nullptr };
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
+
 	wxBookCtrlBase*						tabs {nullptr};
 
     bool                                isOSX {false};
@@ -106,6 +114,10 @@ protected:
     void create_settings_mode_color_widget();
     void create_settings_font_widget();
     void create_downloader_path_sizer();
+#ifdef SLIC3R_LOCAL_IMPORT_SERVER
+	void create_local_import_token_widget();
+	void update_local_import_token_widget(bool require_key);
+#endif // SLIC3R_LOCAL_IMPORT_SERVER
 	void init_highlighter(const t_config_option_key& opt_key);
 	std::vector<ConfigOptionsGroup*> optgroups();
 

--- a/src/slic3r/Utils/LocalImportServer.cpp
+++ b/src/slic3r/Utils/LocalImportServer.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <random>
 
 #include <boost/asio.hpp>
 #include <boost/beast/core.hpp>
@@ -179,6 +180,17 @@ struct LocalImportServer::Impl
     asio::io_context        ioc;
     std::unique_ptr<tcp::acceptor> acceptor;
 };
+
+std::string LocalImportServer::generate_token()
+{
+    std::random_device rd;
+    static const char hexd[] = "0123456789abcdef";
+    std::string token;
+    token.reserve(32);
+    for (int i = 0; i < 32; ++i)
+        token.push_back(hexd[rd() & 0xF]);
+    return token;
+}
 
 LocalImportServer::LocalImportServer(Config cfg, FileCallback on_file)
     : m_cfg(std::move(cfg))

--- a/src/slic3r/Utils/LocalImportServer.cpp
+++ b/src/slic3r/Utils/LocalImportServer.cpp
@@ -1,0 +1,270 @@
+#include "LocalImportServer.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
+
+namespace Slic3r {
+namespace GUI {
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+namespace http = beast::http;
+using tcp = asio::ip::tcp;
+
+namespace {
+
+// Reduce a client-supplied name to a safe leaf filename ending in a model
+// extension. The same input maps to the same output, so re-sending a part
+// overwrites the same temp file (PrusaSlicer then replaces it cleanly).
+std::string safe_name(const std::string& suggested)
+{
+    boost::filesystem::path p(suggested);
+    std::string base = p.filename().string(); // strip any path components
+    std::string ext  = p.extension().string();
+    std::string stem = base.substr(0, base.size() - ext.size());
+
+    std::transform(ext.begin(), ext.end(), ext.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    std::string clean;
+    clean.reserve(stem.size());
+    for (char c : stem) {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if (std::isalnum(uc) || c == '-' || c == '_' || c == '.' || c == ' ' || c == '(' || c == ')')
+            clean.push_back(c);
+        else
+            clean.push_back('_');
+    }
+    // trim spaces and dots
+    while (!clean.empty() && (clean.front() == '.' || clean.front() == ' '))
+        clean.erase(clean.begin());
+    while (!clean.empty() && (clean.back() == '.' || clean.back() == ' '))
+        clean.pop_back();
+    if (clean.empty())
+        clean = "model";
+
+    static const char* kModelExts[] = { ".step", ".stp", ".stl", ".obj", ".3mf", ".amf" };
+    bool ok_ext = false;
+    for (const char* e : kModelExts)
+        if (ext == e) { ok_ext = true; break; }
+    if (!ok_ext)
+        ext = ".step";
+
+    return clean + ext;
+}
+
+boost::filesystem::path write_temp(const std::string& name, const std::string& data)
+{
+    boost::filesystem::path dir = boost::filesystem::temp_directory_path() / "PrusaSlicer-import";
+    boost::system::error_code ec;
+    boost::filesystem::create_directories(dir, ec);
+    boost::filesystem::path path = dir / safe_name(name);
+    boost::nowide::ofstream out(path.string().c_str(), std::ios::binary | std::ios::trunc);
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    out.close();
+    return path;
+}
+
+// Reads one request, routes it, writes the response, closes the socket. Kept as a
+// free function so the (Asio-free) header need not declare Asio types.
+void handle_connection(const LocalImportServer::Config& cfg,
+                       const LocalImportServer::FileCallback& on_file,
+                       tcp::socket& socket)
+{
+    beast::error_code ec;
+    beast::flat_buffer buffer;
+    http::request_parser<http::string_body> parser;
+    parser.body_limit(cfg.max_body_bytes);
+    http::read(socket, buffer, parser, ec);
+    if (ec) {
+        socket.shutdown(tcp::socket::shutdown_both, ec);
+        return;
+    }
+    http::request<http::string_body> req = parser.release();
+
+    const std::string origin(req[http::field::origin]);
+    const bool origin_ok = !cfg.allowed_origin.empty() && origin == cfg.allowed_origin;
+
+    http::response<http::string_body> res;
+    res.version(req.version());
+    res.keep_alive(false);
+    res.set(http::field::server, "PrusaSlicer-LocalImport");
+
+    auto set_cors = [&]() {
+        if (origin_ok) {
+            res.set(http::field::access_control_allow_origin, origin);
+            res.set(http::field::vary, "Origin");
+        }
+        res.set(http::field::access_control_allow_methods, "POST, OPTIONS");
+        res.set(http::field::access_control_allow_headers, "Content-Type, X-Prusa-Token, X-Filename");
+        res.set(http::field::access_control_max_age, "600");
+    };
+
+    std::string target(req.target());
+    const std::string path = target.substr(0, target.find('?'));
+
+    auto send = [&](http::status status, const std::string& ctype, const std::string& body) {
+        res.result(status);
+        res.set(http::field::content_type, ctype);
+        res.body() = body;
+        res.prepare_payload();
+        http::write(socket, res, ec);
+        socket.shutdown(tcp::socket::shutdown_both, ec);
+    };
+
+    if (req.method() == http::verb::options && path == "/open") {
+        set_cors();
+        send(http::status::no_content, "text/plain", {});
+        return;
+    }
+    if (req.method() == http::verb::get && path == "/ping") {
+        set_cors();
+        send(http::status::ok, "application/json",
+             std::string("{\"app\":\"PrusaSlicer\",\"endpoint\":\"local-import\"}"));
+        return;
+    }
+    if (req.method() == http::verb::post && path == "/open") {
+        set_cors();
+        if (!origin.empty() && !origin_ok) {
+            send(http::status::forbidden, "text/plain", "origin not allowed");
+            return;
+        }
+        if (!cfg.token.empty() && std::string(req["X-Prusa-Token"]) != cfg.token) {
+            send(http::status::unauthorized, "text/plain", "bad token");
+            return;
+        }
+        if (req.body().empty()) {
+            send(http::status::bad_request, "text/plain", "empty body");
+            return;
+        }
+
+        std::string filename(req["X-Filename"]);
+        if (filename.empty())
+            filename = "model.step";
+
+        boost::filesystem::path tmp;
+        try {
+            tmp = write_temp(filename, req.body());
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "LocalImportServer: write temp failed: " << e.what();
+            send(http::status::internal_server_error, "text/plain", "could not store file");
+            return;
+        }
+
+        if (on_file)
+            on_file(tmp);
+
+        BOOST_LOG_TRIVIAL(info) << "LocalImportServer: received " << tmp.filename().string()
+                                << " (" << req.body().size() << " bytes)";
+        send(http::status::ok, "application/json",
+             std::string("{\"status\":\"ok\",\"file\":\"") + tmp.filename().string() + "\"}");
+        return;
+    }
+
+    set_cors();
+    send(http::status::not_found, "text/plain", "not found");
+}
+
+} // namespace
+
+struct LocalImportServer::Impl
+{
+    asio::io_context        ioc;
+    std::unique_ptr<tcp::acceptor> acceptor;
+};
+
+LocalImportServer::LocalImportServer(Config cfg, FileCallback on_file)
+    : m_cfg(std::move(cfg))
+    , m_on_file(std::move(on_file))
+    , m_impl(std::make_unique<Impl>())
+{}
+
+LocalImportServer::~LocalImportServer()
+{
+    stop();
+}
+
+bool LocalImportServer::start()
+{
+    if (m_running.load())
+        return true;
+
+    boost::system::error_code ec;
+    tcp::endpoint endpoint(asio::ip::make_address(m_cfg.bind_address, ec), m_cfg.port);
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error) << "LocalImportServer: bad bind address: " << ec.message();
+        return false;
+    }
+
+    m_impl->acceptor = std::make_unique<tcp::acceptor>(m_impl->ioc);
+    m_impl->acceptor->open(endpoint.protocol(), ec);
+    if (!ec) m_impl->acceptor->set_option(asio::socket_base::reuse_address(true), ec);
+    if (!ec) m_impl->acceptor->bind(endpoint, ec);
+    if (!ec) m_impl->acceptor->listen(asio::socket_base::max_listen_connections, ec);
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error) << "LocalImportServer: cannot listen on "
+                                 << m_cfg.bind_address << ':' << m_cfg.port << " - " << ec.message();
+        if (m_cfg.bind_address != "127.0.0.1" && m_cfg.bind_address != "localhost")
+            BOOST_LOG_TRIVIAL(error)
+                << "LocalImportServer: binding to a non-default loopback address requires it to be "
+                   "assigned to the loopback interface first (e.g. macOS: 'sudo ifconfig lo0 alias "
+                << m_cfg.bind_address << "').";
+        m_impl->acceptor.reset();
+        return false;
+    }
+
+    m_running.store(true);
+    m_thread = std::thread([this] { run(); });
+    BOOST_LOG_TRIVIAL(info) << "LocalImportServer: listening on http://"
+                            << m_cfg.bind_address << ':' << m_cfg.port;
+    return true;
+}
+
+void LocalImportServer::stop()
+{
+    if (!m_running.exchange(false))
+        return;
+    // Wake the io_context and close the acceptor from within its own thread.
+    asio::post(m_impl->ioc, [this] {
+        boost::system::error_code ec;
+        if (m_impl->acceptor)
+            m_impl->acceptor->close(ec);
+    });
+    m_impl->ioc.stop();
+    if (m_thread.joinable())
+        m_thread.join();
+    m_impl->ioc.restart();
+    m_impl->acceptor.reset();
+}
+
+void LocalImportServer::run()
+{
+    // Sequential accept/handle loop. Traffic is occasional (a user clicking
+    // "send"), so a single-threaded synchronous handler is plenty and easy to
+    // reason about.
+    std::function<void()> do_accept = [&]() {
+        auto socket = std::make_shared<tcp::socket>(m_impl->ioc);
+        m_impl->acceptor->async_accept(*socket, [this, socket, &do_accept](const boost::system::error_code& ec) {
+            if (ec) {
+                if (m_running.load())
+                    BOOST_LOG_TRIVIAL(trace) << "LocalImportServer: accept: " << ec.message();
+                return;
+            }
+            handle_connection(m_cfg, m_on_file, *socket);
+            if (m_running.load())
+                do_accept();
+        });
+    };
+    do_accept();
+    m_impl->ioc.run();
+}
+
+} // namespace GUI
+} // namespace Slic3r

--- a/src/slic3r/Utils/LocalImportServer.hpp
+++ b/src/slic3r/Utils/LocalImportServer.hpp
@@ -1,0 +1,77 @@
+#ifndef slic3r_LocalImportServer_hpp_
+#define slic3r_LocalImportServer_hpp_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <boost/filesystem/path.hpp>
+
+namespace Slic3r {
+namespace GUI {
+
+// A small, optional, loopback-only HTTP server that lets an external tool POST a
+// model file (STEP/STL/3MF/OBJ/...) to be opened in the running PrusaSlicer
+// instance. It is intentionally generic and GUI-agnostic: it writes the received
+// bytes to a temporary file and invokes a caller-supplied callback with the path.
+// The caller is responsible for marshalling onto the GUI thread (e.g. via
+// wxGetApp().CallAfter()) and calling Plater::load_files().
+//
+// Plain HTTP is sufficient: the browser code that calls this endpoint is served
+// from a real HTTPS origin, and browsers permit an HTTPS page to call
+// http://127.0.0.1 because loopback is a "potentially trustworthy" origin.
+class LocalImportServer
+{
+public:
+    struct Config
+    {
+        std::string bind_address = "127.0.0.1"; // loopback only; never 0.0.0.0
+        uint16_t    port         = 8126;
+        // Exact origin allowed for cross-origin (browser) calls. Empty disables
+        // the CORS header entirely (no cross-origin browser access). Never "*".
+        std::string allowed_origin;
+        // Optional shared secret; if non-empty, requests must send a matching
+        // "X-Prusa-Token" header.
+        std::string token;
+        // Maximum accepted request body size.
+        std::size_t max_body_bytes = 256u * 1024u * 1024u;
+    };
+
+    // Called from the server thread with the path of a freshly-written temp file.
+    using FileCallback = std::function<void(boost::filesystem::path)>;
+
+    LocalImportServer(Config cfg, FileCallback on_file);
+    ~LocalImportServer();
+
+    LocalImportServer(const LocalImportServer&) = delete;
+    LocalImportServer& operator=(const LocalImportServer&) = delete;
+
+    // Starts listening. Returns false if the socket could not be bound
+    // (e.g. the port is already in use).
+    bool start();
+    // Stops listening and joins the worker thread. Safe to call multiple times.
+    void stop();
+
+    bool running() const { return m_running.load(); }
+    uint16_t port() const { return m_cfg.port; }
+
+private:
+    void run();
+
+    Config            m_cfg;
+    FileCallback      m_on_file;
+    std::thread       m_thread;
+    std::atomic<bool> m_running{ false };
+
+    struct Impl; // hides the Asio/Beast types from the header
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace GUI
+} // namespace Slic3r
+
+#endif // slic3r_LocalImportServer_hpp_

--- a/src/slic3r/Utils/LocalImportServer.hpp
+++ b/src/slic3r/Utils/LocalImportServer.hpp
@@ -59,6 +59,9 @@ public:
     bool running() const { return m_running.load(); }
     uint16_t port() const { return m_cfg.port; }
 
+    // Generates a random hex access key (used for the X-Prusa-Token gate).
+    static std::string generate_token();
+
 private:
     void run();
 


### PR DESCRIPTION
## What this does

Adds an optional, off-by-default HTTP endpoint that listens on localhost so an
external tool can POST a model file (STEP/STL/3MF/OBJ) and have it open in the
already-running PrusaSlicer window.

The motivation is a "Send to PrusaSlicer" button for browser-based CAD tools
(Onshape, etc.), similar to what Fusion 360 offers. As a former long-suffering Fusion 360 user currently migrating much of my work to Onshape, this is one of my biggest current frustrations, hence the PR!

I was recently having to debug some issues with the 3DConnexion server interface that proxies SpaceMouse data into Onshape using a similar local REST server interface, so this is where much of the stylistic inspiration comes from in terms of implementation detail.

## How it works

The endpoint reuses the existing `Plater::load_files()` path; the same one already
used by the drag-and-drop interface. The server runs on its own thread. When a file arrives it's written to a temp file and the path is handed to a callback that marshals onto the GUI thread via `CallAfter()` before calling `load_files()`. We make no changes to the import/loading logic itself.

Request flow:
```
POST http://127.0.0.1:8126/open (model bytes, optional X-Filename / X-Prusa-Token)
-> LocalImportServer (worker thread): validate origin/token/size, write temp file
-> CallAfter -> Plater::load_files() (GUI thread) -> opens in the running window
```

## Settings
Two checkboxes under **Preferences -> Other**, both **default OFF**:
- **Enable local import server** - the on/off toggle.
- **Require an access key** - when on, every request must present a matching
  `X-Prusa-Token` header. A random key is generated into `local_import_token` on first
  enable, so it's secure without manual setup. You can regenerate and copy the key from within the settings UI.
  
Advanced options live in `PrusaSlicer.ini`:
| Key | Default | Meaning |
|---|---|---|
| `enable_local_import_server` | `0` | Master toggle |
| `local_import_require_key` | `0` | Require the `X-Prusa-Token` header |
| `local_import_token` | _(empty)_ | The access key (auto-generated when required) |
| `local_import_bind_address` | `127.0.0.1` | Loopback bind address |
| `local_import_server_port` | `8126` | Port |
| `local_import_allowed_origin` | _(empty)_ | The only browser origin allowed (CORS); empty = none |

## Security
- **Off by default**; binds **loopback only** (never `0.0.0.0`).
- **CORS** is reflected only for the exact configured origin - never `*`.
- **Optional access key** (`X-Prusa-Token`) means you have the ability to add an additional security checkpoint to further restrict any errant browser JS from writing local files without your say-so.
- Request **body size cap**, for obvious reasons!
- **Server-side sanitized temp filenames** - the caller supplies only a leaf name, which
  is stripped of path components and unsafe characters; it cannot influence where the
  file is written. The same name reuses the same temp file so re-sends replace cleanly rather than creating new objects.
- No process execution - bytes are only written to a temp file and handed to the existing
  importer logic.

## Why plain HTTP (no TLS/OpenSSL)
The endpoint is plain HTTP on loopback only. It does **not** pull in OpenSSL or any TLS
stack (not least as we don't do that at present afaik): the browser pages that call it are themselves served over HTTPS, and browsers already permit an HTTPS page to call `http://127.0.0.1` because loopback is a "potentially trustworthy" origin under W3C Secure Contexts. This keeps the change small and avoids touching the dependency graph.
  
## Build / opt-out
Gated behind a new CMake option **`SLIC3R_LOCAL_IMPORT_SERVER`** (default `ON`).

## Testing
- `SLIC3R_LOCAL_IMPORT_SERVER=ON`, enable the toggle in Preferences, then:
curl http://127.0.0.1:8126/ping
curl -X POST --data-binary @part.step -H 'X-Filename: part.step'
http://127.0.0.1:8126/open
-> the part opens in the running window.
- With **Require an access key** on, the same POST without a matching `X-Prusa-Token`
is rejected (401); with the key it succeeds.
- With the feature disabled (default), nothing listens.
## Notes
- The endpoint is intentionally generic - no Onshape/vendor-specific logic lives in
PrusaSlicer; that stays in the external sender.
- Happy to adjust defaults (port, whether the feature flag defaults on/off, exposing the
port/origin in the Preferences UI) to match the preferences - I couldn't seem to find much if any docs on requested styles/security preferences here, so entirely up for feedback!

Thanks for all for good work y'all do on PrusaSlicer :)
Jon