### PR TITLE
Fix Arachne crash on intersecting Voronoi edges

### DIFF
--- a/src/libslic3r/include/libslic3r/SlicingStatus.hpp
+++ b/src/libslic3r/include/libslic3r/SlicingStatus.hpp
@@ -97,6 +97,7 @@ enum class ErrorCode
     NoExtrusions, // _u8L("No extrusions were generated for objects.")
     EmptyPrint, // "The print is empty. The model is not printable with current print settings."
     InvalidThumbnailRequest,
+    ArachneInvalidGraph,
 
     // SLA
     NoPadGenerated, // _u8L("No pad can be generated for this model with the current configuration")

--- a/src/libslic3r/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
+++ b/src/libslic3r/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
@@ -22,6 +22,7 @@
 #include "libslic3r/Arachne/utils/ExtrusionLine.hpp"
 #include "libslic3r/Polygon.hpp"
 #include "Slic3r/Biz/Algorithms/Point.hpp"
+#include "libslic3r/SlicingStatus.hpp"
 
 #ifndef NDEBUG
     #include "libslic3r/EdgeGrid.hpp"
@@ -450,6 +451,18 @@ void SkeletalTrapezoidation::constructFromPolygons(const Polygons& polys)
 #ifdef ARACHNE_DEBUG
     assert(VoronoiUtilsCgal::is_voronoi_diagram_planar_intersection(voronoi_diagram));
 #endif
+
+    const size_t unpaired_edges = std::count_if(
+        graph.edges.begin(),
+        graph.edges.end(),
+        [](const edge_t &edge) { return edge.twin == nullptr; });
+
+    if (unpaired_edges != 0) {
+        SPDLOG_ERROR("Arachne generated an invalid perimeter graph with {} unpaired half-edges", unpaired_edges);
+        throw Biz::Slicing::Exception(Biz::Slicing::Error {
+            .code = Biz::Slicing::ErrorCode::ArachneInvalidGraph,
+        });
+    }
 
     separatePointyQuadEndNodes();
 

--- a/src/slic3r-biz-cgal-algorithms/src/Slic3r/Biz/CGAL/Algorithms/Voronoi.cpp
+++ b/src/slic3r-biz-cgal-algorithms/src/Slic3r/Biz/CGAL/Algorithms/Voronoi.cpp
@@ -178,8 +178,15 @@ VoronoiDiagram::detect_known_issues(const VoronoiDiagram &voronoi_diagram, Segme
         return edge_issue_type;
     } else if (const IssueType cell_issue_type = detect_known_voronoi_cell_issues(voronoi_diagram, segment_begin, segment_end); cell_issue_type != IssueType::NO_ISSUE_DETECTED) {
         return cell_issue_type;
-    } else if (!VoronoiUtilsCgal::is_voronoi_diagram_planar_angle(voronoi_diagram, segment_begin, segment_end)) {
-        // Detection of non-planar Voronoi diagram detects at least GH issues #8474, #8514 and #8446.
+    } else if (!VoronoiUtilsCgal::is_voronoi_diagram_planar_angle(voronoi_diagram, segment_begin, segment_end) ||
+               !VoronoiUtilsCgal::is_voronoi_diagram_planar_intersection(voronoi_diagram)) {
+        // is_voronoi_diagram_planar_angle:        Detects topology errors around a vertex 
+        //                                         at least GH issues #8474, #8514 and #8446
+        //
+        // is_voronoi_diagram_planar_intersection: Detects crossings between otherwise locally well-ordered edges 
+        //                                         at least GH issue #14421
+        //
+        // Both make the diagram unusable by Arachne.
         return IssueType::NON_PLANAR_VORONOI_DIAGRAM;
     }
 

--- a/src/slic3r-shared/src/Slic3r/App/DisplayStrings.cpp
+++ b/src/slic3r-shared/src/Slic3r/App/DisplayStrings.cpp
@@ -174,6 +174,13 @@ std::string to_display_string(Biz::Slicing::ErrorCode code)
         return _u8L("The print is empty. The model is not printable with current print settings.");
     case ErrorCode::InvalidThumbnailRequest:
         return _u8L("Unable to parse 'thumbnails' config option.");
+    case ErrorCode::ArachneInvalidGraph:
+        return _u8L(
+            "Arachne failed to generate a valid perimeter graph.\n\n"
+            "Please open a Github issue at "
+            "https://github.com/prusa3d/PrusaSlicer/issues and attach the project file.\n\n"
+            "As a workaround, try changing Print Settings: Precision & Slicing -> Perimeter Generator -> Classic"
+        );
     case ErrorCode::NoPadGenerated:
         return _u8L("No pad can be generated for this model with the current configuration.");
     case ErrorCode::UnprintableObjects:

--- a/tests/libslic3r/test_voronoi.cpp
+++ b/tests/libslic3r/test_voronoi.cpp
@@ -4,6 +4,7 @@
 #include <libslic3r/Polyline.hpp>
 #include <libslic3r/EdgeGrid.hpp>
 #include <Slic3r/Biz/CGAL/Algorithms/VoronoiOffset.hpp>
+#include <Slic3r/Biz/CGAL/Algorithms/VoronoiUtilsCgal.hpp>
 
 #include <numeric>
 #include <random>
@@ -2163,6 +2164,51 @@ TEST_CASE("Non-planar voronoi diagram", "[VoronoiNonPlanar]")
 #endif
 
     REQUIRE(vd.is_valid());
+}
+
+// This diagram contains crossing finite edges even though the local edge-angle
+// validation considers it planar. It was extracted from an Arachne failure that
+// produced unpaired edges in the skeletal trapezoidation graph. GH issue #14421
+TEST_CASE("Non-planar Voronoi diagram detected by edge intersections", "[VoronoiNonPlanarIntersection]")
+{
+    Polygons polygons {
+        Polygon {
+            { 89969957,  65969957}, {-89969955,  65969957},
+            {-89969955, -65969955}, { 89969957, -65969955},
+        },
+        Polygon {
+            {-75530043, -42030043}, {-75530043,  50030045}, {-64469955,  50030045},
+            {-64469955,  15030045}, {-15469955,  15030045}, {-15469955,  -2191375},
+            {-23308654, -10030043}, {-39469955, -10030043}, {-39469955, -42030043},
+        },
+        Polygon {
+            {-15530043, -62030043}, {-15530043, -52030043}, {-16280043, -52030043},
+            {-16280043,  -9987554}, {-10530043,  -4237556}, {-10530043,  19969957},
+            {-59530044,  19969957}, {-59530044,  50030045}, { 58530045,  50030045},
+            { 58530045,  12530045}, { 72530045,  12530045}, { 72530045,   3530045},
+            { 85530045,   3530045}, { 85530045,   1530045}, { 86530045,   1530045},
+            { 86530045,  -2030043}, { 79530045,  -2030044}, { 79530045, -15030043},
+            { 29469957, -15030043}, { 29469957,  -7469955}, { 70469957,  -7469955},
+            { 70469957,    -30043}, { 52530045,    -30043}, { 52530045,  -2030043},
+            { 30469957,  -2030043}, { 30469957,    469957}, { 23469957,    469957},
+            { 23469957,   3530045}, { 31469957,   3530045}, { 31469957,  39969957},
+            { 10530045,  39969957}, { 10530045,  -4237557}, { 16280045,  -9987553},
+            { 16280045, -52030043}, { 15530045, -52030043}, { 15530045, -62030043},
+        },
+        Polygon {
+            {39469957, -42030043}, {39469957, -19969955},
+            {75530045, -19969955}, {75530045, -42030043},
+        },
+    };
+
+    REQUIRE(intersecting_edges(polygons).empty());
+
+    VD vd;
+    Lines lines = Algorithms::Polygon::to_lines(polygons);
+    vd.construct_voronoi(lines.begin(), lines.end());
+
+    REQUIRE(vd.get_state() == VD::State::REPAIR_SUCCESSFUL);
+    REQUIRE(CGAL::Algorithms::VoronoiUtilsCgal::is_voronoi_diagram_planar_intersection(vd));
 }
 
 // This case is extracted from SPE-1729, where several ExPolygon with very thin lines


### PR DESCRIPTION
Hi :)

PrusaSlicer crashed on me while slicing my own model. I found out I had the same issue as #14421, so I didn't create a new one.

This PR prevents Arachne from crashing on a non-planar Voronoi diagram containing intersecting edges. Currently, only `is_voronoi_diagram_planar_angle` is used, which doesn't catch this edge-case:
https://github.com/prusa3d/PrusaSlicer/blob/6f510128d7c2e543b62919b74bea7e876f564205/src/slic3r-biz-cgal-algorithms/src/Slic3r/Biz/CGAL/Algorithms/Voronoi.cpp#L177-L184

Also, if there are still any unpaired edges, the user will get an error message (with the request to submit a GH issue + suggests trying Classic instead of Arachne), instead of segfaulting the application.

<img width="741" height="264" alt="2026-09-06_16-17" src="https://github.com/user-attachments/assets/013e7547-5bdf-4429-a2d8-4a643a8d30c6" />


## Changes

 - Use the edge-intersection check in addition to the angle-based Voronoi planarity check (and let them be fixed by the same rotate-and-rebuild mechanism)
- If an invalid graph remains, stop slicing with a regular user-facing slicing error instead of crashing
- Add a regression test

Please let me know if you want any changes :)

Fixes #14421