### PR TITLE
Duet: verify RepRapFirmware uploads with the rr_upload crc32 parameter

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -51,6 +51,8 @@ set(SLIC3R_SOURCES
     BuildVolume.cpp
     BuildVolume.hpp
     BoostAdapter.hpp
+    Checksum.cpp
+    Checksum.hpp
     clipper.cpp
     clipper.hpp
     ClipperUtils.cpp

--- a/src/libslic3r/Checksum.cpp
+++ b/src/libslic3r/Checksum.cpp
@@ -1,0 +1,60 @@
+///|/ Copyright (c) 2026 Leonardo Zenzen @LZZZZ
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "Checksum.hpp"
+
+#include <ios>
+#include <vector>
+
+#include <boost/crc.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
+
+namespace Slic3r {
+namespace checksum {
+
+std::optional<uint32_t> crc32_file(const boost::filesystem::path &path)
+{
+    boost::nowide::ifstream file(path.string(), std::ios::in | std::ios::binary);
+    if (! file.is_open()) {
+        BOOST_LOG_TRIVIAL(error) << "Checksum: Could not open " << path << " to compute its CRC32";
+        return std::nullopt;
+    }
+
+    boost::crc_32_type crc;
+    // Heap allocated, this runs on the print host worker thread and the buffer is too big for its stack.
+    std::vector<char> buffer(64 * 1024);
+    for (;;) {
+        file.read(buffer.data(), buffer.size());
+        const std::streamsize read = file.gcount();
+        if (read > 0)
+            crc.process_bytes(buffer.data(), static_cast<size_t>(read));
+        // A short read means we reached the end of the file. Note that this also sets failbit, so the
+        // stream state below must be checked with bad() rather than fail().
+        if (read < static_cast<std::streamsize>(buffer.size()))
+            break;
+    }
+
+    if (file.bad()) {
+        BOOST_LOG_TRIVIAL(error) << "Checksum: Error reading " << path << " to compute its CRC32";
+        return std::nullopt;
+    }
+
+    return crc.checksum();
+}
+
+std::string to_hex(uint32_t value)
+{
+    static const char digits[] = "0123456789abcdef";
+
+    std::string out(8, '0');
+    for (int i = 7; i >= 0; -- i) {
+        out[i] = digits[value & 0xF];
+        value >>= 4;
+    }
+    return out;
+}
+
+} // namespace checksum
+} // namespace Slic3r

--- a/src/libslic3r/Checksum.hpp
+++ b/src/libslic3r/Checksum.hpp
@@ -1,0 +1,30 @@
+///|/ Copyright (c) 2026 Leonardo Zenzen @LZZZZ
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_Checksum_hpp_
+#define slic3r_Checksum_hpp_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <boost/filesystem/path.hpp>
+
+namespace Slic3r {
+namespace checksum {
+
+// CRC-32 of the whole file, read in binary mode.
+// This is the ISO 3309 / ITU-T V.42 variant (polynomial 0x04C11DB7 reflected, initial value
+// 0xFFFFFFFF, final XOR 0xFFFFFFFF) as implemented by zlib's crc32() and by RepRapFirmware,
+// which uses the returned value to verify uploads made through rr_upload.
+// Returns nullopt if the file cannot be opened or a read error occurs.
+std::optional<uint32_t> crc32_file(const boost::filesystem::path &path);
+
+// Lower case hexadecimal, zero padded to 8 digits, without the "0x" prefix.
+std::string to_hex(uint32_t value);
+
+} // namespace checksum
+} // namespace Slic3r
+
+#endif // slic3r_Checksum_hpp_

--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -341,11 +341,18 @@ bool Duet::start_print(wxString &msg, const std::string &filename, ConnectionTyp
 
 int Duet::get_err_code_from_body(const std::string &body) const
 {
-	pt::ptree root;
-	std::istringstream iss (body); // wrap returned json to istringstream
-	pt::read_json(iss, root);
+	try {
+		pt::ptree root;
+		std::istringstream iss (body); // wrap returned json to istringstream
+		pt::read_json(iss, root);
 
-	return root.get<int>("err", 0);
+		return root.get<int>("err", 0);
+	} catch (const std::exception &ex) {
+		// Do not let the exception escape into the print host queue thread, which would tear the whole
+		// queue down for the rest of the session. Report it as an error instead.
+		BOOST_LOG_TRIVIAL(error) << boost::format("Duet: Could not parse the reply as JSON: %1%, body: `%2%`") % ex.what() % body;
+		return -1;
+	}
 }
 
 }

--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -23,6 +23,7 @@
 #include <wx/textctrl.h>
 #include <wx/checkbox.h>
 
+#include "libslic3r/Checksum.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/GUI/I18N.hpp"
@@ -90,7 +91,22 @@ bool Duet::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn e
 	bool res = true;
 	bool dsf = (connectionType == ConnectionType::dsf);
 
-	auto upload_cmd = get_upload_url(upload_data.upload_path.string(), connectionType);
+	// RepRapFirmware compares this against the CRC32 of the data it actually received and fails the
+	// upload on a mismatch, which is the only way to catch a transfer that got corrupted past the
+	// TCP checksum. The DSF endpoint has no equivalent parameter.
+	std::optional<uint32_t> crc32;
+	if (! dsf) {
+		crc32 = checksum::crc32_file(upload_data.source_path);
+		if (! crc32) {
+			// The upload would send an empty body, so fail here rather than truncating the file on the printer.
+			BOOST_LOG_TRIVIAL(error) << boost::format("Duet: Could not read %1% to compute its checksum") % upload_data.source_path;
+			error_fn(format_error(std::string(), L("Could not read the file to be uploaded."), 0));
+			disconnect(connectionType);
+			return false;
+		}
+	}
+
+	auto upload_cmd = get_upload_url(upload_data.upload_path.string(), connectionType, crc32);
 	BOOST_LOG_TRIVIAL(info) << boost::format("Duet: Uploading file %1%, filepath: %2%, post_action: %3%, command: %4%")
 		% upload_data.source_path
 		% upload_data.upload_path
@@ -111,7 +127,13 @@ bool Duet::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn e
 			int err_code = dsf ? (status == 201 ? 0 : 1) : get_err_code_from_body(body);
 			if (err_code != 0) {
 				BOOST_LOG_TRIVIAL(error) << boost::format("Duet: Request completed but error code was received: %1%") % err_code;
-				error_fn(format_error(body, L("Unknown error occured"), 0));
+				// If we sent a checksum, the firmware rejecting the upload most likely means the data did not
+				// arrive intact. RepRapFirmware removes the incomplete file by itself in that case.
+				error_fn(format_error(body, (crc32 && err_code > 0)
+					? L("The printer rejected the uploaded file, most likely because it was corrupted during "
+					    "the transfer (checksum or size mismatch). The incomplete file was removed from the "
+					    "printer. Please try the upload again.")
+					: L("Unknown error occured"), 0));
 				res = false;
 			} else if (upload_data.post_action == PrintHostPostUploadAction::StartPrint) {
 				wxString errormsg;
@@ -220,7 +242,7 @@ void Duet::disconnect(ConnectionType connectionType) const
 	.perform_sync();
 }
 
-std::string Duet::get_upload_url(const std::string &filename, ConnectionType connectionType) const
+std::string Duet::get_upload_url(const std::string &filename, ConnectionType connectionType, const std::optional<uint32_t> &crc32) const
 {
     assert(connectionType != ConnectionType::error);
 
@@ -229,10 +251,13 @@ std::string Duet::get_upload_url(const std::string &filename, ConnectionType con
 				% get_base_url()
 				% Http::url_encode(filename)).str();
 	} else {
-		return (boost::format("%1%rr_upload?name=0:/gcodes/%2%&%3%")
+		// The crc32 parameter is supported since RepRapFirmware 2.04RC3 and expects a lower case hex
+		// string without the "0x" prefix. Older firmware simply ignores it.
+		return (boost::format("%1%rr_upload?name=0:/gcodes/%2%&%3%%4%")
 				% get_base_url()
 				% Http::url_encode(filename)
-				% timestamp_str()).str();
+				% timestamp_str()
+				% (crc32 ? "&crc32=" + checksum::to_hex(*crc32) : std::string())).str();
 	}
 }
 

--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -116,7 +116,7 @@ bool Duet::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn e
 	auto http = (dsf ? Http::put(std::move(upload_cmd)) : Http::post(std::move(upload_cmd)));
 	if (dsf) {
 		http.set_put_body(upload_data.source_path);
-		if (connect_msg.empty())
+		if (! connect_msg.empty())
             http.header("X-Session-Key", GUI::into_u8(connect_msg));
 	} else {
 		http.set_post_body(upload_data.source_path);

--- a/src/slic3r/Utils/Duet.hpp
+++ b/src/slic3r/Utils/Duet.hpp
@@ -7,6 +7,8 @@
 #ifndef slic3r_Duet_hpp_
 #define slic3r_Duet_hpp_
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <wx/string.h>
 
@@ -39,7 +41,10 @@ private:
 	std::string host;
 	std::string password;
 
-	std::string get_upload_url(const std::string &filename, ConnectionType connectionType) const;
+	// crc32 is appended to the RepRapFirmware rr_upload URL when set, so that the firmware can
+	// verify the data it received. It is ignored for the DuetSoftwareFramework endpoint, which
+	// has no equivalent parameter.
+	std::string get_upload_url(const std::string &filename, ConnectionType connectionType, const std::optional<uint32_t> &crc32) const;
 	std::string get_connect_url(const bool dsfUrl) const;
 	std::string get_base_url() const;
 	std::string timestamp_str() const;

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -313,7 +313,10 @@ void Http::priv::form_add_file(const char *name, const fs::path &path, const cha
 //FIXME may throw! Is the caller aware of it?
 void Http::priv::set_post_body(const fs::path &path)
 {
-	boost::nowide::ifstream file(path.string());
+	// Binary mode is mandatory: in text mode a Windows build would collapse CRLF to LF, so the bytes
+	// sent would differ from the bytes on disk. That corrupts binary G-code and breaks any checksum
+	// the caller computed over the file.
+	boost::nowide::ifstream file(path.string(), std::ios::in | std::ios::binary);
 	std::string file_content { std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>() };
 	postfields = std::move(file_content);
 }

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${_TEST_NAME}_tests
 	test_kdtreeindirect.cpp
 	test_arachne.cpp
 	test_arc_welder.cpp
+	test_checksum.cpp
 	test_clipper_offset.cpp
 	test_clipper_utils.cpp
 	test_color.cpp

--- a/tests/libslic3r/test_checksum.cpp
+++ b/tests/libslic3r/test_checksum.cpp
@@ -1,0 +1,119 @@
+#include <catch2/catch_test_macros.hpp>
+#include "libslic3r/libslic3r.h"
+
+#include <atomic>
+#include <string>
+
+#include <boost/crc.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/nowide/fstream.hpp>
+
+#include "libslic3r/Checksum.hpp"
+
+using namespace Slic3r;
+
+namespace {
+
+// Writes the given bytes into a uniquely named file in the temp directory and removes it again
+// when it goes out of scope.
+class ScopedTempFile
+{
+public:
+    explicit ScopedTempFile(const std::string &content)
+    {
+        static std::atomic<int> counter{0};
+        m_path = boost::filesystem::temp_directory_path()
+            / ("slic3r-checksum-test-" + std::to_string(counter.fetch_add(1)) + ".bin");
+
+        boost::nowide::ofstream file(m_path.string(), std::ios::out | std::ios::binary);
+        file.write(content.data(), content.size());
+        file.close();
+    }
+    ~ScopedTempFile() { boost::system::error_code ec; boost::filesystem::remove(m_path, ec); }
+
+    ScopedTempFile(const ScopedTempFile &) = delete;
+    ScopedTempFile& operator=(const ScopedTempFile &) = delete;
+
+    const boost::filesystem::path& path() const { return m_path; }
+
+private:
+    boost::filesystem::path m_path;
+};
+
+} // namespace
+
+TEST_CASE("Hexadecimal formatting of a CRC32", "[Checksum]") {
+    // rr_upload expects the value zero padded to 8 digits and without the "0x" prefix. A shorter
+    // string would be parsed by RepRapFirmware as a different number and every upload would fail.
+    REQUIRE(checksum::to_hex(0xcbf43926) == "cbf43926");
+    REQUIRE(checksum::to_hex(0x000000ff) == "000000ff");
+    REQUIRE(checksum::to_hex(0x00000000) == "00000000");
+    REQUIRE(checksum::to_hex(0xffffffff) == "ffffffff");
+    // Must be lower case hexadecimal.
+    REQUIRE(checksum::to_hex(0xdeadbeef) == "deadbeef");
+}
+
+TEST_CASE("CRC32 of a file matches the standard CRC-32/ISO-HDLC check value", "[Checksum]") {
+    // "123456789" -> 0xCBF43926 is the check value of the CRC-32 variant used by zlib and by
+    // RepRapFirmware. This is what pins the implementation to the variant the firmware expects,
+    // as opposed to for example CRC-32C (Castagnoli), which would yield 0xE3069283.
+    const ScopedTempFile file("123456789");
+    const std::optional<uint32_t> crc = checksum::crc32_file(file.path());
+    REQUIRE(crc.has_value());
+    REQUIRE(*crc == 0xcbf43926u);
+    REQUIRE(checksum::to_hex(*crc) == "cbf43926");
+}
+
+TEST_CASE("CRC32 of an empty file is zero", "[Checksum]") {
+    const ScopedTempFile file("");
+    const std::optional<uint32_t> crc = checksum::crc32_file(file.path());
+    REQUIRE(crc.has_value());
+    REQUIRE(*crc == 0x00000000u);
+}
+
+TEST_CASE("CRC32 is correct across the read buffer boundary", "[Checksum]") {
+    // The implementation reads in 64 KiB chunks and stops on a short read. Sizes that are an exact
+    // multiple of the buffer are the risky ones: there the last full read succeeds without setting
+    // eofbit, so a naive loop either drops the final chunk or counts it twice.
+    constexpr size_t buffer_size = 64 * 1024;
+    const size_t sizes[] = { buffer_size - 1, buffer_size, buffer_size + 1,
+                             2 * buffer_size, 2 * buffer_size + 1, 3 * buffer_size, 200 * 1024 };
+
+    for (size_t size : sizes) {
+        std::string content;
+        content.reserve(size);
+        for (size_t i = 0; i < size; ++ i)
+            content.push_back(static_cast<char>(i * 31 + (i >> 8)));
+
+        const ScopedTempFile file(content);
+        const std::optional<uint32_t> crc = checksum::crc32_file(file.path());
+        REQUIRE(crc.has_value());
+
+        // Cross check against a single shot CRC over the same bytes.
+        boost::crc_32_type reference;
+        reference.process_bytes(content.data(), content.size());
+        INFO("file size " << size);
+        REQUIRE(*crc == reference.checksum());
+    }
+}
+
+TEST_CASE("CRC32 is computed over the raw bytes, including CR LF", "[Checksum]") {
+    // Regression guard: the file must be read in binary mode. If it were opened in text mode, a
+    // Windows build would collapse "\r\n" to "\n" and produce a checksum that does not match the
+    // bytes actually uploaded.
+    const std::string content = "G1 X1 Y1\r\nG1 X2 Y2\r\n";
+    const ScopedTempFile file(content);
+    const std::optional<uint32_t> crc = checksum::crc32_file(file.path());
+    REQUIRE(crc.has_value());
+
+    boost::crc_32_type reference;
+    reference.process_bytes(content.data(), content.size());
+    REQUIRE(*crc == reference.checksum());
+}
+
+TEST_CASE("CRC32 of a missing file reports failure instead of a bogus value", "[Checksum]") {
+    const boost::filesystem::path missing =
+        boost::filesystem::temp_directory_path() / "slic3r-checksum-this-file-does-not-exist.bin";
+    REQUIRE(! boost::filesystem::exists(missing));
+    REQUIRE(! checksum::crc32_file(missing).has_value());
+}


### PR DESCRIPTION
### Problem

`rr_upload` accepts an optional `crc32` parameter that lets RepRapFirmware verify an uploaded file
against the CRC32 computed by the client. PrusaSlicer does not send it, so a Duet upload is never
checked. This adds it.

A 129,682,213 byte upload to a Duet 2 WiFi (RRF 3.6.1) arrived with one corrupted 3,063-byte
window, 94.75% of the way through the file. `rr_upload` returned `{"err":0}` and the size on disk
was exact, so nothing detected it; two prints then failed at that layer while the firmware
reported the job completed normally. Re-uploading produced a byte-exact copy, so the corruption
was transient in transit rather than a bad SD card.

RepRapFirmware has compared this parameter against the data it received since 2.04RC3, failing
the upload and deleting the partial file on mismatch. The Duet3D documentation states "Usage of
this parameter is encouraged."

<details>
<summary>Detail of the corrupted window, if useful</summary>

Bytes 122,867,719–122,870,781; the rest of the file was byte-identical to a fresh export.

- 479 bytes altered, 369 of them (77%) single-bit flips spread evenly across all 8 bit positions
- 15 line terminators destroyed, merging adjacent lines
- 3 NUL bytes and 3 `0x1A` bytes introduced
- not aligned to any 512 B / 4 KiB / 32 KiB boundary
- layer 929 of 1058, producing roughly a hundred malformed commands:

```
sent:      G1 X40.829 Y53.898 E.00429
on disk:   G1 X40.829 Y53&8.<  E.00429
```

TCP's checksum is 16 bits and weak, and here the corruption occurred past it, on the SPI link
between the WiFi module and the main MCU. Only a client-computed checksum verified by the
firmware spans that boundary.

</details>

### Changes

1. **`libslic3r/Checksum.{hpp,cpp}` (new)** — `crc32_file()` streams a file in 64 KiB chunks and
   returns the CRC-32 variant used by zlib and RRF, via header-only `boost::crc_32_type`, so no
   new dependency. Returns `std::nullopt` when the file cannot be read, so a checksum is never
   sent for data that was not read. Placed in `libslic3r` and kept generic so Moonraker can
   follow separately.

2. **`Duet.cpp`** — sends `&crc32=<hex>` on the `rr_upload` URL, and reports a rejected upload as
   probable transfer corruption rather than an unspecified error. Older firmware ignores the
   parameter. The DSF endpoint has no equivalent and is unchanged.

3. **`Http.cpp`** — `set_post_body(const fs::path &)` now opens in binary mode. Prerequisite: in
   text mode a Windows build translates CRLF to LF, so the bytes sent differ from the bytes on
   disk and the checksum would not match what the server receives. Independently, this is why
   binary G-code sent through a POST body is mangled on Windows today. `set_put_body()` was
   already binary. The other affected caller is MKS.

Two adjacent fixes in the same file, as separate commits so they can be dropped independently:

4. **`Duet.cpp`** — `get_err_code_from_body()` called `pt::read_json()` unguarded. A non-JSON
   reply throws, the exception escapes `Duet::upload()`, and it is caught only at the top of
   `PrintHostJobQueue::bg_thread_main()` — which kills the upload queue thread for the rest of the
   session. Now guarded, returning -1, which both callers already treat as a failure.

5. **`Duet.cpp`** — `X-Session-Key` is sent only when the session key is *empty*
   (`if (connect_msg.empty())`), so it is never sent when there is a key. Introduced in
   2a4e09a2e, which added the header, so this path has not worked since.

### Verification

Against the same hardware and the same 129,682,213 byte file:

| Case | Result |
|---|---|
| Correct CRC | Accepted. RRF independently computes CRC-32 over what it received and compares, so acceptance confirms the variant, byte range and hex encoding all match the firmware. Downloading the file back gave a byte-exact match. |
| CRC with one bit flipped | Rejected, error shown to the user, and `rr_filelist` confirmed the file was absent afterwards with no partial leftovers. |
| Mock `rr_upload` server | URL carries `crc32=<hex>`; the value equals an independent `zlib.crc32` of the received body; a payload containing `\r\n`, `0x1A` and NUL arrives at full length. |
| Non-JSON reply | Throws out of `upload()` without change 4; handled cleanly with it. |

`tests/libslic3r/test_checksum.cpp` covers the standard CRC-32 check vector (`"123456789"` →
`0xCBF43926`, which pins the implementation to the variant the firmware expects rather than
CRC-32C), the empty file, sizes either side of the read buffer boundary including exact multiples
of it, and that CRLF is not translated away. `libslic3r_tests` and `slic3rutils_tests` pass.

**Change 5 is not tested** — it only runs against DuetSoftwareFramework on an SBC-based Duet,
which I do not have. If someone with that setup can try it I would appreciate it; otherwise I am
happy to drop that commit and submit it separately. The Windows behaviour of change 3 is reasoned
from `ifstream` semantics rather than observed; on Linux and macOS the two modes are identical.

### Not included

The same gap exists elsewhere and I have kept this to the backend I can verify on hardware.
`Moonraker.cpp` quotes the API documentation for its `checksum` field verbatim in a comment, and
the code four lines below adds `root`, `path`, `print` and `file` but not `checksum`. That needs a
SHA256 source and a Klipper host to test against. `PrusaConnect.cpp` never reads the `hash` field
in the server's reply.
