### PR TITLE
Document that libtool is needed in build time.

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -14,7 +14,7 @@ brew update && brew install automake cmake git gettext libtool texinfo
 ### Linux
 For example on Ubuntu 26.04:
 ```bash
-sudo apt install git build-essential autoconf cmake libglu1-mesa-dev libgtk-3-dev libdbus-1-dev libwebkit2gtk-4.1-dev texinfo
+sudo apt install git build-essential autoconf cmake libtool libglu1-mesa-dev libgtk-3-dev libdbus-1-dev libwebkit2gtk-4.1-dev texinfo
 ```
 Adapt it for your package manager.
 ## 1. Build dependencies


### PR DESCRIPTION
Addressing
```
Can't exec "libtoolize": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 318.
autoreconf: error: libtoolize failed with exit status: 2
gmake[2]: *** [CMakeFiles/dep_MPFR.dir/build.make:92: dep_MPFR-prefix/src/dep_MPFR-stamp/dep_MPFR-configure] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:784: CMakeFiles/dep_MPFR.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

Fixes https://github.com/prusa3d/PrusaSlicer/issues/15741.