### PR TITLE
Fix a crash in Print settings selector dropdown

### DIFF
--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -85,7 +85,8 @@ static gint gtk_popup_key_press (GtkWidget *widget, GdkEvent *gdk_event, wxPopup
     }
 
     gchar* keyval = gdk_keyval_name(((GdkEventKey*)gdk_event)->keyval);
-    const long keyCode = strcmp(keyval, "Up") == 0     ? WXK_UP     :
+    const long keyCode = keyval == nullptr             ? WXK_NONE   :
+                         strcmp(keyval, "Up") == 0     ? WXK_UP     :
                          strcmp(keyval, "Down") == 0   ? WXK_DOWN   :
                          strcmp(keyval, "Left") == 0   ? WXK_LEFT   :
                          strcmp(keyval, "Right") == 0  ? WXK_RIGHT  :


### PR DESCRIPTION
gdk_keyval_name() returns nullptr for a keyval it has no name for, which happens for key presses carrying an unmapped keycode.

This triggered a crash under certain circumstances where KEY_UNKNOWN was sent as part of a dropdown being opened. Observed under KDE and XWayland. Reason for the keypresses still unclear. Either from KDE or Wayland.

Fix is just guarding against the nullptr.