### PR TITLE
Fix Build.md

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -42,7 +42,7 @@ cd build
 cmake .. -DCMAKE_PREFIX_PATH="../deps/build/destdir/usr/local"
 cmake --build .
 ```
-If you encounter any errors on Linux, use the absolute path:
+If you encounter any errors on Linux use the absolute path:
 ```bash
 cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../deps/build/destdir/usr/local)"
 ```

--- a/doc/Build.md
+++ b/doc/Build.md
@@ -42,6 +42,10 @@ cd build
 cmake .. -DCMAKE_PREFIX_PATH="../deps/build/destdir/usr/local"
 cmake --build .
 ```
+If you encounter any errors on Linux, use the absolute path:
+```bash
+cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../deps/build/destdir/usr/local)"
+```
 
 ## 3. Run tests (optional)
 From the repository root:

--- a/doc/Build.md
+++ b/doc/Build.md
@@ -42,7 +42,7 @@ cd build
 cmake .. -DCMAKE_PREFIX_PATH="../deps/build/destdir/usr/local"
 cmake --build .
 ```
-If you encounter any errors on Linux use the absolute path:
+If you encounter any errors on Linux or macOS use the absolute path:
 ```bash
 cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../deps/build/destdir/usr/local)"
 ```


### PR DESCRIPTION
#15620 
On linux an error occurs when using the relative path for cmake flags. Turning it to an absolute by realpath solves the issue.