### PR TITLE
Fix MainFrame.hpp include case (build failure on case-sensitive filesystems)

### DIFF
--- a/src/slic3r/GUI/WebViewPlatformUtilsWin32.cpp
+++ b/src/slic3r/GUI/WebViewPlatformUtilsWin32.cpp
@@ -10,7 +10,7 @@
 
 #include "GUI_App.hpp"
 #include "format.hpp"
-#include "Mainframe.hpp"
+#include "MainFrame.hpp"
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>


### PR DESCRIPTION
### What
`src/slic3r/GUI/WebViewPlatformUtilsWin32.cpp` includes `"Mainframe.hpp"`, but the
header is actually named `MainFrame.hpp`. This one-character change corrects the
include to match the real filename case.

### Why
The file is Windows-only, and Windows filesystems are normally case-insensitive, so
the mismatch has gone unnoticed. Building the Windows (MSVC) target from a
**case-sensitive volume** — e.g. a WSL/9P share or a case-sensitive Windows Dev Drive —
fails to compile:

```
WebViewPlatformUtilsWin32.cpp(13): fatal error C1083:
    Cannot open include file: 'Mainframe.hpp': No such file or directory
```

The fix is a no-op on case-insensitive filesystems, so it does not affect the standard
Visual Studio build.

### How tested
Built the MSVC Windows target (VS 2026 / MSVC 14.50, Ninja) with the source tree on a
case-sensitive volume. Before: compilation of `WebViewPlatformUtilsWin32.cpp` fails with
C1083. After: the file compiles and the full application links (`PrusaSlicer.dll`,
`prusa-slicer.exe`, `prusa-slicer-console.exe`, `prusa-gcodeviewer.exe`), and
`prusa-slicer-console.exe --help` runs.

### Disclaimer
This change was authored by Claude (Anthropic's AI) via Claude Code, at the request of
the submitter, who has reviewed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
