### PR TITLE
Check viewport width in the root_render guard, not height twice

### DIFF
--- a/src/slic3r-shared/src/Slic3r/App/Yoga/RootItem.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/Yoga/RootItem.cpp
@@ -69,7 +69,7 @@ void RootItem::for_each_popup_reconcile(F&& fn)
 
 void RootItem::root_render(const SizeInfo& size_info)
 {
-    if (size_info.viewport_size_y == 0 || size_info.viewport_size_y == 0) {
+    if (size_info.viewport_size_x == 0 || size_info.viewport_size_y == 0) {
         return;
     }
 


### PR DESCRIPTION
`RootItem::root_render` bails out on a degenerate viewport, but the guard tests `viewport_size_y` on both sides of the `||`, so a zero width walks straight past it. Two lines further down both fields go into `const Vec2f size{size_info.viewport_size_x, size_info.viewport_size_y};` and on into the Yoga layout, which is what the guard was put there to avoid.

I have not built this locally. `viewport_size_x` is the other member of the same struct, same type, and it is already read four lines below, so the change is one letter inside an expression that already compiles.
