### PR TITLE
Fix building with Visual Studio 2019

### DIFF
--- a/doc/How to build - Windows.md
+++ b/doc/How to build - Windows.md
@@ -4,7 +4,7 @@
 ## 0. Prerequisities
 
 The following tools need to be installed on your computer:
-- Microsoft Visual Studio version 16 2019 or 17 2022
+- Microsoft Visual Studio version 16 2019 or 17 2022, including the "C++ ATL" component for the used toolset (not part of the default Build Tools installation)
 - CMake
 - git
 

--- a/src/slic3r/GUI/DoubleSliderForLayers.cpp
+++ b/src/slic3r/GUI/DoubleSliderForLayers.cpp
@@ -328,7 +328,7 @@ void DSForLayers::draw_ruler(const ImRect& slideable_region)
         ImGui::RenderText(start, label.c_str());
     };
 
-    auto draw_tick = [x_center, tick_width, inner_x](const float tick_pos, const float outer_x)
+    auto draw_tick = [x_center, tick_width, inner_x, tick_clr](const float tick_pos, const float outer_x)
     {
         ImRect tick_right = ImRect(x_center + inner_x, tick_pos - tick_width, x_center + outer_x, tick_pos);
         ImGui::RenderFrame(tick_right.Min, tick_right.Max, tick_clr, false);

--- a/tests/libslic3r/test_multiple_beds.cpp
+++ b/tests/libslic3r/test_multiple_beds.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Conversion between grid coords and index", "[MultipleBeds]")
 
     // Add indexes covering the whole int positive range.
     const int n{100};
-    std::generate_n(std::back_inserter(original_indices), n, [i = 1]() mutable {
+    std::generate_n(std::back_inserter(original_indices), n, [i = 1, n]() mutable {
         return std::numeric_limits<int>::max() / n * i++;
     });
 


### PR DESCRIPTION
Current master does not build with Visual Studio 2019 (MSVC 14.29), although the Windows build documentation lists it as supported. Two small fixes:

- MSVC 14.29 rejects referencing a `constexpr`/`const` local variable inside a lambda with an explicit capture list unless the variable is captured (error C3493); newer compilers accept it. The two occurrences (`tests/libslic3r/test_multiple_beds.cpp`, `src/slic3r/GUI/DoubleSliderForLayers.cpp`) are fixed by capturing the variable explicitly — no behavior change, the captured values are compile-time constants.
- `src/slic3r/GUI/RemovableDriveManager.cpp` includes `atlbase.h`, which requires the "C++ ATL" component that the default Visual Studio Build Tools installation does not include. The build documentation now mentions it in the prerequisites.

Verified by building the full application and the test suites with Visual Studio 2019 Build Tools 16.11 (x64 host toolset) on Windows 11; `libslic3r_tests` passes.
