### PR TITLE
Fix raft printed with wrong tool in sequential mode with support_material_extruder=0

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -119,6 +119,17 @@ ToolOrdering::ToolOrdering(const PrintObject &object, unsigned int first_extrude
     // Collect extruders required to print the layers.
     this->collect_extruders(object, std::vector<std::pair<double, unsigned int>>(), std::vector<std::pair<double, unsigned int>>());
 
+    // In sequential printing, each object's ToolOrdering is seeded with the previously printed
+    // object's last tool. For a rafted object, the lowest layers are raft/support layers whose
+    // extruder is the "current tool" placeholder (when support_material_extruder = 0); reorder_extruders
+    // would then resolve them to that seed, i.e. the previous object's tool, so the raft would not use
+    // this object's own first-layer tool.
+    // Seed with -1 instead: reorder_extruders then self-seeds from this object's own first printing
+    // extruder (the same path already used for the very first printed object), so the raft and
+    // first_extruder() both follow the object rather than whatever printed before it.
+    if (! m_layer_tools.empty() && ! m_layer_tools.front().has_object)
+        first_extruder = (unsigned int)-1;
+
     // Reorder the extruders to minimize tool switches.
     this->reorder_extruders(first_extruder);
 


### PR DESCRIPTION
### What

In **Complete individual objects** (`complete_objects`, sequential) mode, when an object has a **raft** and `support_material_extruder` is `0` ("use the current extruder"), the raft is printed with the **previously printed object's tool** instead of the object's own first-layer tool.

### Why

In sequential mode each object gets its own `ToolOrdering`, constructed via the single-object `ToolOrdering(const PrintObject&, unsigned int first_extruder)` constructor and seeded with the previous object's last tool (`GCode.cpp`, the `complete_objects` loop).

For a rafted object, the lowest layers are raft/support layers. With `support_material_extruder = 0`, `collect_extruders()` records the "don't care"/current-tool placeholder (`0`) for those layers, and `reorder_extruders()` then resolves a leading placeholder to the seed — i.e. the previous object's tool. Because the raft is the lowest layer, this also propagates to `first_extruder()` and thus the object's initial tool.

A non-rafted object is unaffected: its first layer is an object layer whose extruder set contains the concrete `perimeter_extruder`, never the placeholder, so the seed never overrides it.

### Fix

Before reordering, if the object's first `LayerTools` is not an object layer (i.e. it begins with a raft/support layer), reset the seed to `-1`. `reorder_extruders()` then self-seeds from the object's **own** first printing extruder — exactly the path already used for the very first printed object — so the raft and the object's initial tool follow the object rather than whatever printed before it.

```cpp
if (! m_layer_tools.empty() && ! m_layer_tools.front().has_object)
    first_extruder = (unsigned int)-1;
```

The change is confined to the single-object (sequential) `ToolOrdering` constructor, so normal all-at-once printing — where a raft following the current tool is the documented behavior of `support_material_extruder = 0` — is unaffected.

This is consistent with the intent of `support_material_extruder = 0` ("minimize tool changes"): a tool change into the object's first-layer tool is required for that object regardless, so performing it before the raft rather than after it adds no extra tool change.

### How tested

Sliced a three-object project in sequential mode with a raft and `support_material_extruder = 0`, where each object is assigned a different extruder:

- **Before:** the next object's raft prints with the previous object's tool, then a tool change occurs for the object body.
- **After:** each object's raft uses that object's own first-layer tool.

Non-sequential (all-at-once) two-extruder slicing is unchanged.

Three objects assigned different extruders, sequential mode, raft enabled, `support_material_extruder = 0`:

| Before | After |
| --- | --- |
| <img width="755" height="617" alt="before" src="https://github.com/user-attachments/assets/379e9915-b99d-4344-93a1-3b1a8237f511" /> | <img width="778" height="635" alt="after" src="https://github.com/user-attachments/assets/7c913cdf-1325-4919-b824-e66366cfa2d1" /> |

### Disclaimer

This change was authored by Claude (Anthropic's AI) via Claude Code, at the request of the submitter, who has reviewed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)