### PR TITLE
Document that locale settings matter in build time.

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -17,6 +17,12 @@ For example on Ubuntu 26.04:
 sudo apt install git build-essential autoconf cmake libglu1-mesa-dev libgtk-3-dev libdbus-1-dev libwebkit2gtk-4.1-dev texinfo
 ```
 Adapt it for your package manager.
+
+Check that `locale` shows reasonable UTF-8-capable locales.
+If not, for example in Ubuntu 26.04 containers the default is `POSIX`, run
+```bash
+export LC_ALL=C.UTF-8
+```
 ## 1. Build dependencies
 From the repository root:
 ```bash


### PR DESCRIPTION
Addressing
```
-- verifying file...
       file='/tmp/PrusaSlicer-version_3.0.0-alpha11/deps/build/downloads/Boost/boost-1.86.0-cmake.zip'
-- Downloading... done
-- extracting...
     src='/tmp/PrusaSlicer-version_3.0.0-alpha11/deps/build/downloads/Boost/boost-1.86.0-cmake.zip'
     dst='/tmp/PrusaSlicer-version_3.0.0-alpha11/deps/build/dep_Boost-prefix/src/dep_Boost'
-- extracting... [tar xf]
CMake Error: Problem with archive_read_next_header(): Pathname cannot be converted from UTF-8 to current locale. CMake Error: Problem extracting tar: /tmp/PrusaSlicer-version_3.0.0-alpha11/deps/build/downloads/Boost/boost-1.86.0-cmake.zip -- extracting... [error clean up]
CMake Error at dep_Boost-stamp/extract-dep_Boost.cmake:40 (message):
  Extract of
  '/tmp/PrusaSlicer-version_3.0.0-alpha11/deps/build/downloads/Boost/boost-1.86.0-cmake.zip'
  failed
```

Fixes https://github.com/prusa3d/PrusaSlicer/issues/15739.