### PR TITLE
Fix crash on first run when presets are installed read-only

### DIFF
--- a/src/slic3r-shared/src/Slic3r/Biz/Preset/IO/BundleLoader.cpp
+++ b/src/slic3r-shared/src/Slic3r/Biz/Preset/IO/BundleLoader.cpp
@@ -46,16 +46,29 @@ void populate_local_bundle(const BundlePaths& bundle_paths)
                     fs::remove_all(dest_path);
                 }
                 fs::create_directories(dest_path);
-                fs::copy(
-                    src_path,
-                    dest_path,
-                    fs::copy_options::recursive | fs::copy_options::overwrite_existing
-                );
+                // Do not use fs::copy() here: it replicates the permissions of
+                // the source tree onto the copy. When the bundled presets are
+                // installed on a read-only medium -- such as the Nix store, where
+                // every directory is r-xr-xr-x -- fs::copy creates the destination
+                // directories read-only and then aborts with EACCES on the first
+                // file it tries to write into them, which nothing catches. Copy
+                // by hand instead, so the user's own copy stays writable.
+                for (const auto& copied : fs::recursive_directory_iterator(src_path)) {
+                    const fs::path target = dest_path / fs::relative(copied.path(), src_path);
+                    if (copied.is_directory()) {
+                        fs::create_directories(target);
+                        continue;
+                    }
+                    fs::create_directories(target.parent_path());
+                    fs::copy_file(copied.path(), target, fs::copy_options::overwrite_existing);
+                    fs::permissions(target, fs::add_perms | fs::owner_write);
+                }
                 fs::copy_file(
                     src_path.string() + ".idx",
                     dest_path.string() + ".idx",
                     fs::copy_options::overwrite_existing
                 );
+                fs::permissions(dest_path.string() + ".idx", fs::add_perms | fs::owner_write);
             }
         }
     }


### PR DESCRIPTION
- PrusaSlicer 3.0.0-alpha11 — source build from master @ 6f510128d7
- NixOS 26.11 (Zokor)
- GNOME Shell 50.4, Wayland
- GTK 3.24.52
- wxWidgets 3.3.3.1, GTK3 backend
- fontconfig 2.18.2

### What happens

On a fresh datadir the application aborts during first run, before the main
window appears. The last line logged is `Populate vendor <repo>/<vendor>` from
`populate_local_bundle()`, immediately before the copy.

The abort is an uncaught `boost::filesystem` exception — `std::terminate`, not a
handled error. Narrowing it down inside that function: `fs::copy()` with
`recursive` creates each destination directory with `mkdir(dest, source_mode)`,
so the copy inherits the permissions of the *installed* resources rather than
the permissions a writable working copy needs. Where the resources carry no
owner-write bit, the destination directory is created without one too, and the
next `copy_file()` into it throws `EACCES`. The parent survives only because
`create_directories()` applies the umask.

Note that adding a permission fixup after `fs::copy()` does not help: the throw
happens inside `fs::copy()` itself.

### Why it does not reproduce on most installs

The trigger is the source's *mode bits*, not whether the install is read-only.
Distribution packages under `/usr/share`, and Flatpak, Snap and AppImage, all
ship 0755 directories — their read-only-ness is a mount property, which
`fs::copy` never consults — so `mkdir(0755)` leaves owner-write and the copy
succeeds. Nix and Guix are the exception: every store entry is `r-xr-xr-x` /
`r--r--r--`, because stripping the write bit is how those systems enforce store
immutability. That is where this fires.

### The fix

Copy the tree by hand instead of with `fs::copy()`, so the destination
permissions are chosen rather than inherited: `create_directories()` for
directories (umask → 0755), `copy_file()` plus an explicit owner-write for files
(→ 0644). Same for the `.idx`, which would otherwise be copied 0444 and could
not be rewritten later.

18 added lines in one file. On installs that already ship 0755/0644 resources
this changes nothing observable — it only stops the copy from depending on the
source permissions.

### Testing

Built from this branch on NixOS — clang 21.1.8, wxWidgets 3.3.3.1 (GTK3),
system dependencies rather than the `deps/` superbuild.

- Before, from an empty datadir: aborts during first run.
- After, from an empty datadir: the vendor bundle populates, the application
  starts, and the copied presets are writable.

When retesting, delete the datadir between runs. `populate_local_bundle()` is
guarded by `if (!fs::exists(dest_path / "vendor.yaml"))`, and a failed run
leaves a partial tree, so a subsequent run skips the copy entirely and a broken
build can look fixed (or a fixed build can look untested).

Linux only. The change is platform independent, but I have not built Windows or
macOS.