### PR TITLE
Add Read/Write Support for Google Draco (.drc) File Format

### DIFF
--- a/deps/+Draco/Draco.cmake
+++ b/deps/+Draco/Draco.cmake
@@ -1,0 +1,5 @@
+add_cmake_project(
+    Draco
+    URL "https://github.com/google/draco/archive/refs/tags/1.5.7.zip"
+    URL_HASH SHA256=27b72ba2d5ff3d0a9814ad40d4cb88f8dc89a35491c0866d952473f8f9416b77
+)

--- a/src/slic3r-app-cli/src/Slic3r/App/CLI/ProcessActions.cpp
+++ b/src/slic3r-app-cli/src/Slic3r/App/CLI/ProcessActions.cpp
@@ -15,6 +15,7 @@
 #include "Slic3r/Biz/Format/OBJ.hpp"
 #include "Slic3r/Biz/Format/ProjectFileConstants.hpp"
 #include "Slic3r/Biz/Format/STL.hpp"
+#include "Slic3r/Biz/Format/DRC.hpp"
 #include "Slic3r/Biz/Platform/JobManager/JobManager.hpp"
 #include "Slic3r/Biz/Preset/IO/BundleLoader.hpp"
 #include "Slic3r/Biz/ProjectInteractor.hpp"
@@ -504,7 +505,8 @@ enum ExportFormat : int
     STL,
     // SVG,
     TMF,
-    Gcode
+    Gcode,
+    DRC
 };
 } // namespace IO
 
@@ -518,6 +520,9 @@ output_filepath(const Project& project, IO::ExportFormat format, const std::stri
         break;
     case IO::STL:
         ext = ".stl";
+        break;
+    case IO::DRC:
+        ext = ".drc";
         break;
     case IO::TMF:
         ext = ".3mf";
@@ -569,6 +574,10 @@ static bool export_projects(
         }
         case IO::STL: {
             success = store_stl(path, Algorithms::Model::flatten_to_mesh(project.model()), true);
+            break;
+        }
+        case IO::DRC: {
+            success = store_drc(path.c_str(), &project.model());
             break;
         }
         case IO::TMF: {
@@ -730,6 +739,12 @@ static bool perform_model_exports(
         }
     }
 
+    if (action.export_drc) {
+        if (!export_projects(runtime, project_ids, IO::DRC, output)) {
+            return false;
+        }
+    }
+
     if (action.export_3mf) {
         if (!export_projects(runtime, project_ids, IO::TMF, output)) {
             return false;
@@ -846,7 +861,7 @@ bool process_actions(
         }
     }
 
-    if (action.export_stl || action.export_obj || action.export_3mf) {
+    if (action.export_stl || action.export_obj || action.export_drc || action.export_3mf) {
         if (!perform_model_exports(runtime, init_params, project_ids)) {
             return true;
         }

--- a/src/slic3r-app-launcher/src/Slic3r/App/Launcher/ReadCLI.cpp
+++ b/src/slic3r-app-launcher/src/Slic3r/App/Launcher/ReadCLI.cpp
@@ -417,6 +417,8 @@ void add_action_options(CLI::App& app, App::InitParams& params)
 
     app.add_flag("--export-stl", params.action.export_stl, "Export the model(s) as STL.");
 
+    app.add_flag("--export-drc", params.action.export_drc, "Export the model(s) as DRC.");
+
     app.add_flag(
         "--gcodeviewer",
         params.action.gcode_viewer,

--- a/src/slic3r-shared/CMakeLists.txt
+++ b/src/slic3r-shared/CMakeLists.txt
@@ -1137,6 +1137,8 @@ set(SLIC3R_SHARED_FILES
         src/Slic3r/Biz/Format/objparser.hpp
         include/Slic3r/Biz/Format/STEP.hpp
         src/Slic3r/Biz/Format/STEP.cpp
+        include/Slic3r/Biz/Format/DRC.hpp
+        src/Slic3r/Biz/Format/DRC.cpp
 
         include/Slic3r/Biz/ArrangeInteractor.hpp
         src/Slic3r/Biz/ArrangeInteractor.cpp
@@ -1387,6 +1389,7 @@ endif ()
 find_package(magic_enum REQUIRED)
 find_package(range-v3 REQUIRED)
 find_package(libdeflate CONFIG REQUIRED)
+find_package(draco CONFIG REQUIRED)
 
 slic3r_remap_configs("pugixml::static;yoga::yogacore;${YAML_LIB}" RelWithDebInfo Release)
 
@@ -1422,6 +1425,7 @@ target_link_libraries(slic3r-shared PUBLIC
         range-v3::range-v3
         libcereal
         libdeflate::libdeflate_static
+        draco::draco
 )
 target_compile_definitions(slic3r-shared PUBLIC ${SLIC3R_YAML_DEFINE} ${USE_NATIVE_MENU_DEFINE})
 if (SLIC3R_SENTRY_DSN)

--- a/src/slic3r-shared/include/Slic3r/App/Init.hpp
+++ b/src/slic3r-shared/include/Slic3r/App/Init.hpp
@@ -48,6 +48,7 @@ struct ActionParams
     bool slice                              = false;
     bool export_stl                         = false;
     bool export_obj                         = false;
+    bool export_drc                         = false;
     bool export_3mf                         = false;
     bool export_gcode                       = false;
     bool export_sla                         = false;
@@ -79,6 +80,7 @@ struct ActionParams
             || slice
             || export_stl
             || export_obj
+            || export_drc
             || export_3mf
             || export_gcode
             || export_sla

--- a/src/slic3r-shared/include/Slic3r/App/Wildcards.hpp
+++ b/src/slic3r-shared/include/Slic3r/App/Wildcards.hpp
@@ -23,7 +23,8 @@ enum class TypeFlag : int
     Svg            = 1 << 10,
     AllTextures    = 1 << 11,
     Zip            = 1 << 12,
-    AllFlags       = 1 << 13
+    Drc            = 1 << 13,
+    AllFlags       = 1 << 14
 };
 
 constexpr TypeFlag operator|(TypeFlag lhs, TypeFlag rhs)

--- a/src/slic3r-shared/include/Slic3r/Biz/Format/DRC.hpp
+++ b/src/slic3r-shared/include/Slic3r/Biz/Format/DRC.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Slic3r/Domain/TriangleMesh.hpp"
+#include "tl/expected.hpp"
+
+namespace Slic3r::Domain {
+    class Model;
+}
+
+namespace Slic3r::Biz {
+
+tl::expected<Domain::TriangleMesh, std::string> load_drc(const std::string& path);
+
+}; // namespace Slic3r::Biz

--- a/src/slic3r-shared/include/Slic3r/Biz/Format/DRC.hpp
+++ b/src/slic3r-shared/include/Slic3r/Biz/Format/DRC.hpp
@@ -9,6 +9,14 @@ namespace Slic3r::Domain {
 
 namespace Slic3r::Biz {
 
+constexpr int DRC_BITS_MIN = 8;
+constexpr int DRC_BITS_MAX = 30;
+constexpr int DRC_BITS_DEFAULT = 0;
+constexpr int DRC_SPEED_DEFAULT = 0;
+constexpr char DRC_BITS_DEFAULT_STR[] = "0";
+
 tl::expected<Domain::TriangleMesh, std::string> load_drc(const std::string& path);
+bool store_drc(const std::string& path, const Domain::TriangleMesh& mesh, int bits = DRC_BITS_DEFAULT, int speed = DRC_SPEED_DEFAULT);
+bool store_drc(const std::string& path, Domain::Model* model, int bits = DRC_BITS_DEFAULT, int speed = DRC_SPEED_DEFAULT);
 
 }; // namespace Slic3r::Biz

--- a/src/slic3r-shared/src/Slic3r/App/MenuCommandRegistrar.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/MenuCommandRegistrar.cpp
@@ -55,7 +55,8 @@ constexpr Wildcards::TypeFlag import_file_types = Wildcards::TypeFlag::Project3m
     | Wildcards::TypeFlag::Stl
     | Wildcards::TypeFlag::Obj
     | Wildcards::TypeFlag::Svg
-    | Wildcards::TypeFlag::Step;
+    | Wildcards::TypeFlag::Step
+    | Wildcards::TypeFlag::Drc;
 
 /**
  * File types offered when replacing or reloading a volume mesh.
@@ -63,7 +64,8 @@ constexpr Wildcards::TypeFlag import_file_types = Wildcards::TypeFlag::Project3m
 constexpr Wildcards::TypeFlag model_file_types = Wildcards::TypeFlag::Project3mf
     | Wildcards::TypeFlag::Stl
     | Wildcards::TypeFlag::Obj
-    | Wildcards::TypeFlag::Step;
+    | Wildcards::TypeFlag::Step
+    | Wildcards::TypeFlag::Drc;
 
 class CommandBuilder
 {
@@ -1344,7 +1346,7 @@ void MenuCommandRegistrar::export_selection_as_stl_obj()
         this->default_dialog_folder(),
         MeshExportLogic::proposed_export_file_name(m_project_interactor.scene_interactor()),
         Wildcards::generate_wildcards(
-            Wildcards::TypeFlag::Stl | Wildcards::TypeFlag::Obj,
+            Wildcards::TypeFlag::Stl | Wildcards::TypeFlag::Obj | Wildcards::TypeFlag::Drc,
             Wildcards::TypeFlag::Stl
         ),
         callback

--- a/src/slic3r-shared/src/Slic3r/App/Wildcards.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/Wildcards.cpp
@@ -35,6 +35,7 @@ const std::map<TypeFlag, std::string>& get_wildcard_map()
         {TypeFlag::Png,            "PNG files (*.png)|*.png"},
         {TypeFlag::Svg,            "SVG files (*.svg)|*.svg"},
         {TypeFlag::Zip,            "Zip files (*.zip)|*.zip"},
+        {TypeFlag::Drc,            "Draco files (*.drc)|*.drc"},
         {TypeFlag::AllTextures,    "Texture files|*.png;*.svg"},
     };
     return map;

--- a/src/slic3r-shared/src/Slic3r/Biz/Config/Legacy/PrintConfig.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/Config/Legacy/PrintConfig.cpp
@@ -5951,6 +5951,11 @@ CLIActionsConfigDef::CLIActionsConfigDef()
     def->tooltip = L("Export the model(s) as STL.");
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("export_drc", coBool);
+    def->label = L("Export DRC");
+    def->tooltip = L("Export the model(s) as DRC.");
+    def->set_default_value(new ConfigOptionBool(false));
+
     // needs model and configuration
 
     def = this->add("export_3mf", coBool);

--- a/src/slic3r-shared/src/Slic3r/Biz/FileLoadingLogic.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/FileLoadingLogic.cpp
@@ -3,6 +3,7 @@
 #include "Slic3r/Biz/Format/SVG.hpp"
 #include "Slic3r/Biz/Format/OBJ.hpp"
 #include "Slic3r/Biz/Format/STEP.hpp"
+#include "Slic3r/Biz/Format/DRC.hpp"
 #include "Slic3r/Biz/Format/3mf.hpp"
 #include "Slic3r/Biz/Config/3mf_legacy.hpp"
 #include "Slic3r/Biz/Scene/SceneInteractor.hpp"
@@ -708,8 +709,9 @@ static tl::expected<ReturnData, FileLoadError> read_data_from_file(
     const bool is_svg = boost::algorithm::iends_with(path_str, ".svg");
     const bool is_step = boost::algorithm::iends_with(path_str, ".step") ||
                          boost::algorithm::iends_with(path_str, ".stp");
-    if (is_stl || is_obj) {
-        auto loaded_mesh = is_stl ? Biz::load_stl(path_str) : Biz::load_obj(path_str);
+    const bool is_drc = boost::algorithm::iends_with(path_str, ".drc");
+    if (is_stl || is_obj || is_drc) {
+        auto loaded_mesh = is_stl ? Biz::load_stl(path_str) : is_obj ? Biz::load_obj(path_str) : Biz::load_drc(path_str);
         if (loaded_mesh) {
             Domain::TriangleMesh mesh = loaded_mesh.value();
             ret.mesh                  = mesh;
@@ -1224,6 +1226,7 @@ const std::vector<std::string>& get_import_extensions()
         ".3mf",
         ".stl",
         ".obj",
+        ".drc",
         ".svg",
         ".step", ".stp"
     };

--- a/src/slic3r-shared/src/Slic3r/Biz/Format/DRC.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/Format/DRC.cpp
@@ -1,0 +1,85 @@
+#include "Slic3r/Biz/Format/DRC.hpp"
+
+#include <string>
+#include <utility>
+#include <cstring>
+
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/nowide/cstdio.hpp>
+
+#include <draco/compression/encode.h>
+#include <draco/compression/decode.h>
+#include <draco/io/mesh_io.h>
+#include <draco/mesh/mesh.h>
+
+#include "fmt/format.h"
+
+#include "Slic3r/Biz/Algorithms/Model.hpp"
+#include "Slic3r/Biz/Algorithms/TriangleMesh.hpp"
+
+using namespace draco;
+
+namespace Slic3r::Biz {
+
+tl::expected<Domain::TriangleMesh, std::string> load_drc(const std::string& path)
+{
+    try {
+        boost::iostreams::mapped_file_source file(path);
+
+        DecoderBuffer buffer;
+        buffer.Init(file.data(), file.size());
+
+        auto geotype = Decoder::GetEncodedGeometryType(&buffer);
+        if (!geotype.ok())
+            return tl::make_unexpected(fmt::format("load_drc: error getting geometry type for {}.", path));
+        if (geotype.value() != TRIANGULAR_MESH)
+            return tl::make_unexpected(fmt::format("load_drc: geometry is not triangular mesh for {}.", path));
+
+        Decoder decoder;
+        Mesh dracoMesh;
+        Status status = decoder.DecodeBufferToGeometry(&buffer, &dracoMesh);
+        if (!status.ok())
+            return tl::make_unexpected(fmt::format("load_drc: error decoding geometry for {}.", path));
+
+
+        const PointAttribute *const positions = dracoMesh.GetNamedAttribute(GeometryAttribute::POSITION);
+        if (positions == NULL)
+            return tl::make_unexpected(fmt::format("load_drc: error decoding vertices for {}.", path));
+        if (positions->num_components() != 3)
+            return tl::make_unexpected(fmt::format("load_drc: trianglar mesh did not contain triangles for {}.", path));
+        
+        size_t num_vertices = positions->size();
+        
+        indexed_triangle_set its;
+        its.vertices.reserve(num_vertices);
+        for (AttributeValueIndex i(0); i < num_vertices; ++ i) {
+            float pos[3];
+            positions->ConvertValue<float>(i, 3, pos);
+            its.vertices.emplace_back(pos[0], pos[1], pos[2]);
+        }
+
+        size_t num_faces = dracoMesh.num_faces();
+        its.indices.reserve(num_faces);
+        for (FaceIndex i(0); i < num_faces; ++ i) {
+            Mesh::Face face = dracoMesh.face(i);
+
+            its.indices.push_back(Domain::Index3{
+                static_cast<int>(positions->mapped_index(face[0]).value()),
+                static_cast<int>(positions->mapped_index(face[1]).value()),
+                static_cast<int>(positions->mapped_index(face[2]).value())
+            });
+        }
+
+        using Biz::Algorithms::TriangleMesh::construct;
+        Domain::TriangleMesh mesh_out(construct(std::move(its)));
+        if (mesh_out.empty())
+            return tl::make_unexpected(fmt::format("load_obj: This Draco file couldn't be read because it's empty. {}", path));
+        if (mesh_out.volume() < 0)
+            mesh_out.flip_triangles();
+        return mesh_out;
+    } catch (const std::exception& e) {
+        return tl::make_unexpected(fmt::format("load_drc: exception while loading {}: {}", path, e.what()));
+    }
+}
+
+}; // namespace Slic3r::Biz

--- a/src/slic3r-shared/src/Slic3r/Biz/Format/DRC.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/Format/DRC.cpp
@@ -82,4 +82,62 @@ tl::expected<Domain::TriangleMesh, std::string> load_drc(const std::string& path
     }
 }
 
+bool store_drc(const std::string& path, const Domain::TriangleMesh& mesh, int bits, int speed)
+{
+    try {
+        const std::vector<stl_triangle_vertex_indices>* indices = &(mesh.its.indices);
+        const std::vector<stl_vertex>* vertices = &(mesh.its.vertices);
+        
+        Mesh dracoMesh;
+
+        dracoMesh.set_num_points(vertices->size());
+        
+        GeometryAttribute gaPos;
+        gaPos.Init(GeometryAttribute::POSITION, nullptr, 3, DT_FLOAT32, false, sizeof(float)*3, 0);
+        int32_t idPos = dracoMesh.AddAttribute(gaPos, true, indices->size() * 3);
+        
+        dracoMesh.attribute(idPos)->Resize(vertices->size());
+        
+        for (size_t i = 0; i < vertices->size(); ++ i) {
+            float vertex[3];
+            vertex[0] = vertices->at(i)(0);
+            vertex[1] = vertices->at(i)(1);
+            vertex[2] = vertices->at(i)(2);
+            dracoMesh.attribute(idPos)->SetAttributeValue(AttributeValueIndex(i), vertex);
+        }
+        
+        dracoMesh.SetNumFaces(indices->size());
+        for (size_t i = 0; i < indices->size(); ++ i) {
+            Mesh::Face face;
+            face[0] = PointIndex(indices->at(i)[0]);
+            face[1] = PointIndex(indices->at(i)[1]);
+            face[2] = PointIndex(indices->at(i)[2]);
+            dracoMesh.SetFace(FaceIndex(i), face);
+        }
+        
+        Encoder encoder;
+        encoder.SetSpeedOptions(speed, speed);
+        encoder.SetAttributeQuantization(GeometryAttribute::POSITION, bits);
+        
+        EncoderBuffer buffer;
+        if (!encoder.EncodeMeshToBuffer(dracoMesh, &buffer).ok()) return false;
+        
+        FILE* fp = boost::nowide::fopen(path.c_str(), "wb");
+        if (!fp) return false;
+        size_t written = fwrite(buffer.data(), 1, buffer.size(), fp);
+        fclose(fp);
+        
+        if (written != buffer.size()) return false;
+    } catch (const std::exception&) {
+        return false;
+    }
+    return true;
+}
+
+bool store_drc(const std::string& path, Domain::Model* model, int bits, int speed)
+{
+    Domain::TriangleMesh mesh = Algorithms::Model::flatten_to_mesh(*model);
+    return store_drc(path, mesh, bits, speed);
+}
+
 }; // namespace Slic3r::Biz

--- a/src/slic3r-shared/src/Slic3r/Biz/MeshExportLogic.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/MeshExportLogic.cpp
@@ -4,6 +4,7 @@
 #include "Slic3r/Biz/CGAL/Algorithms/MergeObjectVolumes.hpp"
 #include "Slic3r/Biz/Format/OBJ.hpp"
 #include "Slic3r/Biz/Format/STL.hpp"
+#include "Slic3r/Biz/Format/DRC.hpp"
 #include "Slic3r/Biz/I18N/I18N.hpp"
 #include "Slic3r/Biz/IMessageDialogProvider.hpp"
 #include "Slic3r/Biz/Scene/SceneInteractor.hpp"
@@ -40,6 +41,10 @@ bool store_mesh_by_extension(const boost::filesystem::path& output_path, const T
 
     if (boost::algorithm::iequals(extension, ".obj")) {
         return store_obj(output_path.string(), mesh);
+    }
+
+    if (boost::algorithm::iequals(extension, ".drc")) {
+        return store_drc(output_path.string(), mesh);
     }
 
     return false;


### PR DESCRIPTION
This is a PrusaSlicer 3.x port of my previous PR for PrusaSlicer 2.x (#15250), which itself is a port of the feature for OrcaSlicer, which was included in v2.3.2.

I've split this into three separate commits this time, to make it easier to integrate just part of it if that's what's wished.

This Implements Google's Draco (.drc) model format. It supports both read and write, but will currently only write lossless DRC files. The code to write lossy files is there, but it isn't hooked into the GUI yet, since I wasn't sure how you wanted that done. In OrcaSlicer it's done with a setting in Preferences; I can do the same here if you like, but it's less obvious where to put it. It could be added to the Save dialogue, but since the same one is used for all formats, that wouldn't be ideal either. Please let me know what you'd like to see, and I'll work on it.

The main feature of Draco is being extremely space-efficient compared to existing formats. In my testing, DRC could achieve visually-lossless quality at 10% or less (sometimes much less) of the size of STL.
See https://google.github.io/draco/ and https://github.com/google/draco for information.

<img width="404" height="174" alt="image" src="https://github.com/user-attachments/assets/08a3eeb3-77f9-4634-aa69-51d79afc597d" />

(This screenshot is from OrcaSlicer, but it still demonstrates the model's visual quality despite being ~3% of the size.)
<img width="1188" height="794" alt="image" src="https://github.com/user-attachments/assets/f4335ec0-691e-443f-ac7a-edc60b7a9efc" />

Since this is a thing that comes up a lot: This code is 100% human-generated.
I did have Claude check my work for bugs and other errors, but I fixed them myself.