### PR TITLE
Allow mouse-wheel adjustment of settings controls

### DIFF
--- a/src/slic3r-shared/include/Slic3r/App/Yoga/InputText.hpp
+++ b/src/slic3r-shared/include/Slic3r/App/Yoga/InputText.hpp
@@ -22,6 +22,7 @@ public:
     {
         std::function<void(bool hovered)> hovered_changed{nullptr};
         std::function<void(bool active)> active_changed{nullptr};
+        std::function<void(float wheel_delta)> mouse_wheel{nullptr};
         /**
          * @brief text_edited is fired only after editing is finished (e.g. Enter/ESC or item lost
          * it's focus) This is due to optional validator which is invoked just before this callback

--- a/src/slic3r-shared/src/Slic3r/App/Yoga/ComboBox.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/Yoga/ComboBox.cpp
@@ -145,6 +145,7 @@ bool ComboBox::YGBeginCombo(
             ImGuiInputTextFlags_AutoSelectAll,
             nullptr
         );
+        hovered |= ImGui::IsItemHovered();
         if (ImGui::IsItemActivated() && m_validator) {
             std::string without_unit = m_validator->string_without_unit();
             strncpy(
@@ -349,7 +350,7 @@ void ComboBox::render(const Vec2f& pos, const Vec2f& size)
 
         const std::string id = "###" + object_name();
         bool new_hovered     = false;
-        if (YGBeginCombo(
+        const bool popup_open = YGBeginCombo(
                 id.c_str(),
                 m_override_label.empty() ? m_current_label.c_str() : m_override_label.c_str(),
                 to_im(size),
@@ -364,8 +365,11 @@ void ComboBox::render(const Vec2f& pos, const Vec2f& size)
                 new_hovered,
                 m_imgui_render ? m_imgui_render->font(m_label_font_type) : nullptr,
                 m_label_color
-            ))
-        {
+            );
+        if (enabled() && !popup_open && new_hovered && !m_items.empty()) {
+            ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY);
+        }
+        if (popup_open) {
             const ImVec2 im_size = to_im(size);
             for (int index = 0; index < static_cast<int>(m_items.size()); ++index) {
                 ImGui::PushID(index);
@@ -387,6 +391,29 @@ void ComboBox::render(const Vec2f& pos, const Vec2f& size)
             }
 
             ImGui::EndCombo();
+        }
+
+        ImGuiIO& io = ImGui::GetIO();
+        if (enabled()
+            && !popup_open
+            && new_hovered
+            && !m_items.empty()
+            && io.MouseWheel != 0.f)
+        {
+            const int offset    = io.MouseWheel > 0.f ? -1 : 1;
+            const int new_index = std::clamp(
+                m_current_index + offset,
+                0,
+                static_cast<int>(m_items.size()) - 1
+            );
+            io.MouseWheel = 0.f;
+
+            if (new_index != m_current_index) {
+                set_current_index(new_index);
+                if (m_callbacks.selection_changed) {
+                    m_callbacks.selection_changed(new_index);
+                }
+            }
         }
 
         ImGui::PopStyleVar(1);

--- a/src/slic3r-shared/src/Slic3r/App/Yoga/InputText.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/Yoga/InputText.cpp
@@ -165,6 +165,14 @@ void InputText::render(const Vec2f& pos, const Vec2f& size)
                 m_callbacks.hovered_changed(m_hovered);
             }
         }
+        if (enabled() && hovered && m_callbacks.mouse_wheel) {
+            ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelY);
+        }
+        if (enabled() && hovered && GImGui->IO.MouseWheel != 0.f && m_callbacks.mouse_wheel) {
+            const float wheel_delta = GImGui->IO.MouseWheel;
+            GImGui->IO.MouseWheel   = 0.f;
+            m_callbacks.mouse_wheel(wheel_delta);
+        }
 
         ImGui::PopFont();
 

--- a/src/slic3r-shared/src/Slic3r/App/Yoga/InputTextWithSpin.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/Yoga/InputTextWithSpin.cpp
@@ -34,6 +34,14 @@ InputTextWithSpin::InputTextWithSpin(
             m_callbacks.text_edited();
         }
     };
+    InputTextField::callbacks().mouse_wheel = [this](float wheel_delta)
+    {
+        if (wheel_delta > 0.f) {
+            increase_value();
+        } else {
+            decrease_value();
+        }
+    };
 
     set_padding(0);
     Item* spins = emplace_back<Item>();

--- a/src/slic3r-shared/test/Slic3r/App/Yoga/ComboBoxTests.cpp
+++ b/src/slic3r-shared/test/Slic3r/App/Yoga/ComboBoxTests.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <Slic3r/App/Yoga/ComboBox.hpp>
+#include <Slic3r/App/Yoga/ScrollArea.hpp>
 
 #include "YogaComponentFixture.hpp"
 
@@ -154,6 +155,105 @@ TEST_CASE_METHOD(YogaComponentFixture, "ComboBox: selection_changed does not fir
     open_combo(*this, combo);
 
     REQUIRE(changed_index == -1);
+}
+
+TEST_CASE_METHOD(YogaComponentFixture, "ComboBox: mouse wheel changes selection while hovered")
+{
+    ComboBox* combo = make_combo(*this, {"alpha", "beta", "gamma"});
+    combo->set_current_index(1);
+
+    std::vector<int> changed_indices;
+    combo->callbacks().selection_changed = [&](int index) { changed_indices.push_back(index); };
+
+    render();
+    const Vec2f pos = combo->get_global_pos();
+    mouse_move(pos.x() + combo->width() * 0.5f, pos.y() + combo->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, 1.f);
+    render();
+
+    REQUIRE(combo->current_index() == 0);
+    REQUIRE(changed_indices == std::vector<int>{0});
+
+    ImGui::GetIO().AddMouseWheelEvent(0.f, -1.f);
+    render();
+
+    REQUIRE(combo->current_index() == 1);
+    REQUIRE(changed_indices == std::vector<int>{0, 1});
+}
+
+TEST_CASE_METHOD(YogaComponentFixture, "ComboBox: mouse wheel changes editable selection")
+{
+    ComboBox* combo = make_combo(*this, {"0%", "5%", "10%"});
+    combo->set_editable(true);
+    combo->set_current_index(1);
+
+    int changed_index                    = -1;
+    combo->callbacks().selection_changed = [&](int index) { changed_index = index; };
+
+    render();
+    const Vec2f pos = combo->get_global_pos();
+    mouse_move(pos.x() + combo->width() * 0.25f, pos.y() + combo->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, 1.f);
+    render();
+
+    REQUIRE(combo->current_index() == 0);
+    REQUIRE(changed_index == 0);
+}
+
+TEST_CASE_METHOD(YogaComponentFixture, "ComboBox: mouse wheel respects bounds")
+{
+    ComboBox* combo = make_combo(*this, {"alpha", "beta"});
+
+    int changed_count                    = 0;
+    combo->callbacks().selection_changed = [&](int) { ++changed_count; };
+
+    render();
+    const Vec2f pos = combo->get_global_pos();
+    mouse_move(pos.x() + combo->width() * 0.5f, pos.y() + combo->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, 1.f);
+    render();
+
+    REQUIRE(combo->current_index() == 0);
+    REQUIRE(changed_count == 0);
+}
+
+TEST_CASE_METHOD(
+    YogaComponentFixture,
+    "ComboBox: mouse wheel does not scroll parent ScrollArea"
+)
+{
+    ScrollArea* scroll_area = window->emplace_back<ScrollArea>();
+    scroll_area->set_width(300.f);
+    scroll_area->set_height(100.f);
+    scroll_area->set_orientation(Orientation::Vertical);
+
+    ComboBox* combo = scroll_area->emplace_back<ComboBox>(
+        std::initializer_list<std::string>{"alpha", "beta"}
+    );
+    combo->set_editable(true);
+    combo->set_width(280.f);
+    combo->set_height(30.f);
+    combo->set_flex_shrink(0.f);
+
+    Item* overflow = scroll_area->emplace_back<Item>();
+    overflow->set_height(300.f);
+    overflow->set_flex_shrink(0.f);
+
+    render();
+    render();
+    REQUIRE(scroll_area->scroll_size().y() > 0.f);
+
+    const Vec2f pos = combo->get_global_pos();
+    mouse_move(pos.x() + combo->width() * 0.25f, pos.y() + combo->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, -1.f);
+    render();
+
+    REQUIRE(combo->current_index() == 1);
+    REQUIRE(scroll_area->scroll_pos().y() == 0.f);
 }
 
 TEST_CASE_METHOD(

--- a/src/slic3r-shared/test/Slic3r/App/Yoga/InputTextTests.cpp
+++ b/src/slic3r-shared/test/Slic3r/App/Yoga/InputTextTests.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <Slic3r/App/Yoga/InputText.hpp>
+#include <Slic3r/App/Yoga/InputTextWithSpin.hpp>
+#include <Slic3r/App/Yoga/ScrollArea.hpp>
 #include <Slic3r/App/Yoga/Validator.hpp>
 
 #include "YogaComponentFixture.hpp"
@@ -135,4 +137,77 @@ TEST_CASE_METHOD(YogaComponentFixture, "InputText: hovered is true when mouse is
     render();
 
     REQUIRE(input->hovered());
+}
+
+TEST_CASE_METHOD(YogaComponentFixture, "InputText: mouse_wheel fires while hovered")
+{
+    InputText* input = make_input(*this);
+
+    float wheel_delta             = 0.f;
+    input->callbacks().mouse_wheel = [&](float delta) { wheel_delta = delta; };
+
+    render();
+    const Vec2f pos = input->get_global_pos();
+    mouse_move(pos.x() + input->width() * 0.5f, pos.y() + input->height() * 0.5f);
+    ImGui::GetIO().AddMouseWheelEvent(0.f, 1.f);
+    render();
+
+    REQUIRE(wheel_delta == 1.f);
+}
+
+TEST_CASE_METHOD(YogaComponentFixture, "InputTextWithSpin: mouse wheel changes value")
+{
+    auto* input = window->emplace_back<InputTextWithSpin>(std::make_unique<IntValidator>());
+    input->set_width(300.f);
+    input->set_height(30.f);
+    input->set_margin(Margins(200.f, 200.f, 0.f, 0.f));
+    input->set_text("2");
+
+    render();
+    const Vec2f pos = input->get_global_pos();
+    mouse_move(pos.x() + input->width() * 0.5f, pos.y() + input->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, 1.f);
+    render();
+    REQUIRE(input->text() == "3");
+
+    ImGui::GetIO().AddMouseWheelEvent(0.f, -1.f);
+    render();
+    REQUIRE(input->text() == "2");
+}
+
+TEST_CASE_METHOD(
+    YogaComponentFixture,
+    "InputTextWithSpin: mouse wheel does not scroll parent ScrollArea"
+)
+{
+    ScrollArea* scroll_area = window->emplace_back<ScrollArea>();
+    scroll_area->set_width(300.f);
+    scroll_area->set_height(100.f);
+    scroll_area->set_orientation(Orientation::Vertical);
+
+    auto* input = scroll_area->emplace_back<InputTextWithSpin>(
+        std::make_unique<IntValidator>()
+    );
+    input->set_width(280.f);
+    input->set_height(30.f);
+    input->set_flex_shrink(0.f);
+    input->set_text("2");
+
+    Item* overflow = scroll_area->emplace_back<Item>();
+    overflow->set_height(300.f);
+    overflow->set_flex_shrink(0.f);
+
+    render();
+    render();
+    REQUIRE(scroll_area->scroll_size().y() > 0.f);
+
+    const Vec2f pos = input->get_global_pos();
+    mouse_move(pos.x() + input->width() * 0.5f, pos.y() + input->height() * 0.5f);
+    render();
+    ImGui::GetIO().AddMouseWheelEvent(0.f, -1.f);
+    render();
+
+    REQUIRE(input->text() == "1");
+    REQUIRE(scroll_area->scroll_pos().y() == 0.f);
 }


### PR DESCRIPTION
## Summary

- adjust numeric spin settings with the mouse wheel while hovered
- cycle regular and editable combo-box settings, including Fill Density
- claim wheel input so scrollable settings panels do not move at the same time
- preserve normal scrolling while a combo-box popup is open
- ignore disabled controls and respect combo-box bounds

## Testing

- built `slic3r-shared-tests` in Release mode
- passed focused mouse-wheel tests: 6 test cases, 16 assertions
- built `slic3r-app-launcher` in Release mode with 0 errors
- manually verified numeric fields, dropdowns, Fill Density, Favorites, and Full Settings on Windows

Build configuration used `no-occt`, `SLIC3R_PCH=OFF`, and `SLIC3R_ENABLE_WIN10_MESH_REPAIR=OFF`.