### PR TITLE
Improve SSL certificate store startup notice behavior

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1438,6 +1438,7 @@ bool GUI_App::on_init_inner()
                 dlg(nullptr,
                     wxString::Format(_L("%s\nDo you want to continue?"), msg),
                     "PrusaSlicer", wxICON_QUESTION | wxYES_NO);
+            dlg.SetYesNoLabels(_L("Continue"), _L("Abort"));
             dlg.ShowCheckBox(_L("Remember my choice"));
             if (dlg.ShowModal() != wxID_YES) return false;
 

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -77,20 +77,18 @@ struct CurlGlobalInit
                 }
             }
 
-            if (!bundle)
+            if (!bundle) {
                 message = _u8L("Could not detect system SSL certificate store. "
                                "PrusaSlicer will be unable to establish secure "
                                "network connections.");
-            else
-                message = Slic3r::GUI::format(
-					_L("PrusaSlicer detected system SSL certificate store in: %1%"),
-                    bundle);
-
-            message += "\n" + Slic3r::GUI::format(
-				_L("To specify the system certificate store manually, please "
-                   "set the %1% environment variable to the correct CA bundle "
-                   "and restart the application."),
-                SSL_CA_FILE);
+                message += "\n" + Slic3r::GUI::format(
+                    _L("To specify the system certificate store manually, please "
+                       "set the %1% environment variable to the correct CA bundle "
+                       "and restart the application."),
+                    SSL_CA_FILE);
+            } else {
+                BOOST_LOG_TRIVIAL(info) << "PrusaSlicer detected system SSL certificate store in: " << bundle;
+            }
         }
 
 #endif // OPENSSL_CERT_OVERRIDE


### PR DESCRIPTION
Currently when PrusaSlicer starts on Linux there is a notification  about SSL certificates being read from the system store. I'd guesstimate that 90% of the users seeing the alert are clicking remember and "yes". The users that might care about the SSL certificate location can be expected to be savvy enough to work around the notice on the system level anyway. So in the end this notice is just noise for the users.

This change addresses two things:
1. Remove the alert from users unless there is something that is actually alarming. The notice is still logged silently, so people who want to override SSL store, can still see the log entry there.
2. Changes the buttons to Continue/Abort. The Yes and No do not really map to anything useful for the user anyway as the whole message isn't a Yes/No situation.

This addresses a long running annoyance I've had with PrusaSlicer and derivates. We really should pay more attention to the non-technical user experience and this is my tiny contribution towards that.