### PR TITLE
Add continuous constant-wall spiral mode (thick-wall spiral vase)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2603,10 +2603,18 @@ LayerResult GCodeGenerator::process_layer(
     // Just a reminder: A spiral vase mode is allowed for a single object, single material print only.
     m_enable_loop_clipping = true;
     if (m_spiral_vase && layers.size() == 1 && support_layer == nullptr) {
-        bool enable = (layer.id() > 0 || !print.has_brim()) && (layer.id() >= (size_t)print.config().skirt_height.value && ! print.has_infinite_skirt());
+        // The continuous constant-wall spiral is flat-per-layer with only a short in-wall ramp
+        // at the very end of the layer, so it coexists with skirt/brim on the first layer
+        // (unlike the classic whole-layer Z ramp, which must not start below them).
+        bool enable = print.config().constant_wall_spiral.value ||
+            ((layer.id() > 0 || !print.has_brim()) && (layer.id() >= (size_t)print.config().skirt_height.value && ! print.has_infinite_skirt()));
         if (enable) {
+            // In constant-wall mode a qualifying layer is already a solid wall - bottom solid
+            // layers add nothing there, and non-qualifying layers are caught by the perimeter
+            // and fill counts below (a spiral layer is exactly one perimeter entity, no fills).
+            const bool check_bottom = ! print.config().constant_wall_spiral.value;
             for (const LayerRegion *layer_region : layer.regions())
-                if (size_t(layer_region->region().config().bottom_solid_layers.value) > layer.id() ||
+                if ((check_bottom && size_t(layer_region->region().config().bottom_solid_layers.value) > layer.id()) ||
                     layer_region->perimeters().items_count() > 1u ||
                     layer_region->fills().items_count() > 0) {
                     enable = false;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1052,7 +1052,7 @@ void GCodeGenerator::_do_export(Print& print, GCodeOutputStream &file, Thumbnail
     m_volumetric_speed = DoExport::autospeed_volumetric_limit(print);
     print.throw_if_canceled();
 
-    if (print.config().spiral_vase.value)
+    if (print.config().spiral_vase.value || print.config().constant_wall_spiral.value)
         m_spiral_vase = make_unique<SpiralVase>(print.config());
 
     if (print.config().max_volumetric_extrusion_rate_slope_positive.value > 0 ||

--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -237,11 +237,18 @@ std::string SpiralVase::process_layer_multiwall(const std::string &gcode, bool l
         const double col_volume    = PI * 0.25 * max_nozzle * max_nozzle * (double) layer_height;
         const double de            = col_volume / filament_area;
         char buf[96];
-        if (relative_e)
+        if (relative_e) {
             snprintf(buf, sizeof(buf), "G1 Z%.3f E%.5f F600", z_nominal + layer_height, de);
-        else
+            out_lines.insert(out_lines.begin() + last_extruding + 1, buf);
+        } else {
+            // Absolute E: the injected climb extrudes material the generator never counted, so
+            // restore the counter afterwards - otherwise every next layer's first E value sits
+            // below the counter and reads as a (physically meaningless) micro-retract.
             snprintf(buf, sizeof(buf), "G1 Z%.3f E%.5f F600", z_nominal + layer_height, last_abs_e + de);
-        out_lines.insert(out_lines.begin() + last_extruding + 1, buf);
+            out_lines.insert(out_lines.begin() + last_extruding + 1, buf);
+            snprintf(buf, sizeof(buf), "G92 E%.5f", last_abs_e);
+            out_lines.insert(out_lines.begin() + last_extruding + 2, buf);
+        }
     }
     std::string new_gcode;
     new_gcode.reserve(gcode.size() + 32);

--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -44,6 +44,11 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
         return gcode;
     }
 
+    // Multi-wall (thick) spiral vase: the layer is one morphed multi-ring spiral path; keep it
+    // FLAT at its nominal height and only ramp the final short arc up to the next layer.
+    if (m_config.spiral_vase_wall_count.value != 1)
+        return this->process_layer_multiwall(gcode, last_layer);
+
     // Get total XY length for this layer by summing all extrusion moves.
     float total_layer_length = 0.f;
     float layer_height       = 0.f;
@@ -162,6 +167,69 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
 
     m_previous_layer = std::move(current_layer);
     return new_gcode + transition_gcode;
+}
+
+// Multi-wall (thick) spiral vase - flat layers with a short spiral transition.
+// The layer's perimeter G-code is one continuous morphed spiral covering every concentric wall.
+// The whole layer is printed FLAT at its nominal Z, so every wall is present at every height ->
+// a genuinely solid thick wall. Only the final L_TRANS of the layer (the tail of the last ring,
+// which the perimeter morph alternates between the innermost and outermost wall per layer) ramps
+// Z up by one layer height, turning the layer-change Z seam into a short fixed-length spiral.
+// L_TRANS is a constant arc length (0.05 inch) regardless of part size.
+std::string SpiralVase::process_layer_multiwall(const std::string &gcode, bool /*last_layer*/)
+{
+    const float L_TRANS = 1.27f; // 0.05 inch, fixed regardless of geometry
+
+    // --- First pass: total XY extrusion length, layer height, and the layer's nominal Z. ---
+    float total_len = 0.f, layer_height = 0.f, z_nominal = 0.f;
+    bool  set_z = false;
+    {
+        GCodeReader r = m_reader; // clone
+        r.parse_buffer(gcode, [&total_len, &layer_height, &z_nominal, &set_z]
+            (GCodeReader &reader, const GCodeReader::GCodeLine &line) {
+            if (line.cmd_is("G1")) {
+                if (line.extruding(reader))
+                    total_len += line.dist_XY(reader);
+                else if (line.has(Z)) {
+                    layer_height += line.dist_Z(reader);
+                    if (! set_z) { z_nominal = line.new_Z(reader); set_z = true; }
+                }
+            }
+        });
+    }
+    if (total_len <= 0.f) { m_reader.parse_buffer(gcode); return gcode; }
+
+    // The final L_TRANS of the layer ramps from the flat height up to the next layer.
+    const float ramp_start = std::max(0.f, total_len - L_TRANS);
+    const float ramp_span  = total_len - ramp_start; // == min(L_TRANS, total_len)
+
+    std::string new_gcode;
+    float       len = 0.f;
+    m_reader.parse_buffer(gcode, [&]
+        (GCodeReader &reader, GCodeReader::GCodeLine line) {
+        if (! line.cmd_is("G1")) { new_gcode += line.raw() + '\n'; return; }
+        // Flatten any Z-only move (layer change / travel hop) to the layer's nominal height;
+        // the spiral transition at the end of the previous layer already climbed us here.
+        if (line.has_z() && ! (line.has_x() || line.has_y())) {
+            line.set(reader, Z, z_nominal);
+            new_gcode += line.raw() + '\n';
+            return;
+        }
+        const bool extruding = line.extruding(reader) && line.dist_XY(reader) > 0;
+        if (! extruding) { new_gcode += line.raw() + '\n'; return; } // travel / retract: unchanged
+
+        len += line.dist_XY(reader);
+        float zz = z_nominal; // flat across the body of the layer
+        if (ramp_span > 0.f && len > ramp_start) {
+            float f = (len - ramp_start) / ramp_span;
+            if (f > 1.f) f = 1.f;
+            zz = z_nominal + f * layer_height; // short spiral up to the next layer
+        }
+        line.set(reader, Z, zz);
+        new_gcode += line.raw() + '\n';
+    });
+
+    return new_gcode;
 }
 
 }

--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -44,9 +44,10 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
         return gcode;
     }
 
-    // Multi-wall (thick) spiral vase: the layer is one morphed multi-ring spiral path; keep it
-    // FLAT at its nominal height and only ramp the final short arc up to the next layer.
-    if (m_config.spiral_vase_wall_count.value != 1)
+    // Continuous constant-wall spiral: the layer is one morphed multi-ring spiral path; keep it
+    // FLAT at its nominal height and only ramp the final short arc (the in-wall elevator) up to
+    // the next layer.
+    if (m_config.constant_wall_spiral.value)
         return this->process_layer_multiwall(gcode, last_layer);
 
     // Get total XY length for this layer by summing all extrusion moves.

--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -177,10 +177,8 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
 // which the perimeter morph alternates between the innermost and outermost wall per layer) ramps
 // Z up by one layer height, turning the layer-change Z seam into a short fixed-length spiral.
 // L_TRANS is a constant arc length (0.05 inch) regardless of part size.
-std::string SpiralVase::process_layer_multiwall(const std::string &gcode, bool /*last_layer*/)
+std::string SpiralVase::process_layer_multiwall(const std::string &gcode, bool last_layer)
 {
-    const float L_TRANS = 1.27f; // 0.05 inch, fixed regardless of geometry
-
     // --- First pass: total XY extrusion length, layer height, and the layer's nominal Z. ---
     float total_len = 0.f, layer_height = 0.f, z_nominal = 0.f;
     bool  set_z = false;
@@ -200,36 +198,57 @@ std::string SpiralVase::process_layer_multiwall(const std::string &gcode, bool /
     }
     if (total_len <= 0.f) { m_reader.parse_buffer(gcode); return gcode; }
 
-    // The final L_TRANS of the layer ramps from the flat height up to the next layer.
-    const float ramp_start = std::max(0.f, total_len - L_TRANS);
-    const float ramp_span  = total_len - ramp_start; // == min(L_TRANS, total_len)
-
-    std::string new_gcode;
-    float       len = 0.f;
+    // The whole layer prints FLAT at its nominal Z. The climb to the next layer is a single
+    // STRAIGHT VERTICAL extruding move (the elevator column) appended after the layer's last
+    // extrusion - the layer ends on the seam interstice pad the generator placed there, and the
+    // next layer's paths arc around the column. The print's last layer gets no climb.
+    std::vector<std::string> out_lines;
+    size_t      last_extruding = std::string::npos;
+    float       last_abs_e = 0.f;
+    const bool  relative_e = m_config.use_relative_e_distances.value;
     m_reader.parse_buffer(gcode, [&]
         (GCodeReader &reader, GCodeReader::GCodeLine line) {
-        if (! line.cmd_is("G1")) { new_gcode += line.raw() + '\n'; return; }
-        // Flatten any Z-only move (layer change / travel hop) to the layer's nominal height;
-        // the spiral transition at the end of the previous layer already climbed us here.
+        if (! line.cmd_is("G1")) { out_lines.emplace_back(line.raw()); return; }
+        // Flatten any Z move to the layer's nominal height; the vertical elevator at the end of
+        // the previous layer already climbed us here.
         if (line.has_z() && ! (line.has_x() || line.has_y())) {
             line.set(reader, Z, z_nominal);
-            new_gcode += line.raw() + '\n';
+            out_lines.emplace_back(line.raw());
             return;
         }
-        const bool extruding = line.extruding(reader) && line.dist_XY(reader) > 0;
-        if (! extruding) { new_gcode += line.raw() + '\n'; return; } // travel / retract: unchanged
-
-        len += line.dist_XY(reader);
-        float zz = z_nominal; // flat across the body of the layer
-        if (ramp_span > 0.f && len > ramp_start) {
-            float f = (len - ramp_start) / ramp_span;
-            if (f > 1.f) f = 1.f;
-            zz = z_nominal + f * layer_height; // short spiral up to the next layer
-        }
-        line.set(reader, Z, zz);
-        new_gcode += line.raw() + '\n';
+        if (line.has(E) && ! relative_e)
+            last_abs_e = line.e();
+        if (line.extruding(reader) && line.dist_XY(reader) > 0) {
+            line.set(reader, Z, z_nominal);
+            out_lines.emplace_back(line.raw());
+            last_extruding = out_lines.size() - 1;
+        } else
+            out_lines.emplace_back(line.raw());
     });
 
+    if (! last_layer && layer_height > 0.f && last_extruding != std::string::npos) {
+        // The vertical elevator: climb one layer height IN PLACE, right at the elevator pad (the
+        // layer's last extrusion), extruding enough to leave a nozzle-diameter column bead
+        // (pressure stays up, no retract, no restart). Inserted before any trailing travel so
+        // the column lands exactly where the next layer's avoidance arcs expect it.
+        const double max_nozzle    = *std::max_element(m_config.nozzle_diameter.values.begin(), m_config.nozzle_diameter.values.end());
+        const double fil_d         = m_config.filament_diameter.get_at(0);
+        const double filament_area = PI * 0.25 * fil_d * fil_d;
+        const double col_volume    = PI * 0.25 * max_nozzle * max_nozzle * (double) layer_height;
+        const double de            = col_volume / filament_area;
+        char buf[96];
+        if (relative_e)
+            snprintf(buf, sizeof(buf), "G1 Z%.3f E%.5f F600", z_nominal + layer_height, de);
+        else
+            snprintf(buf, sizeof(buf), "G1 Z%.3f E%.5f F600", z_nominal + layer_height, last_abs_e + de);
+        out_lines.insert(out_lines.begin() + last_extruding + 1, buf);
+    }
+    std::string new_gcode;
+    new_gcode.reserve(gcode.size() + 32);
+    for (const std::string &l : out_lines) {
+        new_gcode += l;
+        new_gcode += '\n';
+    }
     return new_gcode;
 }
 

--- a/src/libslic3r/GCode/SpiralVase.hpp
+++ b/src/libslic3r/GCode/SpiralVase.hpp
@@ -43,6 +43,9 @@ public:
     std::string process_layer(const std::string &gcode, bool last_layer);
 
 private:
+    // Multi-wall (thick) spiral vase: flat layers with a short spiral ramp at the layer change.
+    std::string process_layer_multiwall(const std::string &gcode, bool last_layer);
+
     const PrintConfig  &m_config;
     GCodeReader 		m_reader;
     float               m_max_xy_smoothing = 0.f;

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -139,7 +139,10 @@ void LayerRegion::make_perimeters(
         auto perimeters_begin      = uint32_t(m_perimeters.size());
         auto gap_fills_begin       = uint32_t(m_thin_fills.size());
         auto fill_expolygons_begin = uint32_t(fill_expolygons.size());
-        if (this->layer()->object()->config().perimeter_generator.value == PerimeterGeneratorType::Arachne && !spiral_vase)
+        // The continuous constant-wall spiral is implemented in the classic generator; force it
+        // for the whole print when the mode is on so qualifying layers can take the spiral path.
+        if (this->layer()->object()->config().perimeter_generator.value == PerimeterGeneratorType::Arachne && !spiral_vase &&
+            !print_config.constant_wall_spiral.value)
             PerimeterGenerator::process_arachne(
                 // input:
                 params,

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1186,7 +1186,7 @@ void PerimeterGenerator::process_arachne(
 // (outer->inner on even layers, inner->outer on odd) so the layer-change spiral ramp connects
 // end-to-start. Z stays 0 here; the SpiralVase post-processor flattens each layer at its nominal
 // height and turns the final ~1.27mm of the layer into a short spiral ramp to the next layer.
-static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t layer_id)
+static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t layer_id, double wall_area_scaled2)
 {
     // 1. Collect the ExtrusionLoop entities.
     std::vector<const ExtrusionLoop *> loops;
@@ -1453,13 +1453,62 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
         std::reverse(radii.begin(), radii.end());
     }
 
-    // 7. Build the path: hold each ring FLAT at its own radius, and step inward to the next
-    //    ring only over a short eased transition (~L_TRANS_RADIAL arc, smoothstep so there is no
-    //    sharp jerk) at the ring seam - instead of spiralling the radius over the whole
-    //    revolution. Seams are aligned across rings (step 5b), so they stack into one line.
+    // 7.+8. Build the spiral as ONE ExtrusionMultiPath (a single entity, so the per-layer spiral
+    //    vase check still sees one perimeter) whose segments carry LOCALLY-correct volumetric
+    //    flow, then normalize globally so the layer extrudes EXACTLY wall_area * layer_height -
+    //    100% of the sliced wall volume, neither over- nor under-deposited.
+    //
+    //    Geometry (unchanged): hold each ring FLAT at its own radius, step to the next ring only
+    //    over a short smoothstep transition (~L_TRANS_RADIAL of arc) at the ring seam. Seams are
+    //    aligned across rings (step 5b), so they stack into one line.
+    //
+    //    Local coverage model (bead cross-section = coverage_width * layer_height):
+    //      - flat ring arcs: each bead covers one ring pitch.
+    //      - step diagonals: adjacent diagonals are parallel, radially one pitch apart, so their
+    //        perpendicular spacing is pitch * cos(theta), theta = atan(pitch / L_TRANS). Constant
+    //        nominal flow would over-deposit by 1/cos(theta) right at the seam.
+    //      - the final ring's seam arc: the incoming diagonal converged onto this ring across the
+    //        same arc, so the leftover strip between them narrows from one pitch to zero. Constant
+    //        flow would re-deposit a full bead on top of the diagonal's tail - THE seam blob.
+    //        Taper the coverage with the same smoothstep the diagonal used (chunked, since one
+    //        path has one flow value).
+    //    The global normalization then absorbs the small remaining geometric slivers (the
+    //    triangular step voids), distributing them uniformly (~1-2%), so total volume is exact.
     const double L_TRANS_RADIAL = scale_(1.27); // 0.05 inch of arc for the wall-to-wall step
-    std::vector<Point> spiral;
-    spiral.reserve((size_t) K_aug * M);
+    const double h = (double) ref.height();     // layer height (mm)
+
+    // Uniform pitch of the final ring set (scaled units).
+    double pitch_scaled = 0.;
+    {
+        std::vector<double> fspac;
+        fspac.reserve(radii.size());
+        for (size_t r = 0; r + 1 < radii.size(); ++r)
+            fspac.push_back(std::abs(radii[r] - radii[r + 1]));
+        if (! fspac.empty()) {
+            std::sort(fspac.begin(), fspac.end());
+            const size_t fm = fspac.size();
+            pitch_scaled = (fm % 2 == 1) ? fspac[fm / 2]
+                                         : 0.5 * (fspac[fm / 2 - 1] + fspac[fm / 2]);
+        }
+    }
+    if (pitch_scaled <= 0.)
+        pitch_scaled = scale_(std::max(0.1f, ref.width()));
+    const double pitch_mm = unscale<double>(coord_t(pitch_scaled));
+
+    ExtrusionMultiPath multi;
+    // Segment accumulator: emit consecutive points sharing one coverage width as one sub-path.
+    // Consecutive sub-paths share their boundary point so the chain is continuous.
+    auto emit_segment = [&multi, &ref, h](Points &&pts, double coverage_mm) {
+        if (pts.size() < 2)
+            return;
+        const double w = std::max(coverage_mm, 0.05); // keep E > 0 so the move stays an extrusion
+        Polyline pl;
+        pl.points = std::move(pts);
+        multi.paths.emplace_back(std::move(pl),
+            ExtrusionAttributes(ref.role(), ExtrusionFlow(w * h, (float) w, (float) h)));
+    };
+
+    const double cos_theta = L_TRANS_RADIAL / std::hypot(L_TRANS_RADIAL, pitch_scaled);
     for (size_t r = 0; r + 1 < K_aug; ++r) {
         const std::vector<Point> &a = resampled[r];
         const std::vector<Point> &b = resampled[r + 1];
@@ -1470,6 +1519,9 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
         if (trans < 1) trans = 1;
         if (trans > M) trans = M;
         const size_t flat = M - trans;        // points held flat at ring r before the step
+        Points flat_pts, diag_pts;
+        flat_pts.reserve(flat + 1);
+        diag_pts.reserve(trans + 1);
         for (size_t j = 0; j < M; ++j) {
             double t;
             if (j < flat) {
@@ -1479,50 +1531,76 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
                 if (u > 1.0) u = 1.0;
                 t = u * u * (3.0 - 2.0 * u);   // smoothstep ease - no kink at either end
             }
-            spiral.push_back(lerp(a[j], b[j], t));
+            const Point p = lerp(a[j], b[j], t);
+            if (j < flat) {
+                flat_pts.push_back(p);
+            } else {
+                if (diag_pts.empty() && ! flat_pts.empty())
+                    diag_pts.push_back(flat_pts.back()); // share the boundary point
+                diag_pts.push_back(p);
+            }
+        }
+        emit_segment(std::move(flat_pts), pitch_mm);
+        emit_segment(std::move(diag_pts), pitch_mm * cos_theta);
+    }
+    // The final ring: full flat revolution, but its seam arc re-traces the arc the incoming
+    // diagonal converged onto - taper the coverage to match the narrowing leftover strip.
+    {
+        const std::vector<Point> &fin = resampled[K_aug - 1];
+        double circ = 0.;
+        for (size_t j = 0; j < M; ++j)
+            circ += (fin[(j + 1) % M] - fin[j]).cast<double>().norm();
+        size_t trans = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
+        if (trans < 1) trans = 1;
+        if (trans > M) trans = M;
+        const size_t flat = M - trans;
+        Points flat_pts(fin.begin(), fin.begin() + flat);
+        emit_segment(std::move(flat_pts), pitch_mm);
+        // Chunk the tapered arc: coverage tracks the strip left by the diagonal, (1 - t) * pitch.
+        const size_t N_CHUNK = 4;
+        for (size_t c = 0; c < N_CHUNK; ++c) {
+            const size_t j0 = flat + (trans * c) / N_CHUNK;
+            const size_t j1 = flat + (trans * (c + 1)) / N_CHUNK;
+            if (j0 >= j1)
+                continue;
+            Points chunk;
+            chunk.reserve(j1 - j0 + 1);
+            if (j0 > 0)
+                chunk.push_back(fin[j0 - 1]); // share the boundary point
+            for (size_t j = j0; j < j1; ++j)
+                chunk.push_back(fin[j]);
+            const double u_mid = (double(j0 + j1) * 0.5 - double(flat) + 1.0) / double(trans);
+            const double t_mid = std::min(1.0, u_mid * u_mid * (3.0 - 2.0 * u_mid));
+            emit_segment(std::move(chunk), pitch_mm * std::max(0.05, 1.0 - t_mid));
         }
     }
-    // Append the final ring fully to finish the innermost (or outermost) ring.
-    for (size_t j = 0; j < M; ++j)
-        spiral.push_back(resampled[K_aug - 1][j]);
+    if (multi.paths.empty())
+        return;
 
-    // 8. Build a single ExtrusionPath from the spiral points.
-    //    Deposit each bead slightly WIDER than the ring pitch so adjacent rings overlap and fuse
-    //    into a solid wall. Width == pitch (0% overlap) leaves the beads merely touching, which
-    //    reads visibly gappy at typical perimeter pitches. A ~15% overlap closes the seam at
-    //    every pitch without meaningful over-extrusion (matches the overlap solid infill uses).
-    //    Rectangular flow (w*h) keeps the deposited width == w.
-    double out_mm3_per_mm = ref.mm3_per_mm();
-    float  out_width      = ref.width();
+    // Global volumetric normalization: scale every segment's flow so the layer's total extruded
+    // volume equals EXACTLY the sliced wall area times the layer height.
     {
-        std::vector<double> fspac;            // consecutive |spacings| of the final ring set (scaled)
-        fspac.reserve(radii.size());
-        for (size_t r = 0; r + 1 < radii.size(); ++r)
-            fspac.push_back(std::abs(radii[r] - radii[r + 1]));
-        if (! fspac.empty()) {
-            std::sort(fspac.begin(), fspac.end());
-            const size_t fm  = fspac.size();
-            const double med_scaled = (fm % 2 == 1) ? fspac[fm / 2]
-                                                    : 0.5 * (fspac[fm / 2 - 1] + fspac[fm / 2]);
-            if (med_scaled > 0.) {
-                const double OVERLAP = 1.15;
-                const double w_mm = unscale<double>(coord_t(med_scaled)) * OVERLAP; // bead width (mm)
-                const double h    = (double) ref.height();                          // layer height (mm)
-                out_width      = (float) w_mm;
-                out_mm3_per_mm = w_mm * h;
+        double v_planned = 0.;
+        for (const ExtrusionPath &p : multi.paths)
+            v_planned += p.mm3_per_mm() * unscale<double>(p.polyline.length());
+        const double wall_area_mm2 = wall_area_scaled2 * SCALING_FACTOR * SCALING_FACTOR;
+        const double v_exact       = wall_area_mm2 * h;
+        if (const char *dbg = std::getenv("MULTIWALL_DEBUG"); dbg != nullptr && (atoi(dbg) == (int) layer_id || atoi(dbg) == -1))
+            fprintf(stderr, "[multiwall] layer %zu: v_planned=%.2f v_exact=%.2f (A=%.2f mm2, h=%.3f) f=%.4f segs=%zu\n",
+                layer_id, v_planned, v_exact, wall_area_mm2, h, v_exact / std::max(1e-9, v_planned), multi.paths.size());
+        if (v_planned > 0. && v_exact > 0.) {
+            const double f = v_exact / v_planned;
+            for (ExtrusionPath &p : multi.paths) {
+                ExtrusionAttributes attr = p.attributes();
+                attr.mm3_per_mm *= f;
+                p = ExtrusionPath(std::move(p.polyline), attr);
             }
         }
     }
-    Polyline pl;
-    pl.points.reserve(spiral.size());
-    for (const Point &p : spiral)
-        pl.points.push_back(p);
-    ExtrusionPath path(std::move(pl),
-        ExtrusionAttributes(ref.role(), ExtrusionFlow(out_mm3_per_mm, out_width, ref.height())));
 
-    // 9. Replace the loop collection with the single spiral path.
+    // 9. Replace the loop collection with the single continuous multi-segment spiral.
     entities.clear();
-    entities.append(std::move(path));
+    entities.append(std::move(multi));
 }
 
 void PerimeterGenerator::process_classic(
@@ -1803,8 +1881,9 @@ void PerimeterGenerator::process_classic(
         ExtrusionEntityCollection entities = traverse_loops_classic(params, lower_slices_polygons_cache, contours.front(), thin_walls);
         if (multiwall_spiral && entities.entities.size() > 1) {
             // Multi-wall (thick) spiral vase: morph the concentric loops into one continuous
-            // spiral path per layer (flat rings + short smoothstep seam transitions).
-            make_multiwall_spiral(entities, (size_t) params.layer_id);
+            // spiral path per layer (flat rings + short smoothstep seam transitions). The sliced
+            // wall area drives the exact per-layer extrusion volume (area * layer height).
+            make_multiwall_spiral(entities, (size_t) params.layer_id, std::abs(surface.expolygon.area()));
         }
         // if brim will be printed, reverse the order of perimeters so that
         // we continue inwards after having finished the brim

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1495,10 +1495,70 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     }
     const size_t K_aug = resampled.size();
 
-    // 6. Order outer->inner (already sorted that way); reverse to inner->outer on odd layers.
+    // Uniform pitch of the final ring set (scaled units).
+    double pitch_scaled = 0.;
+    {
+        std::vector<double> fspac;
+        fspac.reserve(radii.size());
+        for (size_t r = 0; r + 1 < radii.size(); ++r)
+            fspac.push_back(std::abs(radii[r] - radii[r + 1]));
+        if (! fspac.empty()) {
+            std::sort(fspac.begin(), fspac.end());
+            const size_t fm = fspac.size();
+            pitch_scaled = (fm % 2 == 1) ? fspac[fm / 2]
+                                         : 0.5 * (fspac[fm / 2 - 1] + fspac[fm / 2]);
+        }
+    }
+    if (pitch_scaled <= 0.)
+        pitch_scaled = scale_(std::max(0.1f, ref.width()));
+    const double pitch_mm = unscale<double>(coord_t(pitch_scaled));
+    // Wall-to-wall step-over: a SHORT tangent S-arc with one-wall-width corner radius (total
+    // arc ~2 pitches long) instead of a long straight ramp.
+    const double L_STEP    = 2.0 * pitch_scaled;
+    const double cos_theta = L_STEP / std::hypot(L_STEP, 0.5 * PI * pitch_scaled); // avg slope of the cosine S
+
+    // Per-ring seam-arc length in samples.
+    auto trans_of = [&](const std::vector<Point> &ring) -> size_t {
+        double circ = 0.;
+        for (size_t j = 0; j < M; ++j)
+            circ += (ring[(j + 1) % M] - ring[j]).cast<double>().norm();
+        size_t tr = (circ > 0.) ? (size_t)(L_STEP * (double) M / circ + 0.5) : M;
+        if (tr < 3) tr = 3;
+        if (tr > M) tr = M;
+        return tr;
+    };
+
+    // 6. Order outer->inner (already sorted that way). Odd layers run inner->outer AND in the
+    //    OPPOSITE rotation around the part (boustrophedon): the layer starts exactly where the
+    //    previous layer's vertical elevator ended, prints its whole spiral in one direction, and
+    //    climbs - the next layer then continues in the other direction from that very spot.
+    //    No backward positioning move, no connector, no travel: even layers run B -> A and climb
+    //    at A; odd layers run A -> B and climb at B (A and B are two fixed spots one step-arc
+    //    apart on the wall).
     if (layer_id % 2 == 1) {
         std::reverse(resampled.begin(), resampled.end());
         std::reverse(radii.begin(), radii.end());
+        const Point C = loop_polys.front().polygon.centroid();
+        for (std::vector<Point> &ring : resampled) {
+            // Flip the winding (CCW -> CW)...
+            std::reverse(ring.begin(), ring.end());
+            // ...re-anchor index 0 to +X in the flipped ring...
+            size_t best_j  = 0;
+            double best_d  = -std::numeric_limits<double>::infinity();
+            for (size_t j = 0; j < M; ++j) {
+                const Vec2d d  = (ring[j] - C).cast<double>();
+                const double n = d.norm();
+                const double c = (n > 0.) ? d.x() / n : -1.;
+                if (c > best_d) { best_d = c; best_j = j; }
+            }
+            if (best_j != 0)
+                std::rotate(ring.begin(), ring.begin() + best_j, ring.end());
+            // ...then shift by one step-arc so this layer's entry point (index flat) coincides
+            // with the even layers' exit point (the anchor).
+            const size_t tr = trans_of(ring) % M;
+            if (tr != 0)
+                std::rotate(ring.begin(), ring.begin() + tr, ring.end());
+        }
     }
 
     // 7.+8. Build the spiral as ONE ExtrusionMultiPath (a single entity, so the per-layer spiral
@@ -1524,24 +1584,6 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     //    triangular step voids), distributing them uniformly (~1-2%), so total volume is exact.
     const double h = (double) ref.height();     // layer height (mm)
 
-    // Uniform pitch of the final ring set (scaled units).
-    double pitch_scaled = 0.;
-    {
-        std::vector<double> fspac;
-        fspac.reserve(radii.size());
-        for (size_t r = 0; r + 1 < radii.size(); ++r)
-            fspac.push_back(std::abs(radii[r] - radii[r + 1]));
-        if (! fspac.empty()) {
-            std::sort(fspac.begin(), fspac.end());
-            const size_t fm = fspac.size();
-            pitch_scaled = (fm % 2 == 1) ? fspac[fm / 2]
-                                         : 0.5 * (fspac[fm / 2 - 1] + fspac[fm / 2]);
-        }
-    }
-    if (pitch_scaled <= 0.)
-        pitch_scaled = scale_(std::max(0.1f, ref.width()));
-    const double pitch_mm = unscale<double>(coord_t(pitch_scaled));
-
     ExtrusionMultiPath multi;
     // Segment accumulator: emit consecutive points sharing one coverage width as one sub-path.
     // Consecutive sub-paths share their boundary point so the chain is continuous.
@@ -1555,24 +1597,8 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             ExtrusionAttributes(ref.role(), ExtrusionFlow(w * h, (float) w, (float) h)));
     };
 
-    // Wall-to-wall step-over: a SHORT tangent S-arc with one-wall-width corner radius (total
-    // arc ~2 pitches long), curving around the elevator column instead of a long straight ramp.
-    const double L_STEP     = 2.0 * pitch_scaled;
-    const double cos_theta  = L_STEP / std::hypot(L_STEP, 0.5 * PI * pitch_scaled); // avg slope of the cosine S
     const double MIN_COVER = 0.05; // mm; keeps a segment extruding (continuity) with ~no deposit
     const size_t N_CHUNK   = 4;   // sub-segments used to approximate a linearly varying flow
-
-    // Per-ring seam-arc length in samples (all rings share M samples; use ring 0's circumference).
-    auto trans_of = [&](const std::vector<Point> &ring) -> size_t {
-        double circ = 0.;
-        for (size_t j = 0; j < M; ++j)
-            circ += (ring[(j + 1) % M] - ring[j]).cast<double>().norm();
-        size_t tr = (circ > 0.) ? (size_t)(L_STEP * (double) M / circ + 0.5) : M;
-        if (tr < 3) tr = 3;
-        if (tr < 1) tr = 1;
-        if (tr > M) tr = M;
-        return tr;
-    };
 
     // ---- FIRST ring: one full clean revolution. This ring is a SURFACE (exterior on even
     //      layers, interior on odd), so it must be a complete undistorted circle. It starts at
@@ -1582,18 +1608,10 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     const size_t flat0  = M - trans0;
     {
         const std::vector<Point> &r0 = resampled[0];
-        // Continuity: the previous layer's vertical elevator ended at the seam anchor (index 0)
-        // on the midline between this layer's first two rings. A short MIN-flow connector rides
-        // from there back to the circle's start at flat0, through the still-empty seam window at
-        // this layer's height - and the avoidance projection below arcs it around the elevator
-        // column. The whole part stays ONE uninterrupted extrusion.
-        if (elevator_below && K_aug >= 2) {
-            Points conn;
-            conn.push_back(lerp(resampled[0][0], resampled[1][0], 0.5)); // elevator top
-            conn.push_back(lerp(resampled[0][flat0], resampled[1][flat0], 0.5));
-            conn.push_back(r0[flat0]);                                   // onto the ring start
-            emit_segment(std::move(conn), MIN_COVER);
-        }
+        // Continuity: the previous layer's vertical elevator climbed ON THE WALL LINE exactly
+        // here - this layer's circle starts at that spot and runs the OPPOSITE rotation
+        // (boustrophedon), so there is no backward positioning move and no travel at all.
+        (void) elevator_below;
         Points pts;
         pts.reserve(M + 1);
         for (size_t j = 0; j < M; ++j)
@@ -1693,42 +1711,16 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, 1.0 - std::min(1.0, u_mid)));
         }
     }
-    // ---- THE ELEVATOR PAD: the climb to the next layer is a single STRAIGHT VERTICAL extruding
-    //      move (appended by the SpiralVase post-processor at the end of the layer). Here the
-    //      path only steps onto the pad: the midline of the interstice between the last two
-    //      rings at the seam - half a pitch inside the wall, touching neither surface. The
-    //      vertical column bead grows layer by layer at this spot; the next layer starts right
-    //      here and its nearby paths arc around the column (see the avoidance projection below).
-    if (elevator_above && K_aug >= 2) {
-        // Pad at index 0 (the +X anchor) - the same formula the next layer uses for its entry
-        // connector, so the column top and the next layer's start coincide.
-        const Point S_out = lerp(resampled[K_aug - 1][0], resampled[K_aug - 2][0], 0.5);
-        Points pad;
-        pad.push_back(resampled[K_aug - 1][M - 1]); // from the final ring's end
-        pad.push_back(S_out);                       // onto the pad (a ~half-pitch step)
-        emit_segment(std::move(pad), MIN_COVER);
-    }
+    // ---- THE ELEVATOR: the climb to the next layer is a single STRAIGHT VERTICAL extruding
+    //      move appended by the SpiralVase post-processor after the layer's last extrusion -
+    //      which is the closing taper's end, ON THE WALL LINE at the seam anchor. The vertical
+    //      column bead is part of the wall itself: a clean stacked seam on the outer wall on odd
+    //      layers and the inner wall on even layers (the print direction alternates). The next
+    //      layer's first ring simply prints through that point. (elevator_above needs no
+    //      geometry here; the top layer's climb is suppressed by the post-processor.)
+    (void) elevator_above;
     if (multi.paths.empty())
         return;
-
-    // ---- AVOIDANCE ARCS: the previous layer left a vertical elevator column at this layer's
-    //      seam interstice. Any path point within one bead width of the column is projected onto
-    //      a bead-width-radius circle around it, so the neighbouring rings arc smoothly in and
-    //      out around the elevator instead of ramming or squishing it.
-    if (elevator_below && K_aug >= 2) {
-        const Point   S_in    = lerp(resampled[0][0], resampled[1][0], 0.5);
-        const double  r_avoid = pitch_scaled; // one wall (bead) width
-        const double  r2      = r_avoid * r_avoid;
-        for (ExtrusionPath &p : multi.paths)
-            for (Point &q : p.polyline.points) {
-                const Vec2d d  = (q - S_in).cast<double>();
-                const double dd = d.squaredNorm();
-                if (dd < r2 && dd > 1e-6) {
-                    const double f = r_avoid / std::sqrt(dd);
-                    q = S_in + Point(coord_t(d.x() * f), coord_t(d.y() * f));
-                }
-            }
-    }
 
     // Global volumetric normalization: scale every segment's flow so the layer's total extruded
     // volume equals EXACTLY the sliced wall area times the layer height.

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1509,69 +1509,165 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     };
 
     const double cos_theta = L_TRANS_RADIAL / std::hypot(L_TRANS_RADIAL, pitch_scaled);
-    for (size_t r = 0; r + 1 < K_aug; ++r) {
-        const std::vector<Point> &a = resampled[r];
-        const std::vector<Point> &b = resampled[r + 1];
+    const double MIN_COVER = 0.05; // mm; keeps a segment extruding (continuity) with ~no deposit
+    const size_t N_CHUNK   = 4;   // sub-segments used to approximate a linearly varying flow
+
+    // Per-ring seam-arc length in samples (all rings share M samples; use ring 0's circumference).
+    auto trans_of = [&](const std::vector<Point> &ring) -> size_t {
         double circ = 0.;
         for (size_t j = 0; j < M; ++j)
-            circ += (a[(j + 1) % M] - a[j]).cast<double>().norm();
-        size_t trans = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
-        if (trans < 1) trans = 1;
-        if (trans > M) trans = M;
-        const size_t flat = M - trans;        // points held flat at ring r before the step
+            circ += (ring[(j + 1) % M] - ring[j]).cast<double>().norm();
+        size_t tr = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
+        if (tr < 1) tr = 1;
+        if (tr > M) tr = M;
+        return tr;
+    };
+
+    // ---- FIRST ring: one full clean revolution. This ring is a SURFACE (exterior on even
+    //      layers, interior on odd), so it must be a complete undistorted circle. It starts at
+    //      index `flat0` (where the previous layer's elevator ended, on the midline half a pitch
+    //      away) and runs the full circle back to that angle.
+    const size_t trans0 = trans_of(resampled[0]);
+    const size_t flat0  = M - trans0;
+    {
+        const std::vector<Point> &r0 = resampled[0];
+        Points pts;
+        pts.reserve(M + 2);
+        // Continuity: the previous layer's elevator ended on the midline between this layer's
+        // first two rings at this exact angle - start there so the whole part is ONE
+        // uninterrupted extrusion (no travel, no retract, no restart).
+        if (layer_id > 0 && K_aug >= 2)
+            pts.push_back(lerp(resampled[0][flat0], resampled[1][flat0], 0.5));
+        for (size_t j = 0; j < M; ++j)
+            pts.push_back(r0[(flat0 + j) % M]);
+        pts.push_back(r0[flat0]); // close the circle
+        emit_segment(std::move(pts), pitch_mm);
+    }
+    // ---- DEPARTURE diagonal from ring 0 over the seam arc [flat0..M): ring 0's line there is
+    //      already fully printed (full circle above), so the diagonal only needs to cover the
+    //      WIDENING strip it leaves as it pulls away: coverage grows linearly 0 -> pitch.
+    //      Exception: if the previous layer's elevator climbed through this interstice, it
+    //      already deposited here - traverse with (almost) no extrusion instead.
+    {
+        const std::vector<Point> &a = resampled[0];
+        const std::vector<Point> &b = resampled[1 < K_aug ? 1 : 0];
+        const bool elevator_below = layer_id > 0;
+        for (size_t c = 0; c < N_CHUNK; ++c) {
+            const size_t j0 = flat0 + (trans0 * c) / N_CHUNK;
+            const size_t j1 = flat0 + (trans0 * (c + 1)) / N_CHUNK;
+            if (j0 >= j1)
+                continue;
+            Points chunk;
+            chunk.reserve(j1 - j0 + 1);
+            {   // share the boundary point with the previous emitted geometry
+                const size_t jp = (j0 == flat0) ? flat0 : j0 - 1;
+                const double tp = (j0 == flat0) ? 0.0 : double(jp - flat0 + 1) / double(trans0);
+                chunk.push_back(lerp(a[jp], b[jp], tp));
+            }
+            for (size_t j = j0; j < j1; ++j) {
+                double t = double(j - flat0 + 1) / double(trans0);
+                if (t > 1.0) t = 1.0;
+                chunk.push_back(lerp(a[j], b[j], t));
+            }
+            const double t_mid = (double(j0 + j1) * 0.5 - double(flat0) + 1.0) / double(trans0);
+            emit_segment(std::move(chunk),
+                elevator_below ? MIN_COVER : pitch_mm * std::max(MIN_COVER, std::min(1.0, t_mid)));
+        }
+    }
+    // ---- INTERIOR rings 1..K-2: flat arc then a straight LINEAR diagonal to the next ring.
+    //      Straight parallel diagonals are spaced exactly pitch * cos(theta) apart perpendicular
+    //      to their direction, so the correspondingly narrowed bead fills the step band EXACTLY
+    //      (the previous smoothstep S-curve diverged at its flat ends and left diamond voids).
+    for (size_t r = 1; r + 1 < K_aug; ++r) {
+        const std::vector<Point> &a = resampled[r];
+        const std::vector<Point> &b = resampled[r + 1];
+        const size_t trans = trans_of(a);
+        const size_t flat  = M - trans;
         Points flat_pts, diag_pts;
-        flat_pts.reserve(flat + 1);
+        flat_pts.reserve(flat + 2);
         diag_pts.reserve(trans + 1);
+        // The incoming diagonal landed on this ring at index M-1; start there so the short
+        // closing chord M-1 -> 0 is extruded, not hopped (keeps the extrusion gapless).
+        flat_pts.push_back(a[M - 1]);
         for (size_t j = 0; j < M; ++j) {
             double t;
             if (j < flat) {
-                t = 0.0;                       // flat circle at ring r's radius
+                t = 0.0;
             } else {
-                double u = double(j - flat + 1) / double(trans); // 0..1 across the seam step
-                if (u > 1.0) u = 1.0;
-                t = u * u * (3.0 - 2.0 * u);   // smoothstep ease - no kink at either end
+                t = double(j - flat + 1) / double(trans);
+                if (t > 1.0) t = 1.0;
             }
             const Point p = lerp(a[j], b[j], t);
             if (j < flat) {
                 flat_pts.push_back(p);
             } else {
                 if (diag_pts.empty() && ! flat_pts.empty())
-                    diag_pts.push_back(flat_pts.back()); // share the boundary point
+                    diag_pts.push_back(flat_pts.back());
                 diag_pts.push_back(p);
             }
         }
         emit_segment(std::move(flat_pts), pitch_mm);
         emit_segment(std::move(diag_pts), pitch_mm * cos_theta);
     }
-    // The final ring: full flat revolution, but its seam arc re-traces the arc the incoming
-    // diagonal converged onto - taper the coverage to match the narrowing leftover strip.
+    // ---- FINAL ring: one full clean revolution (the other SURFACE - interior on even layers,
+    //      exterior on odd). Its seam arc re-traces the arc the incoming diagonal converged
+    //      onto, so the leftover strip narrows linearly: taper the coverage (1-t)*pitch.
+    size_t fin_flat = 0, fin_trans = 0;
     {
         const std::vector<Point> &fin = resampled[K_aug - 1];
-        double circ = 0.;
-        for (size_t j = 0; j < M; ++j)
-            circ += (fin[(j + 1) % M] - fin[j]).cast<double>().norm();
-        size_t trans = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
-        if (trans < 1) trans = 1;
-        if (trans > M) trans = M;
-        const size_t flat = M - trans;
-        Points flat_pts(fin.begin(), fin.begin() + flat);
+        fin_trans = trans_of(fin);
+        fin_flat  = M - fin_trans;
+        Points flat_pts;
+        flat_pts.reserve(fin_flat + 1);
+        flat_pts.push_back(fin[M - 1]); // incoming diagonal landed here: extrude the closing chord
+        flat_pts.insert(flat_pts.end(), fin.begin(), fin.begin() + fin_flat);
         emit_segment(std::move(flat_pts), pitch_mm);
-        // Chunk the tapered arc: coverage tracks the strip left by the diagonal, (1 - t) * pitch.
-        const size_t N_CHUNK = 4;
         for (size_t c = 0; c < N_CHUNK; ++c) {
-            const size_t j0 = flat + (trans * c) / N_CHUNK;
-            const size_t j1 = flat + (trans * (c + 1)) / N_CHUNK;
+            const size_t j0 = fin_flat + (fin_trans * c) / N_CHUNK;
+            const size_t j1 = fin_flat + (fin_trans * (c + 1)) / N_CHUNK;
             if (j0 >= j1)
                 continue;
             Points chunk;
             chunk.reserve(j1 - j0 + 1);
             if (j0 > 0)
-                chunk.push_back(fin[j0 - 1]); // share the boundary point
+                chunk.push_back(fin[j0 - 1]);
             for (size_t j = j0; j < j1; ++j)
                 chunk.push_back(fin[j]);
-            const double u_mid = (double(j0 + j1) * 0.5 - double(flat) + 1.0) / double(trans);
-            const double t_mid = std::min(1.0, u_mid * u_mid * (3.0 - 2.0 * u_mid));
-            emit_segment(std::move(chunk), pitch_mm * std::max(0.05, 1.0 - t_mid));
+            const double u_mid = (double(j0 + j1) * 0.5 - double(fin_flat) + 1.0) / double(fin_trans);
+            emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, 1.0 - std::min(1.0, u_mid)));
+        }
+    }
+    // ---- THE ELEVATOR: the Z climb to the next layer, on the MIDLINE between the last two
+    //      rings - half a pitch inside the wall, so the climbing bead never sits on (and never
+    //      squishes out of) the interior or exterior surface. It runs BACKWARD along the seam
+    //      arc, which cancels the path's angular advance: the climb ends at the midline point of
+    //      the seam-arc start, exactly where the NEXT layer's first ring begins. The SpiralVase
+    //      post-processor ramps Z over the last L_TRANS of the layer = precisely this arc.
+    //      Flow tapers 0 -> pitch along the climb: at the start the bead overlaps this layer's
+    //      already-full interstice (deposit nothing), at the top it lays a full bead into the
+    //      next layer's empty seam interstice (whose own departure diagonal then deposits
+    //      nothing - see elevator_below above). Every point in the wall gets exactly one bead.
+    if (K_aug >= 2) {
+        const std::vector<Point> &fin  = resampled[K_aug - 1];
+        const std::vector<Point> &prev = resampled[K_aug - 2];
+        for (size_t c = 0; c < N_CHUNK; ++c) {
+            // Backward: from index M-1 down to fin_flat, in N_CHUNK pieces.
+            const size_t i0 = (fin_trans * c) / N_CHUNK;          // steps taken backward so far
+            const size_t i1 = (fin_trans * (c + 1)) / N_CHUNK;
+            if (i0 >= i1)
+                continue;
+            Points chunk;
+            chunk.reserve(i1 - i0 + 2);
+            if (i0 == 0)
+                chunk.push_back(fin[M - 1]); // continue from the final ring's end
+            else
+                chunk.push_back(lerp(fin[M - i0], prev[M - i0], 0.5));
+            for (size_t i = i0 + 1; i <= i1; ++i) {
+                const size_t j = M - i; // walks M-1, M-2, ... down to fin_flat
+                chunk.push_back(lerp(fin[j], prev[j], 0.5));
+            }
+            const double climb_mid = (double(i0 + i1) * 0.5) / double(fin_trans); // 0 -> 1
+            emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, climb_mid));
         }
     }
     if (multi.paths.empty())
@@ -1595,6 +1691,18 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
                 attr.mm3_per_mm *= f;
                 p = ExtrusionPath(std::move(p.polyline), attr);
             }
+        }
+    }
+
+    if (const char *dbg = std::getenv("MULTIWALL_DEBUG"); dbg != nullptr && atoi(dbg) == (int) layer_id) {
+        fprintf(stderr, "[multiwall] layer %zu: %zu sub-paths (K_aug=%zu, M=%zu, fin_flat=%zu, fin_trans=%zu)\n",
+            layer_id, multi.paths.size(), K_aug, M, fin_flat, fin_trans);
+        for (size_t i = 0; i < multi.paths.size(); ++i) {
+            const Polyline &pl = multi.paths[i].polyline;
+            fprintf(stderr, "[multiwall]   seg %2zu: %4zu pts  w=%.3f  first=(%.3f,%.3f) last=(%.3f,%.3f)\n",
+                i, pl.points.size(), multi.paths[i].width(),
+                unscale<double>(pl.points.front().x()), unscale<double>(pl.points.front().y()),
+                unscale<double>(pl.points.back().x()),  unscale<double>(pl.points.back().y()));
         }
     }
 

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1177,6 +1177,326 @@ void PerimeterGenerator::process_arachne(
     append(out_fill_expolygons, std::move(infill_areas));
 }
 
+// Multi-wall (thick) spiral vase: morph the concentric perimeter loops of one layer into a
+// single continuous extrusion path. Each ring is held FLAT (constant radius) for most of its
+// revolution and steps inward/outward to the next ring only over a short smoothstep arc at the
+// seam, so the wall prints as bonded concentric rings with one aligned seam line. The whole wall
+// is re-spaced at a constant pitch outer->inner so the fill is solid for any geometry (straight
+// tube or tapered cone) with no leftover strip for gap fill. Direction alternates per layer
+// (outer->inner on even layers, inner->outer on odd) so the layer-change spiral ramp connects
+// end-to-start. Z stays 0 here; the SpiralVase post-processor flattens each layer at its nominal
+// height and turns the final ~1.27mm of the layer into a short spiral ramp to the next layer.
+static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t layer_id)
+{
+    // 1. Collect the ExtrusionLoop entities.
+    std::vector<const ExtrusionLoop *> loops;
+    loops.reserve(entities.entities.size());
+    for (const ExtrusionEntity *ee : entities.entities)
+        if (const ExtrusionLoop *loop = dynamic_cast<const ExtrusionLoop *>(ee))
+            loops.push_back(loop);
+    if (loops.size() < 2)
+        return; // nothing to morph, leave unchanged
+
+    // 2. Capture the closed contour of each loop as a Polygon, and a reference ExtrusionPath
+    //    (role/flow) taken from the outermost loop (largest area).
+    struct LoopPoly {
+        Polygon              polygon;
+        const ExtrusionPath *ref;
+    };
+    std::vector<LoopPoly> loop_polys;
+    loop_polys.reserve(loops.size());
+    for (const ExtrusionLoop *loop : loops) {
+        if (loop->paths.empty())
+            continue;
+        loop_polys.push_back({ loop->polygon(), &loop->paths.front() });
+    }
+    if (loop_polys.size() < 2)
+        return;
+
+    // 3. Sort by abs(area) descending (outermost first).
+    std::stable_sort(loop_polys.begin(), loop_polys.end(),
+        [](const LoopPoly &a, const LoopPoly &b) {
+            return std::abs(a.polygon.area()) > std::abs(b.polygon.area());
+        });
+    const ExtrusionPath &ref = *loop_polys.front().ref; // outermost loop's reference path
+
+    // 3b. Filter the sorted loops down to a clean, NESTED, concentric sequence before morphing.
+    //     Filling a solid all the way to its center spawns tiny and/or off-center fragment loops
+    //     near the middle; the plain area-sort interleaves them, so blending dives radially
+    //     (r8 -> r1 -> r8) and produces big radial jumps/crossings. We keep only loops that are
+    //     both concentric with the outermost loop and strictly nested (monotonically shrinking),
+    //     and we stop once a loop is so small that its center is effectively degenerate.
+    {
+        const double area0_abs = std::abs(loop_polys.front().polygon.area());          // scaled^2
+        const Point  C0        = loop_polys.front().polygon.centroid();                 // outer centroid
+        const double R0        = std::sqrt(area0_abs / PI);                             // outer "radius" (scaled)
+        const double conc_tol  = 0.5 * R0;                                              // max centroid drift (scaled)
+        // Center cap thresholds: stop once the remaining hole is tiny. Both are in SCALED units.
+        const double r_min     = scale_(1.0);                                           // 1 mm radius (scaled)
+        // ~ (2 * line spacing)^2. ExtrusionPath width is in mm, so scale it before squaring.
+        const double spacing_s = scale_(2.0 * double(ref.width()));                     // 2*line-width (scaled)
+        const double area_min  = spacing_s * spacing_s;                                 // scaled^2
+
+        std::vector<LoopPoly> kept;
+        kept.reserve(loop_polys.size());
+        kept.push_back(loop_polys.front());                                             // always keep outermost
+        double last_area_abs = area0_abs;
+        for (size_t i = 1; i < loop_polys.size(); ++i) {
+            const double a_abs = std::abs(loop_polys[i].polygon.area());
+            // Center cap: stop adding rings once the loop is degenerate-small.
+            const double r_eq = std::sqrt(a_abs / PI);
+            if (r_eq < r_min || a_abs < area_min)
+                break;
+            // Nested: must be strictly smaller in area than the last kept loop.
+            if (a_abs >= last_area_abs)
+                continue;
+            // Concentric: centroid must sit within 0.5*R0 of the outer centroid.
+            const double drift = (loop_polys[i].polygon.centroid() - C0).cast<double>().norm();
+            if (drift > conc_tol)
+                continue;
+            kept.push_back(loop_polys[i]);
+            last_area_abs = a_abs;
+        }
+        loop_polys.swap(kept);
+    }
+    // After filtering, fewer than 2 nested rings means there is nothing to morph: leave unchanged.
+    if (loop_polys.size() < 2)
+        return;
+
+    // 4. M = sample points per revolution, derived from the outermost loop's perimeter length.
+    const Polygon &outer_polygon = loop_polys.front().polygon;
+    size_t M = std::max<size_t>(64, (size_t)(outer_polygon.length() / scale_(0.4)));
+    M = std::min<size_t>(M, 2048);
+
+    // 5. Resample EACH loop's polygon to exactly M points, evenly spaced by arc length and
+    //    angularly aligned across loops (index j ~ same angular position on every ring), with
+    //    a consistent winding direction so j advances the same way for all loops.
+    const size_t K = loop_polys.size();
+    std::vector<std::vector<Point>> resampled(K);
+    // Thread each kept ring's equivalent radius R = sqrt(|area|/PI) through alongside the
+    // resampled points, in the SAME outer->inner order, so the uniform re-spacing below can
+    // place rings evenly by radius. (loop_polys is sorted outer->inner, same as resampled.)
+    std::vector<double> radii(K);
+    for (size_t r = 0; r < K; ++r)
+        radii[r] = std::sqrt(std::abs(loop_polys[r].polygon.area()) / PI); // scaled units
+    for (size_t r = 0; r < K; ++r) {
+        Polygon poly = loop_polys[r].polygon;
+        // Consistent winding: make every loop counter-clockwise.
+        if (! poly.is_counter_clockwise())
+            poly.reverse();
+        if (poly.points.size() < 3) {
+            // Degenerate: can't morph reliably, bail out and leave entities untouched.
+            return;
+        }
+        // Reference direction = +X from the centroid; start at the loop point whose direction
+        // from the centroid is closest to +X so index j is angularly consistent across loops.
+        const Point centroid = poly.centroid();
+        size_t start_idx = 0;
+        double best_dot = -std::numeric_limits<double>::infinity();
+        for (size_t i = 0; i < poly.points.size(); ++i) {
+            const Vec2d d = (poly.points[i] - centroid).cast<double>();
+            const double len = d.norm();
+            const double cos_to_x = (len > 0.) ? (d.x() / len) : -1.; // dot with +X unit vector
+            if (cos_to_x > best_dot) {
+                best_dot  = cos_to_x;
+                start_idx = i;
+            }
+        }
+        // Build the closed point ring rotated to start at start_idx.
+        const size_t n = poly.points.size();
+        std::vector<Point> ring;
+        ring.reserve(n + 1);
+        for (size_t i = 0; i < n; ++i)
+            ring.push_back(poly.points[(start_idx + i) % n]);
+        ring.push_back(ring.front()); // close it
+
+        // Arc-length cumulative table.
+        std::vector<double> cum(ring.size(), 0.);
+        for (size_t i = 1; i < ring.size(); ++i)
+            cum[i] = cum[i - 1] + (ring[i] - ring[i - 1]).cast<double>().norm();
+        const double total_len = cum.back();
+
+        // Emit M points equally spaced by arc length: target arc length = total_len * j / M.
+        std::vector<Point> &out = resampled[r];
+        out.reserve(M);
+        if (total_len <= 0.) {
+            for (size_t j = 0; j < M; ++j)
+                out.push_back(ring.front());
+        } else {
+            size_t seg = 0;
+            for (size_t j = 0; j < M; ++j) {
+                const double target = total_len * (double) j / (double) M;
+                while (seg + 1 < cum.size() && cum[seg + 1] < target)
+                    ++seg;
+                const double seg_len = cum[seg + 1] - cum[seg];
+                const double t = (seg_len > 0.) ? (target - cum[seg]) / seg_len : 0.;
+                out.push_back(lerp(ring[seg], ring[seg + 1], t));
+            }
+        }
+    }
+
+    // 5b. ALIGN CONSECUTIVE RINGS TO EACH OTHER (not just independently to +X).
+    //     Resampling each ring to +X independently leaves point[j] of ring r and ring r+1 at
+    //     slightly different angles; that offset grows toward the center, so the per-revolution
+    //     lerp(a[j], b[j]) connects angularly-mismatched points and produces jumps near the
+    //     middle. Fix: keep ring[0]'s +X resampling as the reference, then for every subsequent
+    //     ring rotate its M-point sequence (preserving winding) so index 0 lands on the point
+    //     closest to the PREVIOUS ring's start point. This makes index j correspond angularly
+    //     across all rings, killing the angular-misalignment jumps.
+    for (size_t r = 1; r < K; ++r) {
+        const Point &prev_start = resampled[r - 1].front();
+        std::vector<Point> &cur = resampled[r];
+        size_t best_j   = 0;
+        double best_d2  = std::numeric_limits<double>::infinity();
+        for (size_t j = 0; j < M; ++j) {
+            const double d2 = (cur[j] - prev_start).cast<double>().squaredNorm();
+            if (d2 < best_d2) {
+                best_d2 = d2;
+                best_j  = j;
+            }
+        }
+        if (best_j != 0) {
+            // Rotate in place so index best_j becomes index 0 (winding/order unchanged).
+            std::rotate(cur.begin(), cur.begin() + best_j, cur.end());
+        }
+    }
+
+    // 5c. UNIFORMLY RE-SPACE the wall. Discard the perimeter generator's uneven ring radii and lay
+    //     down a fresh set of rings at a CONSTANT pitch from the outermost radius to the innermost,
+    //     interpolating each new ring's SHAPE from the two collected rings that bracket its radius
+    //     (rings are aligned in step 5b, so a per-point lerp is a clean concentric blend). This
+    //     guarantees a fully solid wall with no leftover strip for ANY geometry - straight tube OR
+    //     tapered cone. Otherwise the perimeter generator hands the fractional leftover (where the
+    //     outer-going and inner-going offset fronts meet) to gap fill, which prints as a separate,
+    //     unbonded feature with its own travels. We suppress that gap fill in spiral mode (see
+    //     has_gap_fill in process_classic) and cover the whole wall here instead.
+    {
+        const double ref_spac = scale_(std::max(0.1f, ref.width())); // nozzle line spacing (scaled)
+        // Natural pitch = median collected spacing; fall back to the nozzle width when the layer
+        // has too few rings to trust its own median (e.g. a degenerate top/bottom slice that the
+        // perimeter generator reduced to just the outer + inner contour).
+        double pitch = ref_spac;
+        if (K >= 4) {
+            std::vector<double> spac;
+            spac.reserve(K - 1);
+            for (size_t r = 0; r + 1 < K; ++r)
+                spac.push_back(std::abs(radii[r] - radii[r + 1]));
+            std::sort(spac.begin(), spac.end());
+            const double med = spac[spac.size() / 2];
+            if (med > 0. && med <= 1.8 * ref_spac)
+                pitch = med;
+        }
+        const double r_outer = radii.front();          // K rings are sorted outer -> inner
+        const double r_inner = radii.back();
+        const double span    = r_outer - r_inner;
+        if (pitch > 0. && span > 0.) {
+            size_t N = (size_t) std::lround(span / pitch) + 1; // keep neighbours within `pitch`
+            if (N < 2) N = 2;
+            if (N < K) N = K;                           // never drop below what we already had
+            std::vector<std::vector<Point>> uni_rings;
+            std::vector<double>             uni_radii;
+            uni_rings.reserve(N);
+            uni_radii.reserve(N);
+            size_t a = 0;                               // bracket index into the collected rings
+            for (size_t t = 0; t < N; ++t) {
+                const double rt = r_outer - span * (double) t / (double) (N - 1);
+                // Advance `a` so that radii[a] >= rt >= radii[a+1] (radii are decreasing).
+                while (a + 2 < K && radii[a + 1] >= rt)
+                    ++a;
+                const double ra = radii[a], rb = radii[a + 1];
+                const double denom = ra - rb;
+                double f = (denom != 0.) ? (ra - rt) / denom : 0.;
+                if (f < 0.) f = 0.; else if (f > 1.) f = 1.;
+                std::vector<Point> ring(M);
+                for (size_t j = 0; j < M; ++j)
+                    ring[j] = lerp(resampled[a][j], resampled[a + 1][j], f);
+                uni_rings.push_back(std::move(ring));
+                uni_radii.push_back(rt);
+            }
+            resampled.swap(uni_rings);
+            radii.swap(uni_radii);
+        }
+    }
+    const size_t K_aug = resampled.size();
+
+    // 6. Order outer->inner (already sorted that way); reverse to inner->outer on odd layers.
+    if (layer_id % 2 == 1) {
+        std::reverse(resampled.begin(), resampled.end());
+        std::reverse(radii.begin(), radii.end());
+    }
+
+    // 7. Build the path: hold each ring FLAT at its own radius, and step inward to the next
+    //    ring only over a short eased transition (~L_TRANS_RADIAL arc, smoothstep so there is no
+    //    sharp jerk) at the ring seam - instead of spiralling the radius over the whole
+    //    revolution. Seams are aligned across rings (step 5b), so they stack into one line.
+    const double L_TRANS_RADIAL = scale_(1.27); // 0.05 inch of arc for the wall-to-wall step
+    std::vector<Point> spiral;
+    spiral.reserve((size_t) K_aug * M);
+    for (size_t r = 0; r + 1 < K_aug; ++r) {
+        const std::vector<Point> &a = resampled[r];
+        const std::vector<Point> &b = resampled[r + 1];
+        double circ = 0.;
+        for (size_t j = 0; j < M; ++j)
+            circ += (a[(j + 1) % M] - a[j]).cast<double>().norm();
+        size_t trans = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
+        if (trans < 1) trans = 1;
+        if (trans > M) trans = M;
+        const size_t flat = M - trans;        // points held flat at ring r before the step
+        for (size_t j = 0; j < M; ++j) {
+            double t;
+            if (j < flat) {
+                t = 0.0;                       // flat circle at ring r's radius
+            } else {
+                double u = double(j - flat + 1) / double(trans); // 0..1 across the seam step
+                if (u > 1.0) u = 1.0;
+                t = u * u * (3.0 - 2.0 * u);   // smoothstep ease - no kink at either end
+            }
+            spiral.push_back(lerp(a[j], b[j], t));
+        }
+    }
+    // Append the final ring fully to finish the innermost (or outermost) ring.
+    for (size_t j = 0; j < M; ++j)
+        spiral.push_back(resampled[K_aug - 1][j]);
+
+    // 8. Build a single ExtrusionPath from the spiral points.
+    //    Deposit each bead slightly WIDER than the ring pitch so adjacent rings overlap and fuse
+    //    into a solid wall. Width == pitch (0% overlap) leaves the beads merely touching, which
+    //    reads visibly gappy at typical perimeter pitches. A ~15% overlap closes the seam at
+    //    every pitch without meaningful over-extrusion (matches the overlap solid infill uses).
+    //    Rectangular flow (w*h) keeps the deposited width == w.
+    double out_mm3_per_mm = ref.mm3_per_mm();
+    float  out_width      = ref.width();
+    {
+        std::vector<double> fspac;            // consecutive |spacings| of the final ring set (scaled)
+        fspac.reserve(radii.size());
+        for (size_t r = 0; r + 1 < radii.size(); ++r)
+            fspac.push_back(std::abs(radii[r] - radii[r + 1]));
+        if (! fspac.empty()) {
+            std::sort(fspac.begin(), fspac.end());
+            const size_t fm  = fspac.size();
+            const double med_scaled = (fm % 2 == 1) ? fspac[fm / 2]
+                                                    : 0.5 * (fspac[fm / 2 - 1] + fspac[fm / 2]);
+            if (med_scaled > 0.) {
+                const double OVERLAP = 1.15;
+                const double w_mm = unscale<double>(coord_t(med_scaled)) * OVERLAP; // bead width (mm)
+                const double h    = (double) ref.height();                          // layer height (mm)
+                out_width      = (float) w_mm;
+                out_mm3_per_mm = w_mm * h;
+            }
+        }
+    }
+    Polyline pl;
+    pl.points.reserve(spiral.size());
+    for (const Point &p : spiral)
+        pl.points.push_back(p);
+    ExtrusionPath path(std::move(pl),
+        ExtrusionAttributes(ref.role(), ExtrusionFlow(out_mm3_per_mm, out_width, ref.height())));
+
+    // 9. Replace the loop collection with the single spiral path.
+    entities.clear();
+    entities.append(std::move(path));
+}
+
 void PerimeterGenerator::process_classic(
     // Inputs:
     const Parameters           &params,
@@ -1215,7 +1535,11 @@ void PerimeterGenerator::process_classic(
     // internal flow which is unrelated.
     coord_t min_spacing         = coord_t(perimeter_spacing      * (1 - INSET_OVERLAP_TOLERANCE));
     coord_t ext_min_spacing     = coord_t(ext_perimeter_spacing  * (1 - INSET_OVERLAP_TOLERANCE));
-    bool    has_gap_fill 		= params.config.gap_fill_enabled.value && params.config.gap_fill_speed.value > 0;
+    // Multi-wall spiral vase: the morph re-spaces the whole wall solidly (make_multiwall_spiral
+    // step 5c), so the perimeter generator must NOT also emit gap fill - it would print as a
+    // separate, unbonded feature (a visible seam ring) that the morph does not absorb.
+    const bool multiwall_spiral = params.spiral_vase && params.print_config.spiral_vase_wall_count.value != 1;
+    bool    has_gap_fill 		= params.config.gap_fill_enabled.value && params.config.gap_fill_speed.value > 0 && !multiwall_spiral;
 
     // prepare grown lower layer slices for overhang detection
     if (params.config.overhangs && lower_slices != nullptr && lower_slices_polygons_cache.empty()) {
@@ -1449,6 +1773,11 @@ void PerimeterGenerator::process_classic(
         }
         // at this point, all loops should be in contours[0]
         ExtrusionEntityCollection entities = traverse_loops_classic(params, lower_slices_polygons_cache, contours.front(), thin_walls);
+        if (multiwall_spiral && entities.entities.size() > 1) {
+            // Multi-wall (thick) spiral vase: morph the concentric loops into one continuous
+            // spiral path per layer (flat rings + short smoothstep seam transitions).
+            make_multiwall_spiral(entities, (size_t) params.layer_id);
+        }
         // if brim will be printed, reverse the order of perimeters so that
         // we continue inwards after having finished the brim
         // TODO: add test for perimeter order

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1177,6 +1177,33 @@ void PerimeterGenerator::process_arachne(
     append(out_fill_expolygons, std::move(infill_areas));
 }
 
+// Continuous constant-wall spiral: does this surface qualify for the per-layer spiral treatment?
+// It must be a fully axisymmetric wall: exactly one hole, both boundaries circular (isoperimetric
+// quotient 4*pi*A/P^2 ~ 1), and concentric within a fraction of the wall thickness (which makes
+// the wall thickness constant). Anything else - side holes/ports (they break the annulus),
+// non-round sections, solid regions - prints with the regular settings untouched.
+static bool surface_is_constant_circular_wall(const ExPolygon &exp)
+{
+    if (exp.holes.size() != 1)
+        return false;
+    const Polygon &c = exp.contour;
+    const Polygon &h = exp.holes.front();
+    const double ac = std::abs(c.area()), ah = std::abs(h.area());
+    if (ac <= 0. || ah <= 0. || ah >= ac)
+        return false;
+    auto circularity = [](const Polygon &p, double a) {
+        const double len = p.length();
+        return (len > 0.) ? 4. * PI * a / (len * len) : 0.;
+    };
+    if (circularity(c, ac) < 0.9 || circularity(h, ah) < 0.9)
+        return false;
+    const double rc = std::sqrt(ac / PI), rh = std::sqrt(ah / PI);
+    const double wall = rc - rh;
+    if (wall <= 0.)
+        return false;
+    return (c.centroid() - h.centroid()).cast<double>().norm() <= 0.25 * wall;
+}
+
 // Multi-wall (thick) spiral vase: morph the concentric perimeter loops of one layer into a
 // single continuous extrusion path. Each ring is held FLAT (constant radius) for most of its
 // revolution and steps inward/outward to the next ring only over a short smoothstep arc at the
@@ -1749,11 +1776,14 @@ void PerimeterGenerator::process_classic(
     // internal flow which is unrelated.
     coord_t min_spacing         = coord_t(perimeter_spacing      * (1 - INSET_OVERLAP_TOLERANCE));
     coord_t ext_min_spacing     = coord_t(ext_perimeter_spacing  * (1 - INSET_OVERLAP_TOLERANCE));
-    // Multi-wall spiral vase: the morph re-spaces the whole wall solidly (make_multiwall_spiral
-    // step 5c), so the perimeter generator must NOT also emit gap fill - it would print as a
-    // separate, unbonded feature (a visible seam ring) that the morph does not absorb.
-    const bool multiwall_spiral = params.spiral_vase && params.print_config.spiral_vase_wall_count.value != 1;
-    bool    has_gap_fill 		= params.config.gap_fill_enabled.value && params.config.gap_fill_speed.value > 0 && !multiwall_spiral;
+    // Continuous constant-wall spiral: one-click per-layer feature. When enabled and THIS
+    // surface is a fully axisymmetric constant wall, the whole wall is printed as one continuous
+    // spiral of concentric rings (make_multiwall_spiral): as many perimeters as fit, no gap fill
+    // (the morph re-spaces the wall solidly), no infill. Non-qualifying surfaces print with the
+    // regular settings untouched.
+    const bool constant_wall = params.print_config.constant_wall_spiral.value &&
+                               surface_is_constant_circular_wall(surface.expolygon);
+    bool    has_gap_fill 		= params.config.gap_fill_enabled.value && params.config.gap_fill_speed.value > 0 && !constant_wall;
 
     // prepare grown lower layer slices for overhang detection
     if (params.config.overhangs && lower_slices != nullptr && lower_slices_polygons_cache.empty()) {
@@ -1768,6 +1798,10 @@ void PerimeterGenerator::process_classic(
     // extra perimeters for each one
     // detect how many perimeters must be generated for this island
     int        loop_number = params.config.perimeters + surface.extra_perimeters - 1;  // 0-indexed loops
+    if (constant_wall)
+        // Fill the whole wall with rings: the offsetting loop stops on its own when the wall is
+        // consumed, so this is simply "as many as fit" (the configured count is for regular layers).
+        loop_number = 999;
 
     // Set the topmost layer to be one perimeter.
     if (loop_number > 0 && ((params.config.top_one_perimeter_type != TopOnePerimeterType::None && upper_slices == nullptr) || (params.config.only_one_perimeter_first_layer && params.layer_id == 0)))
@@ -1987,10 +2021,9 @@ void PerimeterGenerator::process_classic(
         }
         // at this point, all loops should be in contours[0]
         ExtrusionEntityCollection entities = traverse_loops_classic(params, lower_slices_polygons_cache, contours.front(), thin_walls);
-        if (multiwall_spiral && entities.entities.size() > 1) {
-            // Multi-wall (thick) spiral vase: morph the concentric loops into one continuous
-            // spiral path per layer (flat rings + short smoothstep seam transitions). The sliced
-            // wall area drives the exact per-layer extrusion volume (area * layer height).
+        if (constant_wall && entities.entities.size() > 1) {
+            // Morph the concentric loops into one continuous spiral path for this layer. The
+            // sliced wall area drives the exact per-layer extrusion volume (area * layer height).
             make_multiwall_spiral(entities, (size_t) params.layer_id, std::abs(surface.expolygon.area()));
         }
         // if brim will be printed, reverse the order of perimeters so that
@@ -2086,7 +2119,9 @@ void PerimeterGenerator::process_classic(
         }
     }
     
-    append(out_fill_expolygons, std::move(infill_areas));
+    // A constant-wall spiral layer is completely filled by its rings: no infill.
+    if (! constant_wall)
+        append(out_fill_expolygons, std::move(infill_areas));
 }
 
 PerimeterRegion::PerimeterRegion(const LayerRegion &layer_region) : region(&layer_region.region())

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1473,6 +1473,26 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             radii.swap(uni_radii);
         }
     }
+    // 5d. RE-ANCHOR every ring's index 0 to the +X direction from the shared centroid. The
+    //     chained alignment (5b) anchors only the outermost ring; layers alternate which ring
+    //     comes first, so the seam angle wandered layer to layer and the elevator columns did
+    //     not stack. With a common absolute anchor the seam - and the vertical elevator pads -
+    //     sit at the same angle on every layer.
+    {
+        const Point C = loop_polys.front().polygon.centroid();
+        for (std::vector<Point> &ring : resampled) {
+            size_t best_j  = 0;
+            double best_d  = -std::numeric_limits<double>::infinity();
+            for (size_t j = 0; j < M; ++j) {
+                const Vec2d d  = (ring[j] - C).cast<double>();
+                const double n = d.norm();
+                const double c = (n > 0.) ? d.x() / n : -1.;
+                if (c > best_d) { best_d = c; best_j = j; }
+            }
+            if (best_j != 0)
+                std::rotate(ring.begin(), ring.begin() + best_j, ring.end());
+        }
+    }
     const size_t K_aug = resampled.size();
 
     // 6. Order outer->inner (already sorted that way); reverse to inner->outer on odd layers.
@@ -1502,7 +1522,6 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     //        path has one flow value).
     //    The global normalization then absorbs the small remaining geometric slivers (the
     //    triangular step voids), distributing them uniformly (~1-2%), so total volume is exact.
-    const double L_TRANS_RADIAL = scale_(1.27); // 0.05 inch of arc for the wall-to-wall step
     const double h = (double) ref.height();     // layer height (mm)
 
     // Uniform pitch of the final ring set (scaled units).
@@ -1536,7 +1555,10 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             ExtrusionAttributes(ref.role(), ExtrusionFlow(w * h, (float) w, (float) h)));
     };
 
-    const double cos_theta = L_TRANS_RADIAL / std::hypot(L_TRANS_RADIAL, pitch_scaled);
+    // Wall-to-wall step-over: a SHORT tangent S-arc with one-wall-width corner radius (total
+    // arc ~2 pitches long), curving around the elevator column instead of a long straight ramp.
+    const double L_STEP     = 2.0 * pitch_scaled;
+    const double cos_theta  = L_STEP / std::hypot(L_STEP, 0.5 * PI * pitch_scaled); // avg slope of the cosine S
     const double MIN_COVER = 0.05; // mm; keeps a segment extruding (continuity) with ~no deposit
     const size_t N_CHUNK   = 4;   // sub-segments used to approximate a linearly varying flow
 
@@ -1545,7 +1567,8 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
         double circ = 0.;
         for (size_t j = 0; j < M; ++j)
             circ += (ring[(j + 1) % M] - ring[j]).cast<double>().norm();
-        size_t tr = (circ > 0.) ? (size_t)(L_TRANS_RADIAL * (double) M / circ + 0.5) : M;
+        size_t tr = (circ > 0.) ? (size_t)(L_STEP * (double) M / circ + 0.5) : M;
+        if (tr < 3) tr = 3;
         if (tr < 1) tr = 1;
         if (tr > M) tr = M;
         return tr;
@@ -1559,23 +1582,29 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     const size_t flat0  = M - trans0;
     {
         const std::vector<Point> &r0 = resampled[0];
+        // Continuity: the previous layer's vertical elevator ended at the seam anchor (index 0)
+        // on the midline between this layer's first two rings. A short MIN-flow connector rides
+        // from there back to the circle's start at flat0, through the still-empty seam window at
+        // this layer's height - and the avoidance projection below arcs it around the elevator
+        // column. The whole part stays ONE uninterrupted extrusion.
+        if (elevator_below && K_aug >= 2) {
+            Points conn;
+            conn.push_back(lerp(resampled[0][0], resampled[1][0], 0.5)); // elevator top
+            conn.push_back(lerp(resampled[0][flat0], resampled[1][flat0], 0.5));
+            conn.push_back(r0[flat0]);                                   // onto the ring start
+            emit_segment(std::move(conn), MIN_COVER);
+        }
         Points pts;
-        pts.reserve(M + 2);
-        // Continuity: the previous layer's micro-helix elevator ended at the seam on the midline
-        // between this layer's first two rings - start there so the whole part is ONE
-        // uninterrupted extrusion (no travel, no retract, no restart).
-        if (elevator_below && K_aug >= 2)
-            pts.push_back(lerp(resampled[0][0], resampled[1][0], 0.5));
+        pts.reserve(M + 1);
         for (size_t j = 0; j < M; ++j)
-            pts.push_back(r0[j]);
-        pts.push_back(r0[0]); // close the circle
+            pts.push_back(r0[(flat0 + j) % M]);
+        pts.push_back(r0[flat0]); // close the circle
         emit_segment(std::move(pts), pitch_mm);
     }
-    // ---- DEPARTURE diagonal from ring 0 over the seam arc [flat0..M): ring 0's line there is
-    //      already fully printed (full circle above), so the diagonal only needs to cover the
-    //      WIDENING strip it leaves as it pulls away: coverage grows linearly 0 -> pitch.
-    //      Exception: if the previous layer's elevator climbed through this interstice, it
-    //      already deposited here - traverse with (almost) no extrusion instead.
+    // ---- DEPARTURE arc from ring 0 over the seam window [flat0..M): ring 0's line there is
+    //      already fully printed (full circle above), so the arc only needs to cover the
+    //      WIDENING strip it leaves as it pulls away: coverage grows 0 -> pitch. (The elevator
+    //      is a point column at the anchor, not a strip - the departure always deposits.)
     {
         const std::vector<Point> &a = resampled[0];
         const std::vector<Point> &b = resampled[1 < K_aug ? 1 : 0];
@@ -1588,17 +1617,16 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             chunk.reserve(j1 - j0 + 1);
             {   // share the boundary point with the previous emitted geometry
                 const size_t jp = (j0 == flat0) ? flat0 : j0 - 1;
-                const double tp = (j0 == flat0) ? 0.0 : double(jp - flat0 + 1) / double(trans0);
-                chunk.push_back(lerp(a[jp], b[jp], tp));
+                const double up = (j0 == flat0) ? 0.0 : double(jp - flat0 + 1) / double(trans0);
+                chunk.push_back(lerp(a[jp], b[jp], 0.5 - 0.5 * std::cos(PI * std::min(1.0, up))));
             }
             for (size_t j = j0; j < j1; ++j) {
-                double t = double(j - flat0 + 1) / double(trans0);
-                if (t > 1.0) t = 1.0;
-                chunk.push_back(lerp(a[j], b[j], t));
+                double u = double(j - flat0 + 1) / double(trans0);
+                if (u > 1.0) u = 1.0;
+                chunk.push_back(lerp(a[j], b[j], 0.5 - 0.5 * std::cos(PI * u)));
             }
             const double t_mid = (double(j0 + j1) * 0.5 - double(flat0) + 1.0) / double(trans0);
-            emit_segment(std::move(chunk),
-                elevator_below ? MIN_COVER : pitch_mm * std::max(MIN_COVER, std::min(1.0, t_mid)));
+            emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, std::min(1.0, t_mid)));
         }
     }
     // ---- INTERIOR rings 1..K-2: flat arc then a straight LINEAR diagonal to the next ring.
@@ -1621,8 +1649,9 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             if (j < flat) {
                 t = 0.0;
             } else {
-                t = double(j - flat + 1) / double(trans);
-                if (t > 1.0) t = 1.0;
+                double u = double(j - flat + 1) / double(trans);
+                if (u > 1.0) u = 1.0;
+                t = 0.5 - 0.5 * std::cos(PI * u); // tangent S-arc: one-wall-radius corners
             }
             const Point p = lerp(a[j], b[j], t);
             if (j < flat) {
@@ -1671,7 +1700,9 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     //      vertical column bead grows layer by layer at this spot; the next layer starts right
     //      here and its nearby paths arc around the column (see the avoidance projection below).
     if (elevator_above && K_aug >= 2) {
-        const Point S_out = lerp(resampled[K_aug - 1][M - 1], resampled[K_aug - 2][M - 1], 0.5);
+        // Pad at index 0 (the +X anchor) - the same formula the next layer uses for its entry
+        // connector, so the column top and the next layer's start coincide.
+        const Point S_out = lerp(resampled[K_aug - 1][0], resampled[K_aug - 2][0], 0.5);
         Points pad;
         pad.push_back(resampled[K_aug - 1][M - 1]); // from the final ring's end
         pad.push_back(S_out);                       // onto the pad (a ~half-pitch step)

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1220,6 +1220,19 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
         });
     const ExtrusionPath &ref = *loop_polys.front().ref; // outermost loop's reference path
 
+    // Temporary diagnostics: MULTIWALL_DEBUG=<layer_id> dumps the collected loop radii.
+    if (const char *dbg = std::getenv("MULTIWALL_DEBUG"); dbg != nullptr && atoi(dbg) == (int) layer_id) {
+        fprintf(stderr, "[multiwall] layer %zu: %zu loops collected\n", layer_id, loop_polys.size());
+        for (size_t i = 0; i < loop_polys.size(); ++i) {
+            const double a_abs = std::abs(loop_polys[i].polygon.area());
+            const Point  c     = loop_polys[i].polygon.centroid();
+            fprintf(stderr, "[multiwall]   loop %2zu: r_eq=%7.3f mm  centroid=(%.2f,%.2f) ccw=%d pts=%zu\n",
+                i, unscale<double>(coord_t(std::sqrt(a_abs / PI))),
+                unscale<double>(c.x()), unscale<double>(c.y()),
+                int(loop_polys[i].polygon.is_counter_clockwise()), loop_polys[i].polygon.points.size());
+        }
+    }
+
     // 3b. Filter the sorted loops down to a clean, NESTED, concentric sequence before morphing.
     //     Filling a solid all the way to its center spawns tiny and/or off-center fragment loops
     //     near the middle; the plain area-sort interleaves them, so blending dives radially
@@ -1231,6 +1244,16 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
         const Point  C0        = loop_polys.front().polygon.centroid();                 // outer centroid
         const double R0        = std::sqrt(area0_abs / PI);                             // outer "radius" (scaled)
         const double conc_tol  = 0.5 * R0;                                              // max centroid drift (scaled)
+        // Shape gate: isoperimetric quotient A/P^2 is scale-invariant and characterizes SHAPE
+        // (circle 1/4pi; any similar shape keeps the same value at every offset depth). Where the
+        // outer-going and hole-going offset fronts meet, the leftover strip can survive as a
+        // degenerate self-crossing "bowtie" loop: huge perimeter, tiny net area -> quotient
+        // collapses to a few % of the outer's. Morphing against such a loop lerps angularly
+        // mismatched points straight through the center (criss-cross disc). Reject any loop whose
+        // quotient falls below 35% of the outer contour's - inner rings of legitimate shapes only
+        // get ROUNDER (higher quotient) as they shrink, so real rings always pass.
+        const double P0 = loop_polys.front().polygon.length();
+        const double q0 = (P0 > 0.) ? area0_abs / (P0 * P0) : 0.;
         // Center cap thresholds: stop once the remaining hole is tiny. Both are in SCALED units.
         const double r_min     = scale_(1.0);                                           // 1 mm radius (scaled)
         // ~ (2 * line spacing)^2. ExtrusionPath width is in mm, so scale it before squaring.
@@ -1253,6 +1276,11 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             // Concentric: centroid must sit within 0.5*R0 of the outer centroid.
             const double drift = (loop_polys[i].polygon.centroid() - C0).cast<double>().norm();
             if (drift > conc_tol)
+                continue;
+            // Shape-similar: reject degenerate bowtie/sliver leftovers (see q0 above).
+            const double Pi_len = loop_polys[i].polygon.length();
+            const double qi     = (Pi_len > 0.) ? a_abs / (Pi_len * Pi_len) : 0.;
+            if (qi < 0.35 * q0)
                 continue;
             kept.push_back(loop_polys[i]);
             last_area_abs = a_abs;

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1213,7 +1213,8 @@ static bool surface_is_constant_circular_wall(const ExPolygon &exp)
 // (outer->inner on even layers, inner->outer on odd) so the layer-change spiral ramp connects
 // end-to-start. Z stays 0 here; the SpiralVase post-processor flattens each layer at its nominal
 // height and turns the final ~1.27mm of the layer into a short spiral ramp to the next layer.
-static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t layer_id, double wall_area_scaled2)
+static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t layer_id, double wall_area_scaled2,
+                                  bool elevator_below, bool elevator_above)
 {
     // 1. Collect the ExtrusionLoop entities.
     std::vector<const ExtrusionLoop *> loops;
@@ -1552,22 +1553,22 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
 
     // ---- FIRST ring: one full clean revolution. This ring is a SURFACE (exterior on even
     //      layers, interior on odd), so it must be a complete undistorted circle. It starts at
-    //      index `flat0` (where the previous layer's elevator ended, on the midline half a pitch
-    //      away) and runs the full circle back to that angle.
+    //      the seam (where the previous layer's micro-helix elevator ended, on the midline half
+    //      a pitch away) and runs the full circle back to that angle.
     const size_t trans0 = trans_of(resampled[0]);
     const size_t flat0  = M - trans0;
     {
         const std::vector<Point> &r0 = resampled[0];
         Points pts;
         pts.reserve(M + 2);
-        // Continuity: the previous layer's elevator ended on the midline between this layer's
-        // first two rings at this exact angle - start there so the whole part is ONE
+        // Continuity: the previous layer's micro-helix elevator ended at the seam on the midline
+        // between this layer's first two rings - start there so the whole part is ONE
         // uninterrupted extrusion (no travel, no retract, no restart).
-        if (layer_id > 0 && K_aug >= 2)
-            pts.push_back(lerp(resampled[0][flat0], resampled[1][flat0], 0.5));
+        if (elevator_below && K_aug >= 2)
+            pts.push_back(lerp(resampled[0][0], resampled[1][0], 0.5));
         for (size_t j = 0; j < M; ++j)
-            pts.push_back(r0[(flat0 + j) % M]);
-        pts.push_back(r0[flat0]); // close the circle
+            pts.push_back(r0[j]);
+        pts.push_back(r0[0]); // close the circle
         emit_segment(std::move(pts), pitch_mm);
     }
     // ---- DEPARTURE diagonal from ring 0 over the seam arc [flat0..M): ring 0's line there is
@@ -1578,7 +1579,6 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
     {
         const std::vector<Point> &a = resampled[0];
         const std::vector<Point> &b = resampled[1 < K_aug ? 1 : 0];
-        const bool elevator_below = layer_id > 0;
         for (size_t c = 0; c < N_CHUNK; ++c) {
             const size_t j0 = flat0 + (trans0 * c) / N_CHUNK;
             const size_t j1 = flat0 + (trans0 * (c + 1)) / N_CHUNK;
@@ -1664,41 +1664,40 @@ static void make_multiwall_spiral(ExtrusionEntityCollection &entities, size_t la
             emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, 1.0 - std::min(1.0, u_mid)));
         }
     }
-    // ---- THE ELEVATOR: the Z climb to the next layer, on the MIDLINE between the last two
-    //      rings - half a pitch inside the wall, so the climbing bead never sits on (and never
-    //      squishes out of) the interior or exterior surface. It runs BACKWARD along the seam
-    //      arc, which cancels the path's angular advance: the climb ends at the midline point of
-    //      the seam-arc start, exactly where the NEXT layer's first ring begins. The SpiralVase
-    //      post-processor ramps Z over the last L_TRANS of the layer = precisely this arc.
-    //      Flow tapers 0 -> pitch along the climb: at the start the bead overlaps this layer's
-    //      already-full interstice (deposit nothing), at the top it lays a full bead into the
-    //      next layer's empty seam interstice (whose own departure diagonal then deposits
-    //      nothing - see elevator_below above). Every point in the wall gets exactly one bead.
-    if (K_aug >= 2) {
-        const std::vector<Point> &fin  = resampled[K_aug - 1];
-        const std::vector<Point> &prev = resampled[K_aug - 2];
-        for (size_t c = 0; c < N_CHUNK; ++c) {
-            // Backward: from index M-1 down to fin_flat, in N_CHUNK pieces.
-            const size_t i0 = (fin_trans * c) / N_CHUNK;          // steps taken backward so far
-            const size_t i1 = (fin_trans * (c + 1)) / N_CHUNK;
-            if (i0 >= i1)
-                continue;
-            Points chunk;
-            chunk.reserve(i1 - i0 + 2);
-            if (i0 == 0)
-                chunk.push_back(fin[M - 1]); // continue from the final ring's end
-            else
-                chunk.push_back(lerp(fin[M - i0], prev[M - i0], 0.5));
-            for (size_t i = i0 + 1; i <= i1; ++i) {
-                const size_t j = M - i; // walks M-1, M-2, ... down to fin_flat
-                chunk.push_back(lerp(fin[j], prev[j], 0.5));
-            }
-            const double climb_mid = (double(i0 + i1) * 0.5) / double(fin_trans); // 0 -> 1
-            emit_segment(std::move(chunk), pitch_mm * std::max(MIN_COVER, climb_mid));
-        }
+    // ---- THE ELEVATOR PAD: the climb to the next layer is a single STRAIGHT VERTICAL extruding
+    //      move (appended by the SpiralVase post-processor at the end of the layer). Here the
+    //      path only steps onto the pad: the midline of the interstice between the last two
+    //      rings at the seam - half a pitch inside the wall, touching neither surface. The
+    //      vertical column bead grows layer by layer at this spot; the next layer starts right
+    //      here and its nearby paths arc around the column (see the avoidance projection below).
+    if (elevator_above && K_aug >= 2) {
+        const Point S_out = lerp(resampled[K_aug - 1][M - 1], resampled[K_aug - 2][M - 1], 0.5);
+        Points pad;
+        pad.push_back(resampled[K_aug - 1][M - 1]); // from the final ring's end
+        pad.push_back(S_out);                       // onto the pad (a ~half-pitch step)
+        emit_segment(std::move(pad), MIN_COVER);
     }
     if (multi.paths.empty())
         return;
+
+    // ---- AVOIDANCE ARCS: the previous layer left a vertical elevator column at this layer's
+    //      seam interstice. Any path point within one bead width of the column is projected onto
+    //      a bead-width-radius circle around it, so the neighbouring rings arc smoothly in and
+    //      out around the elevator instead of ramming or squishing it.
+    if (elevator_below && K_aug >= 2) {
+        const Point   S_in    = lerp(resampled[0][0], resampled[1][0], 0.5);
+        const double  r_avoid = pitch_scaled; // one wall (bead) width
+        const double  r2      = r_avoid * r_avoid;
+        for (ExtrusionPath &p : multi.paths)
+            for (Point &q : p.polyline.points) {
+                const Vec2d d  = (q - S_in).cast<double>();
+                const double dd = d.squaredNorm();
+                if (dd < r2 && dd > 1e-6) {
+                    const double f = r_avoid / std::sqrt(dd);
+                    q = S_in + Point(coord_t(d.x() * f), coord_t(d.y() * f));
+                }
+            }
+    }
 
     // Global volumetric normalization: scale every segment's flow so the layer's total extruded
     // volume equals EXACTLY the sliced wall area times the layer height.
@@ -2022,9 +2021,17 @@ void PerimeterGenerator::process_classic(
         // at this point, all loops should be in contours[0]
         ExtrusionEntityCollection entities = traverse_loops_classic(params, lower_slices_polygons_cache, contours.front(), thin_walls);
         if (constant_wall && entities.entities.size() > 1) {
+            // The elevator handshake is geometry-aware: climb into the next layer only if it will
+            // also print as a spiral (otherwise end flat), and discount this layer's departure
+            // diagonal only if the layer below actually climbed here (otherwise deposit fully).
+            const bool elevator_below = lower_slices != nullptr && lower_slices->size() == 1 &&
+                                        surface_is_constant_circular_wall(lower_slices->front());
+            const bool elevator_above = upper_slices != nullptr && upper_slices->size() == 1 &&
+                                        surface_is_constant_circular_wall(upper_slices->front());
             // Morph the concentric loops into one continuous spiral path for this layer. The
             // sliced wall area drives the exact per-layer extrusion volume (area * layer height).
-            make_multiwall_spiral(entities, (size_t) params.layer_id, std::abs(surface.expolygon.area()));
+            make_multiwall_spiral(entities, (size_t) params.layer_id, std::abs(surface.expolygon.area()),
+                                  elevator_below, elevator_above);
         }
         // if brim will be printed, reverse the order of perimeters so that
         // we continue inwards after having finished the brim

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -469,7 +469,7 @@ std::string Preset::trim_vendor_repo_prefix(const std::string& id, const VendorP
 }
 
 static std::vector<std::string> s_Preset_print_options {
-    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "spiral_vase_wall_count", "slice_closing_radius", "slicing_mode",
+    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "constant_wall_spiral", "slice_closing_radius", "slicing_mode",
     "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
     "ensure_vertical_shell_thickness", "extra_perimeters", "extra_perimeters_on_overhangs",
     "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -469,7 +469,7 @@ std::string Preset::trim_vendor_repo_prefix(const std::string& id, const VendorP
 }
 
 static std::vector<std::string> s_Preset_print_options {
-    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "slice_closing_radius", "slicing_mode",
+    "layer_height", "first_layer_height", "perimeters", "spiral_vase", "spiral_vase_wall_count", "slice_closing_radius", "slicing_mode",
     "top_solid_layers", "top_solid_min_thickness", "bottom_solid_layers", "bottom_solid_min_thickness",
     "ensure_vertical_shell_thickness", "extra_perimeters", "extra_perimeters_on_overhangs",
     "avoid_crossing_curled_overhangs", "avoid_crossing_perimeters", "thin_walls", "overhangs",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -222,6 +222,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             // In Spiral Vase mode, holes are closed and only the largest area contour is kept at each layer.
             // Therefore toggling the Spiral Vase on / off requires complete reslicing.
             || opt_key == "spiral_vase"
+            // Continuous constant-wall spiral changes perimeter generation and infill per layer.
+            || opt_key == "constant_wall_spiral"
             || opt_key == "filament_shrinkage_compensation_xy"
             || opt_key == "filament_shrinkage_compensation_z"
             || opt_key == "prefer_clockwise_movements") {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3152,19 +3152,18 @@ void PrintConfigDef::init_fff_params()
                    "It won't work when printing more than one single object.");
     def->set_default_value(new ConfigOptionBool(false));
 
-    def = this->add("spiral_vase_wall_count", coInt);
-    def->label = L("Spiral vase wall count");
-    def->tooltip = L("Number of concentric walls printed as one continuous spiral per layer when "
-                   "Spiral vase is enabled. 1 = classic single-wall spiral vase. Higher values print "
-                   "a thick, solid wall: each layer is filled with concentric rings joined into one "
-                   "continuous extrusion (flat rings with a short smooth transition between them), "
-                   "and the layer change is a short spiral ramp instead of a Z hop. "
-                   "0 = automatic: fill the sliced wall of the model completely, deriving the wall "
-                   "count per layer from the model geometry (works for tapered shapes such as cones).");
-    def->min = 0;
-    def->max = 100;
-    def->mode = comExpert;
-    def->set_default_value(new ConfigOptionInt(1));
+    def = this->add("constant_wall_spiral", coBool);
+    def->label = L("Continuous constant-wall spiral");
+    def->tooltip = L("One-click continuous printing for round, constant-wall shapes. Every layer whose "
+                   "cross-section is a circular wall of constant thickness (fully axisymmetric) is "
+                   "printed as one continuous spiral of concentric rings with exact volumetric flow: "
+                   "the wall fills completely, the climb to the next layer is a short ramp buried "
+                   "inside the wall, and the whole section prints without a single retraction or "
+                   "restart. Layers that are not a constant circular wall (holes, ports, non-round "
+                   "sections, solid tops and bottoms) automatically print with the regular settings. "
+                   "No other settings are modified by this mode.");
+    def->mode = comSimple;
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("standby_temperature_delta", coInt);
     def->label = L("Temperature variation");
@@ -5545,20 +5544,9 @@ void DynamicPrintConfig::normalize_fdm()
             opt_n->values.assign(opt_n->values.size(), false);  // Set all values to false.
         }
         {
-            // Multi-wall (thick) spiral vase: spiral_vase_wall_count drives the perimeter count.
-            // 1 = classic single-wall spiral vase. N>1 = N concentric walls morphed into one
-            // continuous spiral per layer. 0 = automatic: as many walls as fit the sliced wall
-            // of the model (works for tapered shapes; effectively "fill the wall completely").
-            int spiral_walls = this->has("spiral_vase_wall_count") ?
-                this->opt<ConfigOptionInt>("spiral_vase_wall_count", true)->value : 1;
-            this->opt<ConfigOptionInt>("perimeters", true)->value       = (spiral_walls <= 0) ? 1000 : spiral_walls;
+            this->opt<ConfigOptionInt>("perimeters", true)->value       = 1;
             this->opt<ConfigOptionInt>("top_solid_layers", true)->value = 0;
             this->opt<ConfigOptionPercent>("fill_density", true)->value = 0;
-            if (spiral_walls != 1) {
-                // The multi-wall spiral starts at the build plate: no solid bottom.
-                this->opt<ConfigOptionInt>("bottom_solid_layers", true)->value = 0;
-                this->opt<ConfigOptionFloat>("bottom_solid_min_thickness", true)->value = 0.;
-            }
         }
     }
 
@@ -5893,9 +5881,7 @@ std::string validate(const FullPrintConfig &cfg)
     if (cfg.spiral_vase) {
         // Note that we might want to have more than one perimeter on the bottom
         // solid layers.
-        // Multi-wall spiral vase (spiral_vase_wall_count != 1) morphs any number of concentric
-        // perimeters into one continuous spiral per layer, so more than one perimeter is valid.
-        if (cfg.perimeters > 1 && cfg.spiral_vase_wall_count == 1)
+        if (cfg.perimeters > 1)
             return "Can't make more than one perimeter when spiral vase mode is enabled";
         else if (cfg.perimeters < 1)
             return "Can't make less than one perimeter when spiral vase mode is enabled";

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3152,6 +3152,20 @@ void PrintConfigDef::init_fff_params()
                    "It won't work when printing more than one single object.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("spiral_vase_wall_count", coInt);
+    def->label = L("Spiral vase wall count");
+    def->tooltip = L("Number of concentric walls printed as one continuous spiral per layer when "
+                   "Spiral vase is enabled. 1 = classic single-wall spiral vase. Higher values print "
+                   "a thick, solid wall: each layer is filled with concentric rings joined into one "
+                   "continuous extrusion (flat rings with a short smooth transition between them), "
+                   "and the layer change is a short spiral ramp instead of a Z hop. "
+                   "0 = automatic: fill the sliced wall of the model completely, deriving the wall "
+                   "count per layer from the model geometry (works for tapered shapes such as cones).");
+    def->min = 0;
+    def->max = 100;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionInt(1));
+
     def = this->add("standby_temperature_delta", coInt);
     def->label = L("Temperature variation");
     // TRN PrintSettings : "Ooze prevention" > "Temperature variation"
@@ -5531,9 +5545,20 @@ void DynamicPrintConfig::normalize_fdm()
             opt_n->values.assign(opt_n->values.size(), false);  // Set all values to false.
         }
         {
-            this->opt<ConfigOptionInt>("perimeters", true)->value       = 1;
+            // Multi-wall (thick) spiral vase: spiral_vase_wall_count drives the perimeter count.
+            // 1 = classic single-wall spiral vase. N>1 = N concentric walls morphed into one
+            // continuous spiral per layer. 0 = automatic: as many walls as fit the sliced wall
+            // of the model (works for tapered shapes; effectively "fill the wall completely").
+            int spiral_walls = this->has("spiral_vase_wall_count") ?
+                this->opt<ConfigOptionInt>("spiral_vase_wall_count", true)->value : 1;
+            this->opt<ConfigOptionInt>("perimeters", true)->value       = (spiral_walls <= 0) ? 1000 : spiral_walls;
             this->opt<ConfigOptionInt>("top_solid_layers", true)->value = 0;
             this->opt<ConfigOptionPercent>("fill_density", true)->value = 0;
+            if (spiral_walls != 1) {
+                // The multi-wall spiral starts at the build plate: no solid bottom.
+                this->opt<ConfigOptionInt>("bottom_solid_layers", true)->value = 0;
+                this->opt<ConfigOptionFloat>("bottom_solid_min_thickness", true)->value = 0.;
+            }
         }
     }
 
@@ -5868,7 +5893,9 @@ std::string validate(const FullPrintConfig &cfg)
     if (cfg.spiral_vase) {
         // Note that we might want to have more than one perimeter on the bottom
         // solid layers.
-        if (cfg.perimeters > 1)
+        // Multi-wall spiral vase (spiral_vase_wall_count != 1) morphs any number of concentric
+        // perimeters into one continuous spiral per layer, so more than one perimeter is valid.
+        if (cfg.perimeters > 1 && cfg.spiral_vase_wall_count == 1)
             return "Can't make more than one perimeter when spiral vase mode is enabled";
         else if (cfg.perimeters < 1)
             return "Can't make less than one perimeter when spiral vase mode is enabled";

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1031,7 +1031,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionInts,               slowdown_below_layer_time))
     ((ConfigOptionFloat,              solid_infill_acceleration))
     ((ConfigOptionBool,               spiral_vase))
-    ((ConfigOptionInt,                spiral_vase_wall_count))
+    ((ConfigOptionBool,               constant_wall_spiral))
     ((ConfigOptionInt,                standby_temperature_delta))
     ((ConfigOptionInts,               temperature))
     ((ConfigOptionInt,                threads))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1031,6 +1031,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionInts,               slowdown_below_layer_time))
     ((ConfigOptionFloat,              solid_infill_acceleration))
     ((ConfigOptionBool,               spiral_vase))
+    ((ConfigOptionInt,                spiral_vase_wall_count))
     ((ConfigOptionInt,                standby_temperature_delta))
     ((ConfigOptionInts,               temperature))
     ((ConfigOptionInt,                threads))

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -195,13 +195,7 @@ static std::vector<VolumeSlices> slice_volumes_inner(
                     if (model_volume->is_model_part() && print_config.spiral_vase) {
                         auto it = std::find_if(layer_range.volume_regions.begin(), layer_range.volume_regions.end(),
                             [model_volume](const auto &slice){ return model_volume == slice.model_volume; });
-                        // Multi-wall spiral vase (wall count != 1) must slice Regular: a tube's
-                        // inner hole bounds the wall, and the morph fills the wall between the
-                        // outer contour and the hole. PositiveLargestContour would fill the hole
-                        // solid, extending perimeters all the way to the center.
-                        params.mode = (print_config.spiral_vase_wall_count.value == 1)
-                            ? MeshSlicingParams::SlicingMode::PositiveLargestContour
-                            : MeshSlicingParams::SlicingMode::Regular;
+                        params.mode = MeshSlicingParams::SlicingMode::PositiveLargestContour;
                         // Slice the bottom layers with SlicingMode::Regular.
                         // This needs to be in sync with LayerRegion::make_perimeters() spiral_vase!
                         const PrintRegionConfig &region_config = it->region->config();

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -193,9 +193,15 @@ static std::vector<VolumeSlices> slice_volumes_inner(
             if (layer_ranges.size() == 1) {
                 if (const PrintObjectRegions::LayerRangeRegions &layer_range = layer_ranges.front(); layer_range.has_volume(model_volume->id())) {
                     if (model_volume->is_model_part() && print_config.spiral_vase) {
-                        auto it = std::find_if(layer_range.volume_regions.begin(), layer_range.volume_regions.end(), 
+                        auto it = std::find_if(layer_range.volume_regions.begin(), layer_range.volume_regions.end(),
                             [model_volume](const auto &slice){ return model_volume == slice.model_volume; });
-                        params.mode = MeshSlicingParams::SlicingMode::PositiveLargestContour;
+                        // Multi-wall spiral vase (wall count != 1) must slice Regular: a tube's
+                        // inner hole bounds the wall, and the morph fills the wall between the
+                        // outer contour and the hole. PositiveLargestContour would fill the hole
+                        // solid, extending perimeters all the way to the center.
+                        params.mode = (print_config.spiral_vase_wall_count.value == 1)
+                            ? MeshSlicingParams::SlicingMode::PositiveLargestContour
+                            : MeshSlicingParams::SlicingMode::Regular;
                         // Slice the bottom layers with SlicingMode::Regular.
                         // This needs to be in sync with LayerRegion::make_perimeters() spiral_vase!
                         const PrintRegionConfig &region_config = it->region->config();

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -133,20 +133,35 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
 
     double fill_density = config->option<ConfigOptionPercent>("fill_density")->value;
 
+    // Multi-wall spiral vase: spiral_vase_wall_count drives the required perimeter count
+    // (1 = classic single-wall spiral, N = N walls, 0 = auto/fill the wall -> 1000).
+    const int spiral_walls        = config->has("spiral_vase_wall_count") ? config->opt_int("spiral_vase_wall_count") : 1;
+    const int required_perimeters = (spiral_walls <= 0) ? 1000 : spiral_walls;
+    const bool multiwall_bottom_ok = spiral_walls == 1 || config->opt_int("bottom_solid_layers") == 0;
+
     if (config->opt_bool("spiral_vase") &&
-        ! (config->opt_int("perimeters") == 1 &&
+        ! (config->opt_int("perimeters") == required_perimeters &&
            config->opt_int("top_solid_layers") == 0 &&
+           multiwall_bottom_ok &&
            fill_density == 0 &&
            ! config->opt_bool("support_material") &&
            config->opt_int("support_material_enforce_layers") == 0 &&
            ! config->opt_bool("thin_walls")))
     {
-        wxString msg_text = _(L("The Spiral Vase mode requires:\n"
-                                "- one perimeter\n"
-                                "- no top solid layers\n"
-                                "- 0% fill density\n"
-                                "- no support material\n"
-               					"- Detect thin walls disabled"));
+        wxString msg_text = spiral_walls == 1 ?
+            _(L("The Spiral Vase mode requires:\n"
+                "- one perimeter\n"
+                "- no top solid layers\n"
+                "- 0% fill density\n"
+                "- no support material\n"
+                "- Detect thin walls disabled")) :
+            _(L("The multi-wall Spiral Vase mode requires:\n"
+                "- perimeters matching the spiral wall count\n"
+                "- no top solid layers\n"
+                "- no bottom solid layers\n"
+                "- 0% fill density\n"
+                "- no support material\n"
+                "- Detect thin walls disabled"));
         if (is_global_config)
             msg_text += "\n\n" + _(L("Shall I adjust those settings in order to enable Spiral Vase?"));
         MessageDialog dialog(m_msg_dlg_parent, msg_text, _(L("Spiral Vase")),
@@ -155,8 +170,12 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
         auto answer = dialog.ShowModal();
         bool support = true;
         if (!is_global_config || answer == wxID_YES) {
-            new_conf.set_key_value("perimeters", new ConfigOptionInt(1));
+            new_conf.set_key_value("perimeters", new ConfigOptionInt(required_perimeters));
             new_conf.set_key_value("top_solid_layers", new ConfigOptionInt(0));
+            if (spiral_walls != 1) {
+                new_conf.set_key_value("bottom_solid_layers", new ConfigOptionInt(0));
+                new_conf.set_key_value("bottom_solid_min_thickness", new ConfigOptionFloat(0.));
+            }
             new_conf.set_key_value("fill_density", new ConfigOptionPercent(0));
             new_conf.set_key_value("support_material", new ConfigOptionBool(false));
             new_conf.set_key_value("support_material_enforce_layers", new ConfigOptionInt(0));
@@ -308,6 +327,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("infill_anchor", has_infill_anchors);
 
     bool has_spiral_vase         = config->opt_bool("spiral_vase");
+    toggle_field("spiral_vase_wall_count", has_spiral_vase);
     bool has_top_solid_infill 	 = config->opt_int("top_solid_layers") > 0;
     bool has_bottom_solid_infill = config->opt_int("bottom_solid_layers") > 0;
     bool has_solid_infill 		 = has_top_solid_infill || has_bottom_solid_infill;

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -133,35 +133,20 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
 
     double fill_density = config->option<ConfigOptionPercent>("fill_density")->value;
 
-    // Multi-wall spiral vase: spiral_vase_wall_count drives the required perimeter count
-    // (1 = classic single-wall spiral, N = N walls, 0 = auto/fill the wall -> 1000).
-    const int spiral_walls        = config->has("spiral_vase_wall_count") ? config->opt_int("spiral_vase_wall_count") : 1;
-    const int required_perimeters = (spiral_walls <= 0) ? 1000 : spiral_walls;
-    const bool multiwall_bottom_ok = spiral_walls == 1 || config->opt_int("bottom_solid_layers") == 0;
-
     if (config->opt_bool("spiral_vase") &&
-        ! (config->opt_int("perimeters") == required_perimeters &&
+        ! (config->opt_int("perimeters") == 1 &&
            config->opt_int("top_solid_layers") == 0 &&
-           multiwall_bottom_ok &&
            fill_density == 0 &&
            ! config->opt_bool("support_material") &&
            config->opt_int("support_material_enforce_layers") == 0 &&
            ! config->opt_bool("thin_walls")))
     {
-        wxString msg_text = spiral_walls == 1 ?
-            _(L("The Spiral Vase mode requires:\n"
-                "- one perimeter\n"
-                "- no top solid layers\n"
-                "- 0% fill density\n"
-                "- no support material\n"
-                "- Detect thin walls disabled")) :
-            _(L("The multi-wall Spiral Vase mode requires:\n"
-                "- perimeters matching the spiral wall count\n"
-                "- no top solid layers\n"
-                "- no bottom solid layers\n"
-                "- 0% fill density\n"
-                "- no support material\n"
-                "- Detect thin walls disabled"));
+        wxString msg_text = _(L("The Spiral Vase mode requires:\n"
+                                "- one perimeter\n"
+                                "- no top solid layers\n"
+                                "- 0% fill density\n"
+                                "- no support material\n"
+               					"- Detect thin walls disabled"));
         if (is_global_config)
             msg_text += "\n\n" + _(L("Shall I adjust those settings in order to enable Spiral Vase?"));
         MessageDialog dialog(m_msg_dlg_parent, msg_text, _(L("Spiral Vase")),
@@ -170,12 +155,8 @@ void ConfigManipulation::update_print_fff_config(DynamicPrintConfig* config, con
         auto answer = dialog.ShowModal();
         bool support = true;
         if (!is_global_config || answer == wxID_YES) {
-            new_conf.set_key_value("perimeters", new ConfigOptionInt(required_perimeters));
+            new_conf.set_key_value("perimeters", new ConfigOptionInt(1));
             new_conf.set_key_value("top_solid_layers", new ConfigOptionInt(0));
-            if (spiral_walls != 1) {
-                new_conf.set_key_value("bottom_solid_layers", new ConfigOptionInt(0));
-                new_conf.set_key_value("bottom_solid_min_thickness", new ConfigOptionFloat(0.));
-            }
             new_conf.set_key_value("fill_density", new ConfigOptionPercent(0));
             new_conf.set_key_value("support_material", new ConfigOptionBool(false));
             new_conf.set_key_value("support_material_enforce_layers", new ConfigOptionInt(0));
@@ -327,7 +308,6 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("infill_anchor", has_infill_anchors);
 
     bool has_spiral_vase         = config->opt_bool("spiral_vase");
-    toggle_field("spiral_vase_wall_count", has_spiral_vase);
     bool has_top_solid_infill 	 = config->opt_int("top_solid_layers") > 0;
     bool has_bottom_solid_infill = config->opt_int("bottom_solid_layers") > 0;
     bool has_solid_infill 		 = has_top_solid_infill || has_bottom_solid_infill;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1437,6 +1437,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Vertical shells"));
         optgroup->append_single_option_line("perimeters", category_path + "perimeters");
         optgroup->append_single_option_line("spiral_vase", category_path + "spiral-vase");
+        optgroup->append_single_option_line("spiral_vase_wall_count", category_path + "spiral-vase");
 
         Line line { "", "" };
         line.full_width = 1;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1437,7 +1437,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Vertical shells"));
         optgroup->append_single_option_line("perimeters", category_path + "perimeters");
         optgroup->append_single_option_line("spiral_vase", category_path + "spiral-vase");
-        optgroup->append_single_option_line("spiral_vase_wall_count", category_path + "spiral-vase");
+        optgroup->append_single_option_line("constant_wall_spiral", category_path + "spiral-vase");
 
         Line line { "", "" };
         line.full_width = 1;


### PR DESCRIPTION
## Continuous constant-wall spiral mode

Adds an optional **one-click print mode** for round, constant-wall shapes (tubes, cones, and other axisymmetric walls): a single checkbox, **Continuous constant-wall spiral**, under *Print Settings → Layers and perimeters → Vertical shells*.

It generalizes classic Spiral Vase to walls that are **more than one perimeter thick**, while keeping the seamless, retraction-free character of spiral vase.

### What it does

For every layer whose cross-section is a fully axisymmetric wall (exactly one hole; both boundaries circular by isoperimetric quotient; concentric), the layer's concentric perimeters are morphed into **one continuous extrusion**:

- **Uniformly re-spaced concentric rings** fill the whole wall solidly — as many as fit the geometry per layer (works on tapered walls such as cones), no separate gap-fill feature.
- **Short tangent S-arc step-overs** (one-wall-width corner radius) move between rings.
- **Exact volumetric flow**: each layer deposits exactly `wall_area × layer_height` — locally coverage-corrected (flat arcs vs. step-overs) and globally normalized, so the wall is neither over- nor under-extruded.
- **Straight vertical elevator** on the wall line at the seam for the layer change (a nozzle-diameter column bead, no Z-hop ramp), with **boustrophedon** layer direction so each layer begins exactly where the previous one's climb ended — the whole section prints with **zero retractions** and one continuous path.

Layers that are **not** a constant circular wall (side holes, ports, non-round sections, solid tops/bottoms) fall back to the regular settings automatically — the per-layer spiral-vase enable machinery disables the transform for them. No other print settings are modified by the mode.

### Implementation notes

- Classic-generator path only (`process_classic`); the morph replaces the collected loops with one `ExtrusionMultiPath`, so the existing per-layer spiral-vase gating in `GCodeGenerator` still sees a single perimeter and treats the layer as spiral.
- The vertical elevator is emitted by `SpiralVase::process_layer_multiwall` (flat layer + one vertical extruding move at the seam), with an absolute-E `G92` restore so following layers don't read as micro-retracts.
- A degenerate self-crossing "bowtie" leftover loop (where the outer-going and hole-going offset fronts meet) is rejected via a scale-invariant isoperimetric-quotient gate before morphing.
- New option `spiral_vase_wall_count` is superseded by the single `constant_wall_spiral` bool in the final commit; validation/normalization/slicing-mode adjustments are gated on the mode.

### Testing

Built and sliced locally against `version_2.9.6`. On a tapered-cone regression (25 mm tall, ~3 mm wall, 0.2 mm layers): every layer slices as a clean concentric-ring wall, **0 retractions** across the whole print, and total extruded volume within **+0.1%** of the sliced wall volume. A headless G-code analyzer (per-layer radius sweep, continuity, volumetric audit) was used to verify.

This is offered for consideration and feedback — happy to iterate on API/UX (option naming, mode placement) or split it into smaller reviewable pieces if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
