### PR TITLE
Document prerequisites for builds on Fedora.

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -16,7 +16,11 @@ For example on Ubuntu 26.04:
 ```bash
 sudo apt install git build-essential autoconf cmake libglu1-mesa-dev libgtk-3-dev libdbus-1-dev libwebkit2gtk-4.1-dev texinfo
 ```
-Adapt it for your package manager.
+or for Fedora 44:
+```bash
+sudo dnf install cmake g++ git-core m4 texinfo autoconf automake libtool perl-FindBin perl-lib perl-IPC-Cmd perl-Time-Piece webkit2gtk4.1-devel zlib-devel zlib-static libpng-static
+```
+Adapt it for your package manager and packages provided by your operating system.
 ## 1. Build dependencies
 From the repository root:
 ```bash


### PR DESCRIPTION
Figuring out some of the packages needed on Fedora took a while, for example the static packages.

To make it easier for the community folks to build from sources, I propose to show the list.

Tested in a `registry.fedoraproject.org/fedora:44` container.