### PR TITLE
Fix crash in Lua plugins when a predefined wxFont has no installed match

### DIFF
--- a/src/slic3r-shared-wx/src/Slic3r/Biz/WX/FontManager.cpp
+++ b/src/slic3r-shared-wx/src/Slic3r/Biz/WX/FontManager.cpp
@@ -292,6 +292,18 @@ Domain::FontList FontManager::create_favorit()
     };
 
     auto is_invalid = [](const Domain::FontDescriptor& descriptor) {
+        // create_descriptor() returns a default constructed FontDescriptor when
+        // the wxFont has no counterpart in the openable list -- its path is empty
+        // and its type is 'undefined'. Such a descriptor must never survive as a
+        // favorite: FontManager::open() rejects every type that is neither
+        // file_path nor the current platform's, so it hands back a null FontFile,
+        // which the emboss code dereferences without checking.
+        //
+        // The TrueType check below cannot catch it on Linux: an empty path means
+        // an empty font family, and fontconfig resolves an empty family to the
+        // system default font rather than failing.
+        if (descriptor.path.empty())
+            return true;
         // Check that exsit valid TrueType Font for wx font
         return create_font_file(load_wxFont(descriptor.path)) == nullptr;
     };


### PR DESCRIPTION
Fixes #15730.

- PrusaSlicer 3.0.0-alpha11 — source build from master @ 6f510128d7
- NixOS 26.11 (Zokor)
- GNOME Shell 50.4, Wayland
- GTK 3.24.52
- wxWidgets 3.3.3.1, GTK3 backend
- fontconfig 2.18.2

### What happens

Creating a temperature tower results in a crash. The last line logged is the one
from #15730, `FontManager.cpp:163 Changed fontlist detected`.

The core dump faults in `get_text_shape_scale`, on a null reference handed to it
by `TextShapeProvider`'s initializer list. Tracing that back, and reading the
`fonts.cereal` the run had just written:

`create_descriptor()` returns a default constructed `FontDescriptor` — empty
path, type `undefined` — when a wxFont has no (face, style, weight) match in the
openable list, and `create_favorit()` keeps it. The `is_invalid` filter below
should drop it, but on Linux it probes the path through fontconfig, which
answers an empty family with the system default font rather than failing
(`fc-match ""` → DejaVu Sans). So the placeholder stays at the front of the
favorites, `FontManager::open()` returns `nullptr` for it — its type is neither
`file_path` nor the current platform's — and nothing checks before the
dereference.

### How to reproduce

Whether it triggers depends on whether the machine's `wxNORMAL_FONT` face has a
match in the openable list. Where the GTK UI font is openable,
`m_fav_fonts.front()` is a valid descriptor and the missing-font fallback works
fine. Where it is not, the first favorite is the placeholder. On my system
the UI font is Adwaita Sans, which PrusaSlicer records in its *bad* list, so
`wxNORMAL_FONT` and `wxSMALL_FONT` both resolve to nothing.

### The fix

Reject an empty path in `is_invalid` before the TrueType probe. The favorites
then fall through to the existing `m_openable` scan below, which picks the first
genuinely loadable font with a correct platform font type.

12 added lines in one file, most of them comment. No behavioural change on
Windows or macOS, where the placeholder was already filtered out, and none on
Linux systems where the predefined fonts already resolve.

I deliberately did not add a null check at the dereference site instead. That
would convert the segfault into a different failure while still leaving an
unopenable font as favorite \#1.

### Testing

Built from this branch on NixOS — clang, wxWidgets 3.3, system dependencies
rather than the `deps/` superbuild.

- Before: Plugins > Calibration > Temperature Tower segfaults on Run.
- After: the plugin completes and generates the tower.
- After: adding a text object with the Emboss gizmo defaults to font "Sans",
  style "Regular" — the `SWISS` favorite. On this machine `NORMAL` and `SMALL`
  (Adwaita Sans, no upright entry in the openable list) and `MODERN`
  (Monospace, in the bad list) are precisely the placeholders this patch drops,
  so `SWISS` being what remains at the front is the expected result.

Linux/GTK only. Per the analysis above, Windows and macOS should be unaffected
both before and after, but I have not built either.

### Not in scope

On a system without Helvetica the tower's digits come out in the substituted
font, and `temp_tower.lua` centres them on a hardcoded offset without measuring
the text, so they sit slightly off. That is pre-existing plugin behaviour,
visible only once the crash is gone, and not addressed here.