### PR TITLE
[3.0] Fix build with Catch2 v3: include catch_interfaces_capture.hpp

### DIFF
--- a/tests/sla_print/sla_test_utils.cpp
+++ b/tests/sla_print/sla_test_utils.cpp
@@ -11,6 +11,7 @@
 #include "Slic3r/Log.hpp"
 
 #include <iomanip>
+#include <catch2/interfaces/catch_interfaces_capture.hpp>
 
 using namespace Slic3r::Biz;
 using Algorithms::SVG::SVG;


### PR DESCRIPTION
Catch::getResultCapture() requires an explicit include of <catch2/interfaces/catch_interfaces_capture.hpp> in Catch2 v3, which was not previously included.

tests/sla_print/sla_test_utils.cpp:87:32: error: ‘getResultCapture’ is not a member of ‘Catch’
    m.WriteOBJFile((Catch::getResultCapture().getCurrentTestName() + "_" +
                           ^~~~~~~~~~~~~~~~