### PR TITLE
docs: fix typo recomended -> recommended

### DIFF
--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -454,7 +454,7 @@ void PresetUpdater::priv::sync_config(const VendorMap& vendors, const ArchiveRep
 		// vendors that are checked here, doesnt need to be checked again later
 		archive_it->second = VendorStatus::NEW_VERSION;
 
-		// Download recomended ini to cache
+		// Download recommended ini to cache
 		const auto path_in_cache = cache_path / (vendor.id + ".ini");
 		BOOST_LOG_TRIVIAL(info) << "Downloading new bundle for vendor: " << vendor.name;
 		const std::string source_subpath = GUI::format("%1%/%2%.ini", vendor.id, recommended.to_string());
@@ -607,7 +607,7 @@ void PresetUpdater::priv::sync_config(const VendorMap& vendors, const ArchiveRep
 			const auto recommended_archive = recommended_it_archive->config_version;
 			
 			if (recommended_archive <= recommended_cache) {
-				// There isn't  more recent recomended version online. This vendor is also not istalled.
+				// There isn't  more recent recommended version online. This vendor is also not istalled.
 				// Thus only .ini is in resources and came with installation.
 				// And we expect all resources are present.
 				continue;


### PR DESCRIPTION
Corrects the misspelling `recomended` -> `recommended` in `src/slic3r/Utils/PresetUpdater.cpp`.

Documentation only, no behaviour change.