### PR TITLE
Fix organic support smoothing drift

### DIFF
--- a/src/libslic3r/Support/OrganicSupport.cpp
+++ b/src/libslic3r/Support/OrganicSupport.cpp
@@ -838,13 +838,74 @@ static void organic_smooth_branches_avoid_collisions(
     static constexpr const double max_nudge_collision_avoidance = 0.5;
     static constexpr const double max_nudge_smoothing = 0.2;
     static constexpr const size_t num_iter = 100; // 1000;
+
+    // Collision avoidance and Laplacian smoothing run iteratively. Keep each candidate
+    // reachable from its linked layers so the individual nudges cannot accumulate into a jump.
+    auto limit_candidate_to_linked_layers = [&collision_spheres, &linear_data_layers,
+                                             &config](size_t collision_sphere_id, Vec2d candidate) {
+        auto constrain_to_anchor =
+            [](Vec2d candidate, const Vec2d &current_pos, const Vec2d &anchor, double allowed_shift) {
+                const Vec2d delta = candidate - anchor;
+                const double candidate_dist = delta.norm();
+                const double current_dist = (current_pos - anchor).norm();
+                allowed_shift = std::max(allowed_shift, current_dist);
+                return candidate_dist > allowed_shift && candidate_dist > EPSILON ?
+                    anchor + delta * (allowed_shift / candidate_dist) :
+                    candidate;
+            };
+
+        const CollisionSphere &sphere = collision_spheres[collision_sphere_id];
+        const LayerIndex layer_idx = sphere.element.state.layer_idx;
+        const Vec2d current_pos = to_2d(sphere.position).cast<double>();
+        const double current_radius = double(support_element_radius(config, sphere.element));
+        const double max_move = double(config.maximum_move_distance_slow);
+
+        if (sphere.element_below_id != -1 && layer_idx > 0) {
+            const size_t lower_id = linear_data_layers[layer_idx - 1] +
+                size_t(sphere.element_below_id);
+            if (lower_id < collision_spheres.size()) {
+                const CollisionSphere &lower = collision_spheres[lower_id];
+                const double lower_radius = double(support_element_radius(config, lower.element));
+                const double allowed_shift = unscaled<double>(
+                    std::max(0., lower_radius - current_radius) + max_move
+                );
+                candidate = constrain_to_anchor(
+                    candidate, current_pos, to_2d(lower.prev_position).cast<double>(), allowed_shift
+                );
+            }
+        }
+
+        const LayerIndex upper_layer_idx = layer_idx + 1;
+        if (!sphere.element.parents.empty() &&
+            upper_layer_idx < LayerIndex(linear_data_layers.size())) {
+            const size_t upper_offset = linear_data_layers[upper_layer_idx];
+            for (int32_t parent_idx : sphere.element.parents) {
+                const size_t upper_id = upper_offset + size_t(parent_idx);
+                if (upper_id >= collision_spheres.size())
+                    continue;
+                const CollisionSphere &upper = collision_spheres[upper_id];
+                const double upper_radius = double(support_element_radius(config, upper.element));
+                const double allowed_shift = unscaled<double>(
+                    std::max(0., current_radius - upper_radius) + max_move
+                );
+                candidate = constrain_to_anchor(
+                    candidate, current_pos, to_2d(upper.prev_position).cast<double>(), allowed_shift
+                );
+            }
+        }
+
+        return candidate;
+    };
+
     for (size_t iter = 0; iter < num_iter; ++ iter) {
         // Back up prev position before Laplacian smoothing.
         for (CollisionSphere &collision_sphere : collision_spheres)
             collision_sphere.prev_position = collision_sphere.position;
         std::atomic<size_t> num_moved{ 0 };
         tbb::parallel_for(tbb::blocked_range<size_t>(0, collision_spheres.size()),
-            [&collision_spheres, &layer_collision_cache, &slicing_params, &config, &linear_data_layers, &num_moved, &throw_on_cancel](const tbb::blocked_range<size_t> range) {
+            [&collision_spheres, &layer_collision_cache, &slicing_params, &config,
+             &linear_data_layers, &num_moved, &throw_on_cancel,
+             &limit_candidate_to_linked_layers](const tbb::blocked_range<size_t> range) {
             for (size_t collision_sphere_id = range.begin(); collision_sphere_id < range.end(); ++ collision_sphere_id)
                 if (CollisionSphere &collision_sphere = collision_spheres[collision_sphere_id]; ! collision_sphere.locked) {
                     // Calculate collision of multiple 2D layers against a collision sphere.
@@ -873,10 +934,12 @@ static void organic_smooth_branches_avoid_collisions(
                         if (collision_sphere.last_collision_depth > EPSILON)
                             // a little bit of hysteresis to detect end of 
                             ++ num_moved;
-                        // Shift by maximum 2mm.
+                        // Limit collision-avoidance nudge per iteration.
                         double nudge_dist = std::min(std::max(0., collision_sphere.last_collision_depth + collision_extra_gap), max_nudge_collision_avoidance);
                         Vec2d nudge_vector = (to_2d(collision_sphere.position) - to_2d(collision_sphere.last_collision)).cast<double>().normalized() * nudge_dist;
-                        collision_sphere.position.head<2>() += (nudge_vector * nudge_dist).cast<float>();
+                        Vec2d candidate = to_2d(collision_sphere.position).cast<double>() + nudge_vector * nudge_dist;
+                        candidate = limit_candidate_to_linked_layers(collision_sphere_id, candidate);
+                        collision_sphere.position.head<2>() = candidate.cast<float>();
                     }
                     // Laplacian smoothing
                     Vec2d avg{ 0, 0 };
@@ -900,9 +963,13 @@ static void organic_smooth_branches_avoid_collisions(
                     Vec2d new_pos = (1. - smoothing_factor) * old_pos + smoothing_factor * avg;
                     Vec2d shift   = new_pos - old_pos;
                     double nudge_dist_max = shift.norm();
-                    // Shift by maximum 1mm, less than the collision avoidance factor.
+                    // Limit Laplacian smoothing nudge per iteration.
                     double nudge_dist = std::min(std::max(0., nudge_dist_max), max_nudge_smoothing);
-                    collision_sphere.position.head<2>() += (shift.normalized() * nudge_dist).cast<float>();
+                    if (nudge_dist > 0.) {
+                        Vec2d candidate = old_pos + shift * (nudge_dist / nudge_dist_max);
+                        candidate = limit_candidate_to_linked_layers(collision_sphere_id, candidate);
+                        collision_sphere.position.head<2>() = candidate.cast<float>();
+                    }
 
                     throw_on_cancel();
                 }


### PR DESCRIPTION
## Summary

- Constrain iterative organic-support collision avoidance and Laplacian smoothing to positions reachable from linked support nodes.
- Preserve pre-existing layer separation so the constraint does not pull valid branch geometry inward.
- Port only the smoothing changes from OrcaSlicer PRs [#14069](https://github.com/OrcaSlicer/OrcaSlicer/pull/14069) and [#14092](https://github.com/OrcaSlicer/OrcaSlicer/pull/14092), excluding their unrelated raft, layer-mapping, and root-mesh changes.

Fixes #10725.

## Root cause

Organic branch collision avoidance and smoothing run iteratively. The existing code limits each individual nudge, but it does not limit the accumulated distance between nodes on adjacent layers. Repeated nudges can therefore move a node beyond the distance its linked layers can support, producing an abrupt horizontal jump or a gap in the generated branch.

Each candidate position is now constrained using the radius change between linked nodes plus `maximum_move_distance_slow`. The limit is never made smaller than the link's current distance, which prevents already-valid branch separation from being collapsed. Linked positions are read from the existing per-iteration `prev_position` snapshot, keeping the parallel update independent of other workers' in-progress writes.

## Before and after

The comparison below contains direct captures from the built PrusaSlicer G-code Viewer. Both use the exact #10725 project, the same left orthographic camera and zoom, and a lower layer cutoff of Z 121.50 mm. The window titles identify the baseline and patched G-code files.

![PrusaSlicer G-code Viewer baseline and patched comparison](https://raw.githubusercontent.com/Vivalize/PrusaSlicer/32d10ad1be3f5f5bbb7d1f336b07cc5ea723136a/.github/pr-assets/15507/prusaslicer-before-after-left-stacked.png)

As a quantitative cross-check, the next comparison is generated from the support-material extrusion paths emitted by those same baseline and patched slices. Each horizontal line is one printed layer; the top row projects X against Z and the bottom row projects Y against Z.

![Organic support path projection comparison](https://raw.githubusercontent.com/Vivalize/PrusaSlicer/32d10ad1be3f5f5bbb7d1f336b07cc5ea723136a/.github/pr-assets/15507/pr-support-comparison.png)

The reporter's original PrusaSlicer preview is available [in the issue](https://github.com/prusa3d/PrusaSlicer/assets/135333327/b89c9d65-1703-4166-8272-a31ed81ea227).

## Provenance

This is a scoped port and adaptation of the organic smoothing fix authored by [@kisslorand](https://github.com/kisslorand) for OrcaSlicer. The original author is credited in the commit's `Co-authored-by` trailer. Both projects license this code under AGPL-3.0.

## Validation

- Completed a full macOS arm64 Release build of PrusaSlicer from `version_2.9.6` / `b028299c7`.
- Ran `ctest --test-dir build-default --output-on-failure`: 7/7 test targets passed.
- Reproduced #10725 using its attached PrusaSlicer project on the unmodified baseline and the patched build.
- Measured support-path projections around the reported discontinuity: the largest adjacent-layer projected edge change fell from 4.456 mm to 0.709 mm.
- Repeated the patched slice: the corrected support envelope was unchanged, with at most 0.017 mm support-centroid variation from the multithreaded slicing pipeline.
- `git diff --check` passed, and the new helper passes the repository's clang-format configuration.

## Scope note

The existing `Influence area could not be increased` diagnostic still appears for the reproduction, followed by `Trying to keep area by moving faster than intended: Success`. That fallback occurs during earlier influence-area generation. This change addresses the later smoothing drift visible in the emitted support geometry and intentionally does not alter the planner fallback.

A physical print was not performed.
